### PR TITLE
perf(snapshot): faster restore (preserve only target-and-newer overlays) + cleanup fixes

### DIFF
--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -1283,7 +1283,8 @@ class BoxmanManager:
             return True  # no cluster uses a template as base_image
 
         # check which of the needed templates already exist as VMs
-        missing_keys: list = []
+        missing_keys: list = []      # template VM not registered at all
+        broken_keys: list = []       # registered, but backing disk gone
         for tpl_key in needed_template_keys:
             tpl_conf = templates[tpl_key]
             tpl_vm_name = tpl_conf.get('name', tpl_key)
@@ -1312,19 +1313,45 @@ class BoxmanManager:
                     self.logger.warning(f"could not check if template VM '{tpl_vm_name}' exists: {exc}")
 
             if exists:
-                self.logger.info(f"template VM '{tpl_vm_name}' already exists, skipping creation")
+                # The domain is registered, but its backing qcow2 file may
+                # have been deleted out from under libvirt. virt-clone then
+                # fails inscrutably during provision; detect it up-front and
+                # rebuild via the existing force-recreate path which already
+                # does destroy + undefine --remove-all-storage on its own.
+                disks_ok = True
+                if (self.provider is not None
+                        and hasattr(self.provider, 'template_disks_present')):
+                    try:
+                        disks_ok = self.provider.template_disks_present(tpl_vm_name)
+                    except Exception as exc:
+                        self.logger.warning(
+                            f"could not verify template '{tpl_vm_name}' disks: {exc}")
+                if not disks_ok:
+                    self.logger.warning(
+                        f"template VM '{tpl_vm_name}' is registered with libvirt "
+                        f"but its disk file is missing on the host — rebuilding "
+                        f"the template (force=True will destroy the orphan domain)")
+                    broken_keys.append(tpl_key)
+                else:
+                    self.logger.info(
+                        f"template VM '{tpl_vm_name}' already exists, skipping creation")
             else:
                 self.logger.info(
                     f"template VM '{tpl_vm_name}' (key='{tpl_key}') does not exist, "
                     f"will create it before provisioning")
                 missing_keys.append(tpl_key)
 
-        if not missing_keys:
+        if not missing_keys and not broken_keys:
             return True
 
-        # create the missing templates
-        self.logger.info(f"auto-creating {len(missing_keys)} missing template(s): {missing_keys}")
-        self._create_templates_impl(requested=missing_keys, force=False)
+        if missing_keys:
+            self.logger.info(
+                f"auto-creating {len(missing_keys)} missing template(s): {missing_keys}")
+            self._create_templates_impl(requested=missing_keys, force=False)
+        if broken_keys:
+            self.logger.info(
+                f"auto-rebuilding {len(broken_keys)} broken template(s): {broken_keys}")
+            self._create_templates_impl(requested=broken_keys, force=True)
 
         return True
 
@@ -1694,12 +1721,30 @@ class BoxmanManager:
                     else:
                         raise
 
+        clone_tasks = list(vm_clone_tasks())
         processes = [
             Process(target=_clone, args=(cluster, vm_info, new_vm_name))
-            for cluster, vm_info, new_vm_name in vm_clone_tasks()
+            for cluster, vm_info, new_vm_name in clone_tasks
         ]
         [p.start() for p in processes]
         [p.join() for p in processes]
+
+        # Abort provision if any clone subprocess exited non-zero. Without
+        # this check, the subsequent configure / start / wait-for-IP steps
+        # all spam errors against VMs that were never defined, and the
+        # wait-for-IP loop in particular looks like a hang.
+        failed = [
+            (task[2], p.exitcode)
+            for task, p in zip(clone_tasks, processes)
+            if p.exitcode != 0
+        ]
+        if failed:
+            names = ', '.join(name for name, _ in failed)
+            raise RuntimeError(
+                f"clone failed for {len(failed)} VM(s) ({names}); aborting "
+                f"provision. See the virt-clone error logged above for the "
+                f"underlying cause (typically a missing template disk or a "
+                f"libvirt storage pool issue).")
 
     def destroy_vms(self) -> None:
         """
@@ -4366,6 +4411,20 @@ class BoxmanManager:
         ]
         [p.start() for p in processes]
         [p.join() for p in processes]
+
+        # Abort the update if any clone subprocess exited non-zero — same
+        # guard as :meth:`clone_vms` to prevent downstream configure/start
+        # steps from running against VMs that were never defined.
+        failed = [
+            (task[2], p.exitcode)
+            for task, p in zip(clone_tasks, processes)
+            if p.exitcode != 0
+        ]
+        if failed:
+            names = ', '.join(name for name, _ in failed)
+            raise RuntimeError(
+                f"clone failed for {len(failed)} new VM(s) ({names}); "
+                f"aborting update. See the virt-clone error logged above.")
 
         # configure and start new VMs (parallel)
         configure_tasks = []

--- a/src/boxman/providers/libvirt/commands.py
+++ b/src/boxman/providers/libvirt/commands.py
@@ -15,6 +15,14 @@ class LibVirtCommandBase:
     virt-install, virt-clone, etc. It handles configuration, command execution,
     and error management.
     """
+
+    #: Commands that never need root in boxman's file model. Deleting a file
+    #: only requires write permission on its parent dir (boxman-owned), so
+    #: ``rm`` must not be sudo-wrapped — otherwise a host whose sudoers lacks a
+    #: passwordless ``rm`` rule would fail cleanup silently. Overridable per
+    #: command via ``force_sudo_commands``.
+    _NEVER_SUDO_COMMANDS: frozenset = frozenset({'rm'})
+
     def __init__(self,
                  override_config_use_sudo: bool | None = None,
                  provider_config: dict[str, Any] | None = None):
@@ -155,8 +163,12 @@ class LibVirtCommandBase:
 
         Resolution order (first match wins):
         1. ``force_sudo_commands`` — always sudo regardless of ``use_sudo``
-        2. ``sudo_skip_commands`` — never sudo regardless of ``use_sudo``
-        3. Fall back to the global ``use_sudo`` flag.
+        2. ``rm`` — never sudo: unlinking a file needs write permission on the
+           (boxman-owned) parent directory, not root. Prepending a sudo that
+           may require an interactive password would only make cleanup fail
+           silently and leak overlay/.preserve files.
+        3. ``sudo_skip_commands`` — never sudo regardless of ``use_sudo``
+        4. Fall back to the global ``use_sudo`` flag.
 
         Matching is done against the basename of the first token in the
         command string (e.g. ``/usr/bin/qemu-img resize …`` matches
@@ -167,7 +179,7 @@ class LibVirtCommandBase:
 
         if cmd_name in self.force_sudo_commands:
             return True
-        if cmd_name in self.sudo_skip_commands:
+        if cmd_name in self._NEVER_SUDO_COMMANDS or cmd_name in self.sudo_skip_commands:
             return False
         return self.use_sudo
 

--- a/src/boxman/providers/libvirt/destroy_vm.py
+++ b/src/boxman/providers/libvirt/destroy_vm.py
@@ -243,86 +243,33 @@ class DestroyVM(VirshCommand):
             self.logger.error(f"error un-defining vm {self.name}: {exc}")
             return False
 
-    def delete_all_snapshots(self) -> bool:
-        """
-        Delete all snapshots for the VM.
-
-        This should be called before undefining the VM to ensure
-        all associated snapshot data is cleaned up.
-
-        Returns:
-            True if all snapshots were deleted successfully or if there are no snapshots,
-            False if there was an error deleting any snapshot
-        """
-        if not self.is_vm_defined():
-            self.logger.info(f"vm {self.name} is not defined, no snapshots to delete")
-            return True
-
-        try:
-            # List all snapshots
-            self.logger.info(f"checking for snapshots of VM {self.name}")
-            result = self.execute("snapshot-list", self.name, "--name", warn=True)
-
-            if not result.ok:
-                self.logger.warning(f"failed to list snapshots for VM {self.name}: {result.stderr}")
-                return False
-
-            if not result.stdout.strip():
-                self.logger.info(f"no snapshots found for VM {self.name}")
-                return True
-
-            # Process the list of snapshots
-            snapshots = [s for s in result.stdout.strip().split('\n') if s.strip()]
-
-            if not snapshots:
-                self.logger.info(f"no snapshots found for VM {self.name}")
-                return True
-
-            self.logger.info(f"found {len(snapshots)} snapshots to delete for VM {self.name}")
-
-            # Delete each snapshot
-            success = True
-            for snapshot in snapshots:
-                try:
-                    self.logger.info(f"deleting snapshot '{snapshot}' for VM {self.name}")
-                    delete_result = self.execute("snapshot-delete", self.name, snapshot)
-
-                    if not delete_result.ok:
-                        self.logger.error(f"failed to delete snapshot '{snapshot}' for VM {self.name}: {delete_result.stderr}")
-                        success = False
-                except RuntimeError as exc:
-                    self.logger.error(
-                        f"error deleting snapshot '{snapshot}' for VM {self.name}: {exc}")
-                    success = False
-
-            return success
-        except RuntimeError as exc:
-            self.logger.error(f"error handling snapshots for VM {self.name}: {exc}")
-            return False
-
     def remove(self, force: bool | None = None) -> bool:
         """
-        Completely destroy the VM: shutdown, force destroy if needed, and undefine.
+        Completely remove the VM: stop it, then undefine it together with its
+        storage and snapshot metadata.
+
+        Snapshot metadata is cleared in a single atomic
+        ``undefine --snapshots-metadata`` inside :meth:`force_undefine_vm`.
+        We deliberately do NOT iterate ``virsh snapshot-delete`` per
+        snapshot: for boxman's external snapshots (which carry saved memory
+        state) that does not actually delete them, and on a still-running or
+        *paused* domain it pile-ups "cannot acquire state change lock"
+        timeouts that can wedge the domain until libvirtd is restarted.
 
         Args:
-            force: Whether to force destroy the VM if it's running
+            force: If True, skip the graceful shutdown and force-kill the VM
+                before undefining. If False/None, attempt a graceful shutdown
+                first; anything still alive — including a *paused* domain,
+                which ``is_vm_running`` does not report — is force-killed by
+                :meth:`force_undefine_vm` regardless.
 
         Returns:
-            True if all operations were successful, False otherwise
+            True if the VM was removed, False otherwise.
         """
-        if self.is_vm_running():
-            if not self.destroy_vm(force=force):
-                self.logger.error(f"failed to stop VM {self.name}, cannot proceed with undefine")
-                return False
+        # Best-effort graceful shutdown on the non-force path. A timeout here
+        # is not fatal: force_undefine_vm() force-kills whatever is still
+        # alive (running, paused, in-shutdown) before undefining.
+        if force is not True and self.is_vm_running():
+            self.shutdown_vm(timeout=self.shutdown_timeout, force=False)
 
-        # delete all snapshots before un-defining the VM
-        if not self.delete_all_snapshots():
-            self.logger.warning(
-                f"failed to delete all snapshots for VM {self.name}, "
-                f"continuing with undefine anyway")
-            # Continuing with undefine even if snapshot deletion failed
-            # This is a deliberate choice to ensure VM removal attempts completion
-
-        status = self.undefine_vm()
-
-        return status
+        return self.force_undefine_vm()

--- a/src/boxman/providers/libvirt/session.py
+++ b/src/boxman/providers/libvirt/session.py
@@ -2,6 +2,7 @@ import os
 import time
 from multiprocessing import Process, Queue
 from typing import Any
+from xml.etree import ElementTree as ET
 
 from boxman import log
 
@@ -276,6 +277,48 @@ class LibVirtSession:
             raise RuntimeError(
                 f"Failed to clone VM {src_vm_name} to {new_vm_name}"
             )
+
+    def vm_exists(self, vm_name: str) -> bool:
+        """Whether a domain named *vm_name* is registered with libvirt."""
+        virsh = VirshCommand(provider_config=self.provider_config)
+        result = virsh.execute("list", "--all", "--name", hide=True, warn=True)
+        if not result.ok:
+            return False
+        names = [v.strip() for v in result.stdout.splitlines() if v.strip()]
+        return vm_name in names
+
+    def template_disks_present(self, vm_name: str) -> bool:
+        """
+        Whether every ``<disk device='disk'>`` source file referenced in
+        *vm_name*'s domain XML exists on the host filesystem. Returns
+        True if the domain is unknown (no claim about disks). CDROM
+        sources are ignored — a missing seed.iso is normal.
+
+        Detects the broken-template state where the libvirt domain is
+        still registered after its backing qcow2 was deleted; virt-clone
+        from such a "template" fails inscrutably ("cannot open directory
+        ...: No such file or directory").
+        """
+        virsh = VirshCommand(provider_config=self.provider_config)
+        result = virsh.execute("dumpxml", vm_name, hide=True, warn=True)
+        if not result.ok:
+            return True  # nothing to check
+        try:
+            root = ET.fromstring(result.stdout)
+        except ET.ParseError:
+            return True
+        for disk in root.findall(".//disk"):
+            if disk.get('device') != 'disk':
+                continue
+            source = disk.find("source")
+            if source is None:
+                continue
+            path = source.get('file')
+            if path and not os.path.isfile(path):
+                self.logger.warning(
+                    f"template '{vm_name}': disk file missing on host: {path}")
+                return False
+        return True
 
     def destroy_disks(self,
                       workdir : str,

--- a/src/boxman/providers/libvirt/snapshot.py
+++ b/src/boxman/providers/libvirt/snapshot.py
@@ -694,9 +694,12 @@ class SnapshotManager:
         """
         Revert a VM to a specific snapshot.
 
-        Before reverting, overlay files referenced by all snapshots are
-        backed up.  After the revert any overlays that libvirt deleted
-        are restored so that every snapshot remains reachable.
+        Before reverting, the overlay files that ``snapshot-revert`` can
+        delete are backed up — the target snapshot's overlays and any newer
+        ones in the chain (see :meth:`_preserve_snapshot_overlays`, which
+        falls back to backing up every overlay if the target isn't found in
+        the chain). After the revert any overlays libvirt deleted are
+        restored so that every snapshot remains reachable.
 
         Compressed memory: if the snapshot's ``.raw`` memory file is missing
         but a ``.raw.zst`` sibling exists (created by ``snapshot take

--- a/src/boxman/providers/libvirt/snapshot.py
+++ b/src/boxman/providers/libvirt/snapshot.py
@@ -599,23 +599,43 @@ class SnapshotManager:
                 continue
         return overlays
 
-    def _preserve_snapshot_overlays(self, vm_name: str) -> list[tuple]:
+    def _preserve_snapshot_overlays(self,
+                                    vm_name: str,
+                                    snapshot_name: str) -> list[tuple]:
         """
-        Back up overlay files that belong to snapshots and may be deleted
-        by ``snapshot-revert``.
+        Back up the overlay files that ``snapshot-revert`` to
+        *snapshot_name* can delete, so they can be restored afterwards
+        and every snapshot stays reachable.
 
-        libvirt deletes the overlay of the *current* snapshot when
-        reverting to an earlier one.  This method copies those files so
-        they can be restored afterwards, keeping every snapshot reachable.
+        Reverting recreates the target snapshot's own overlay (and may
+        drop overlays newer than it in the chain), so only those are at
+        risk -- overlays of snapshots *older* than the target are backing
+        files the target depends on and are never touched.  Backing up
+        just the target-and-newer overlays avoids full-copying the whole
+        chain on every restore (e.g. restoring the latest snapshot copies
+        one overlay per disk instead of one per disk per snapshot).
+
+        If the target is not found in the chain order (orphaned/missing
+        metadata), fall back to preserving every overlay -- safe but slow.
 
         Returns a list of (original_path, backup_path) tuples.
         """
         all_overlays = self._get_snapshot_overlay_files(vm_name)
 
-        # collect every overlay file referenced by any snapshot
+        # only overlays that revert can delete: the target and any newer
+        # snapshots in the (oldest-first) chain.  Older snapshots are
+        # backing files the target relies on and are left untouched.
+        order = self._chain_order(vm_name)
+        if snapshot_name in order:
+            at_risk = set(order[order.index(snapshot_name):])
+        else:
+            at_risk = set(all_overlays)
+
+        # collect the overlay files referenced by the at-risk snapshots
         files_to_preserve: set = set()
-        for files in all_overlays.values():
-            files_to_preserve.update(files)
+        for snap, files in all_overlays.items():
+            if snap in at_risk:
+                files_to_preserve.update(files)
 
         pairs = [(f, f + '.preserve') for f in sorted(files_to_preserve)
                  if os.path.isfile(f)]
@@ -667,7 +687,7 @@ class SnapshotManager:
 
         if to_cleanup:
             cmd = " && ".join(
-                f"{sudo}rm -f '{b}'" for b in to_cleanup)
+                f"rm -f '{b}'" for b in to_cleanup)
             self.virsh.execute_shell(cmd, warn=True)
 
     def snapshot_restore(self, vm_name: str, snapshot_name: str) -> bool:
@@ -696,7 +716,7 @@ class SnapshotManager:
         Returns:
             bool: True if successful, False otherwise
         """
-        preserved = self._preserve_snapshot_overlays(vm_name)
+        preserved = self._preserve_snapshot_overlays(vm_name, snapshot_name)
 
         # Just-in-time decompress if the memory file was zstd'd.
         mem_path = self._memory_path_from_xml(vm_name, snapshot_name)
@@ -767,8 +787,7 @@ class SnapshotManager:
         if os.path.isfile(zst_path):
             # We kept the .zst around during revert, so delete the
             # decompressed copy rather than re-running zstd.
-            sudo = "sudo " if self.use_sudo else ""
-            self.virsh.execute_shell(f"{sudo}rm -f '{mem_path}'", warn=True)
+            self.virsh.execute_shell(f"rm -f '{mem_path}'", warn=True)
             return
         # No .zst on disk (unusual) — re-compress from scratch.
         if not self.compress_memory_file(mem_path):
@@ -876,18 +895,17 @@ class SnapshotManager:
                     f"{commit.stderr.strip()}")
                 return False
 
-        sudo = "sudo " if self.use_sudo else ""
         for disk_target, _src in disks:
             overlay = self._overlay_path_for_snapshot(
                 vm_name, snapshot_name, disk_target)
             if overlay and os.path.isfile(overlay):
-                self.virsh.execute_shell(f"{sudo}rm -f '{overlay}'", warn=True)
+                self.virsh.execute_shell(f"rm -f '{overlay}'", warn=True)
 
         mem_path = self._memory_path_from_xml(vm_name, snapshot_name)
         if mem_path:
             for path in (mem_path, f"{mem_path}.zst"):
                 if os.path.isfile(path):
-                    self.virsh.execute_shell(f"{sudo}rm -f '{path}'", warn=True)
+                    self.virsh.execute_shell(f"rm -f '{path}'", warn=True)
 
         meta = self.virsh.execute(
             "snapshot-delete", vm_name, snapshot_name, "--metadata", warn=True)
@@ -1130,20 +1148,19 @@ class SnapshotManager:
         if not self._strip_backing_store_cache(vm_name):
             return False
 
-        sudo = "sudo " if self.use_sudo else ""
         for snap in drop_set:
             for disk_target, _ in disks:
                 overlay = self._overlay_path_for_snapshot(
                     vm_name, snap, disk_target)
                 if overlay and os.path.isfile(overlay):
                     self.virsh.execute_shell(
-                        f"{sudo}rm -f '{overlay}'", warn=True)
+                        f"rm -f '{overlay}'", warn=True)
             mem_path = self._memory_path_from_xml(vm_name, snap)
             if mem_path:
                 for path in (mem_path, f"{mem_path}.zst"):
                     if os.path.isfile(path):
                         self.virsh.execute_shell(
-                            f"{sudo}rm -f '{path}'", warn=True)
+                            f"rm -f '{path}'", warn=True)
             meta = self.virsh.execute(
                 "snapshot-delete", vm_name, snap, "--metadata", warn=True)
             if not meta.ok:

--- a/tests/test_libvirt_destroy_vm.py
+++ b/tests/test_libvirt_destroy_vm.py
@@ -188,55 +188,54 @@ class TestForceUndefine:
         assert "destroy" not in calls
 
 
-class TestDeleteAllSnapshots:
-
-    def test_noop_when_vm_not_defined(self, dv: DestroyVM):
-        with patch.object(dv, "is_vm_defined", return_value=False):
-            assert dv.delete_all_snapshots() is True
-
-    def test_noop_when_no_snapshots(self, dv: DestroyVM):
-        with patch.object(dv, "is_vm_defined", return_value=True), \
-             patch.object(dv, "execute", return_value=_result(stdout="\n")):
-            assert dv.delete_all_snapshots() is True
-
-    def test_deletes_all_and_returns_true(self, dv: DestroyVM):
-        def fake(*args, **_kwargs):
-            if args[0] == "snapshot-list":
-                return _result(stdout="snap1\nsnap2\n")
-            return _result()
-        with patch.object(dv, "is_vm_defined", return_value=True), \
-             patch.object(dv, "execute", side_effect=fake) as execute:
-            assert dv.delete_all_snapshots() is True
-        deletes = [c for c in execute.call_args_list if c.args[0] == "snapshot-delete"]
-        assert len(deletes) == 2
-
-    def test_individual_failure_returns_false(self, dv: DestroyVM):
-        def fake(*args, **_kwargs):
-            if args[0] == "snapshot-list":
-                return _result(stdout="snap1\n")
-            return _result(ok=False, stderr="nope")
-        with patch.object(dv, "is_vm_defined", return_value=True), \
-             patch.object(dv, "execute", side_effect=fake):
-            assert dv.delete_all_snapshots() is False
-
-
 class TestRemove:
+    """`remove()` delegates undefine to force_undefine_vm (atomic
+    --snapshots-metadata) and must never iterate per-snapshot
+    `virsh snapshot-delete`, which wedges running/paused domains with saved
+    external snapshots (regression: the 10-VM teardown lock-timeout pileup)."""
 
-    def test_full_happy_path(self, dv: DestroyVM):
+    def test_delegates_to_force_undefine(self, dv: DestroyVM):
         with patch.object(dv, "is_vm_running", return_value=False), \
-             patch.object(dv, "delete_all_snapshots", return_value=True), \
-             patch.object(dv, "undefine_vm", return_value=True):
+             patch.object(dv, "force_undefine_vm", return_value=True) as fu:
             assert dv.remove() is True
+            fu.assert_called_once()
 
-    def test_destroy_failure_short_circuits(self, dv: DestroyVM):
+    def test_non_force_attempts_graceful_shutdown_first(self, dv: DestroyVM):
         with patch.object(dv, "is_vm_running", return_value=True), \
-             patch.object(dv, "destroy_vm", return_value=False):
-            assert dv.remove() is False
+             patch.object(dv, "shutdown_vm", return_value=True) as graceful, \
+             patch.object(dv, "force_undefine_vm", return_value=True) as fu:
+            assert dv.remove(force=None) is True
+            _a, kwargs = graceful.call_args
+            assert kwargs["force"] is False  # graceful only; fu force-kills the rest
+            fu.assert_called_once()
 
-    def test_snapshot_delete_failure_does_not_block_undefine(self, dv: DestroyVM):
-        """Deliberate behavior: attempt undefine even if snapshot cleanup fails."""
+    def test_force_skips_graceful_shutdown(self, dv: DestroyVM):
+        with patch.object(dv, "is_vm_running", return_value=True), \
+             patch.object(dv, "shutdown_vm") as graceful, \
+             patch.object(dv, "force_undefine_vm", return_value=True) as fu:
+            assert dv.remove(force=True) is True
+            graceful.assert_not_called()
+            fu.assert_called_once()
+
+    def test_paused_vm_is_force_killed_and_undefined(self, dv: DestroyVM):
+        """A paused VM (is_vm_running False, is_vm_shut_off False) must still be
+        force-killed and undefined — the bug that left boxman04 wedged."""
+        # is_vm_running False -> graceful skipped; force_undefine_vm runs for real
         with patch.object(dv, "is_vm_running", return_value=False), \
-             patch.object(dv, "delete_all_snapshots", return_value=False), \
-             patch.object(dv, "undefine_vm", return_value=True) as undefine:
+             patch.object(dv, "is_vm_defined", side_effect=[True, False]), \
+             patch.object(dv, "is_vm_shut_off", return_value=False), \
+             patch.object(dv, "execute", return_value=_result()) as execute:
             assert dv.remove() is True
-            undefine.assert_called_once()
+        calls = [c.args[0] for c in execute.call_args_list]
+        assert "destroy" in calls  # force-killed the paused domain
+        assert any("undefine" in c and "--snapshots-metadata" in c for c in calls)
+
+    def test_never_issues_per_snapshot_snapshot_delete(self, dv: DestroyVM):
+        with patch.object(dv, "is_vm_running", return_value=False), \
+             patch.object(dv, "is_vm_defined", side_effect=[True, False]), \
+             patch.object(dv, "is_vm_shut_off", return_value=True), \
+             patch.object(dv, "execute", return_value=_result()) as execute:
+            assert dv.remove() is True
+        commands = [c.args[0] for c in execute.call_args_list]
+        assert not any(c.startswith("snapshot-delete") for c in commands)
+        assert any("--snapshots-metadata" in c for c in commands)

--- a/tests/test_libvirt_session.py
+++ b/tests/test_libvirt_session.py
@@ -252,3 +252,101 @@ class TestCloneVMDelegation:
                    return_value=mock_cloner):
             with pytest.raises(RuntimeError, match="Failed to clone"):
                 s.clone_vm("new-vm", "src", {}, str(tmp_path))
+
+
+class TestVmExists:
+
+    def test_true_when_name_in_list(self):
+        s = _session({})
+        with patch("boxman.providers.libvirt.session.VirshCommand") as virsh_cls:
+            virsh_cls.return_value.execute.return_value = _result(
+                stdout="other-vm\nrocky-template\n")
+            assert s.vm_exists("rocky-template") is True
+
+    def test_false_when_name_absent(self):
+        s = _session({})
+        with patch("boxman.providers.libvirt.session.VirshCommand") as virsh_cls:
+            virsh_cls.return_value.execute.return_value = _result(stdout="other\n")
+            assert s.vm_exists("missing") is False
+
+    def test_false_on_virsh_failure(self):
+        s = _session({})
+        with patch("boxman.providers.libvirt.session.VirshCommand") as virsh_cls:
+            virsh_cls.return_value.execute.return_value = _result(ok=False)
+            assert s.vm_exists("x") is False
+
+
+class TestTemplateDisksPresent:
+    """Guards the broken-template detection that prevents virt-clone from
+    failing inscrutably when the libvirt domain still exists but its
+    backing qcow2 has been deleted."""
+
+    XML_HEALTHY_TEMPLATE = """\
+<domain>
+  <devices>
+    <disk type='file' device='disk'>
+      <source file='{disk_path}'/>
+      <target dev='vda' bus='virtio'/>
+    </disk>
+  </devices>
+</domain>"""
+
+    XML_BROKEN_TEMPLATE = """\
+<domain>
+  <devices>
+    <disk type='file' device='disk'>
+      <source file='/this/path/will/not/exist.qcow2'/>
+      <target dev='vda' bus='virtio'/>
+    </disk>
+  </devices>
+</domain>"""
+
+    XML_CDROM_ONLY = """\
+<domain>
+  <devices>
+    <disk type='file' device='cdrom'>
+      <source file='/path/never-mind-i-am-missing.iso'/>
+      <target dev='hdc' bus='ide'/>
+    </disk>
+  </devices>
+</domain>"""
+
+    def test_true_when_data_disk_present(self, tmp_path: Path):
+        disk = tmp_path / "template.qcow2"
+        disk.write_bytes(b"qcow2-stub")
+        xml = self.XML_HEALTHY_TEMPLATE.format(disk_path=str(disk))
+        s = _session({})
+        with patch("boxman.providers.libvirt.session.VirshCommand") as virsh_cls:
+            virsh_cls.return_value.execute.return_value = _result(stdout=xml)
+            assert s.template_disks_present("rocky-template") is True
+
+    def test_false_when_data_disk_missing(self):
+        s = _session({})
+        with patch("boxman.providers.libvirt.session.VirshCommand") as virsh_cls:
+            virsh_cls.return_value.execute.return_value = _result(
+                stdout=self.XML_BROKEN_TEMPLATE)
+            assert s.template_disks_present("rocky-template") is False
+
+    def test_ignores_missing_cdrom_iso(self):
+        """A missing seed.iso is normal post-template-build; do not
+        report the template as broken just because of an absent cdrom."""
+        s = _session({})
+        with patch("boxman.providers.libvirt.session.VirshCommand") as virsh_cls:
+            virsh_cls.return_value.execute.return_value = _result(
+                stdout=self.XML_CDROM_ONLY)
+            assert s.template_disks_present("rocky-template") is True
+
+    def test_true_when_dumpxml_fails(self):
+        """Unknown domain → no claim about disks → True (do not block)."""
+        s = _session({})
+        with patch("boxman.providers.libvirt.session.VirshCommand") as virsh_cls:
+            virsh_cls.return_value.execute.return_value = _result(
+                ok=False, stderr="domain not found")
+            assert s.template_disks_present("ghost") is True
+
+    def test_true_when_xml_unparseable(self):
+        s = _session({})
+        with patch("boxman.providers.libvirt.session.VirshCommand") as virsh_cls:
+            virsh_cls.return_value.execute.return_value = _result(
+                stdout="not xml at all")
+            assert s.template_disks_present("x") is True

--- a/tests/test_libvirt_snapshot.py
+++ b/tests/test_libvirt_snapshot.py
@@ -243,8 +243,9 @@ class TestGetSnapshotOverlayFiles:
 class TestPreserveSnapshotOverlays:
 
     def test_no_overlays_returns_empty_list(self, sm: SnapshotManager):
-        with patch.object(sm, "_get_snapshot_overlay_files", return_value={}):
-            assert sm._preserve_snapshot_overlays("vm01") == []
+        with patch.object(sm, "_get_snapshot_overlay_files", return_value={}), \
+             patch.object(sm, "_chain_order", return_value=["s"]):
+            assert sm._preserve_snapshot_overlays("vm01", "s") == []
 
     def test_overlays_batched_into_single_rsync_command(
         self, sm: SnapshotManager, tmp_path: Path
@@ -254,11 +255,13 @@ class TestPreserveSnapshotOverlays:
         overlay2 = tmp_path / "o2.qcow2"
         overlay2.write_bytes(b"x")
 
+        # reverting to s1 (oldest) preserves s1 and the newer s2
         with patch.object(
             sm, "_get_snapshot_overlay_files",
             return_value={"s1": [str(overlay1)], "s2": [str(overlay2)]},
-        ), patch.object(sm.virsh, "execute_shell", return_value=_result()) as shell:
-            preserved = sm._preserve_snapshot_overlays("vm01")
+        ), patch.object(sm, "_chain_order", return_value=["s1", "s2"]), \
+                patch.object(sm.virsh, "execute_shell", return_value=_result()) as shell:
+            preserved = sm._preserve_snapshot_overlays("vm01", "s1")
 
         # one single command for BOTH overlays (regression: 057eb7d)
         assert shell.call_count == 1
@@ -271,12 +274,59 @@ class TestPreserveSnapshotOverlays:
             [str(overlay1), str(overlay2)]
         )
 
+    def test_preserves_only_target_and_newer(
+        self, sm: SnapshotManager, tmp_path: Path
+    ):
+        # chain: s1 (oldest) -> s2 -> s3 (newest), one overlay each
+        overlays = {}
+        for name in ("s1", "s2", "s3"):
+            f = tmp_path / f"{name}.qcow2"
+            f.write_bytes(b"x")
+            overlays[name] = [str(f)]
+
+        # restoring the latest snapshot backs up ONLY its own overlay
+        # (the regression this narrowing fixes)
+        with patch.object(sm, "_get_snapshot_overlay_files", return_value=overlays), \
+                patch.object(sm, "_chain_order", return_value=["s1", "s2", "s3"]), \
+                patch.object(sm.virsh, "execute_shell", return_value=_result()):
+            preserved = sm._preserve_snapshot_overlays("vm01", "s3")
+        assert [p[0] for p in preserved] == overlays["s3"]
+
+        # restoring a middle snapshot backs up it + the newer one, not the older
+        with patch.object(sm, "_get_snapshot_overlay_files", return_value=overlays), \
+                patch.object(sm, "_chain_order", return_value=["s1", "s2", "s3"]), \
+                patch.object(sm.virsh, "execute_shell", return_value=_result()):
+            preserved = sm._preserve_snapshot_overlays("vm01", "s2")
+        backed_up = sorted(p[0] for p in preserved)
+        assert backed_up == sorted(overlays["s2"] + overlays["s3"])
+        assert overlays["s1"][0] not in backed_up
+
+    def test_falls_back_to_all_when_target_not_in_chain(
+        self, sm: SnapshotManager, tmp_path: Path
+    ):
+        overlays = {}
+        for name in ("s1", "s2"):
+            f = tmp_path / f"{name}.qcow2"
+            f.write_bytes(b"x")
+            overlays[name] = [str(f)]
+
+        # orphaned/missing metadata: target absent from chain order ->
+        # preserve everything (safe but slow fallback)
+        with patch.object(sm, "_get_snapshot_overlay_files", return_value=overlays), \
+                patch.object(sm, "_chain_order", return_value=[]), \
+                patch.object(sm.virsh, "execute_shell", return_value=_result()):
+            preserved = sm._preserve_snapshot_overlays("vm01", "gone")
+        assert sorted(p[0] for p in preserved) == sorted(
+            overlays["s1"] + overlays["s2"]
+        )
+
     def test_skips_missing_files(self, sm: SnapshotManager, tmp_path: Path):
         with patch.object(
             sm, "_get_snapshot_overlay_files",
             return_value={"s": ["/does/not/exist.qcow2"]},
-        ), patch.object(sm.virsh, "execute_shell") as shell:
-            preserved = sm._preserve_snapshot_overlays("vm01")
+        ), patch.object(sm, "_chain_order", return_value=["s"]), \
+                patch.object(sm.virsh, "execute_shell") as shell:
+            preserved = sm._preserve_snapshot_overlays("vm01", "s")
         assert preserved == []
         shell.assert_not_called()
 
@@ -286,8 +336,9 @@ class TestPreserveSnapshotOverlays:
         overlay.write_bytes(b"x")
         with patch.object(
             sm, "_get_snapshot_overlay_files", return_value={"s": [str(overlay)]}
-        ), patch.object(sm.virsh, "execute_shell", return_value=_result()) as shell:
-            sm._preserve_snapshot_overlays("vm01")
+        ), patch.object(sm, "_chain_order", return_value=["s"]), \
+                patch.object(sm.virsh, "execute_shell", return_value=_result()) as shell:
+            sm._preserve_snapshot_overlays("vm01", "s")
         assert shell.call_args.args[0].startswith("sudo rsync")
 
 
@@ -328,6 +379,22 @@ class TestRestorePreservedOverlays:
         # one rm cleanup call
         assert any("rm -f" in c and str(backup) in c for c in calls)
 
+    def test_cleanup_rm_is_not_sudo_prefixed(self, tmp_path: Path):
+        """Cleanup rm must not be sudo-prefixed even when use_sudo=True —
+        unlinking needs dir-write perms, not root, and a sudo that needs a
+        password would silently leak the .preserve files (see TestRmNeverSudo).
+        """
+        sm = SnapshotManager({"use_sudo": True})
+        overlay = tmp_path / "o.qcow2"
+        overlay.write_bytes(b"x")  # original still present -> backup is cleanup
+        backup = tmp_path / "o.qcow2.preserve"
+        backup.write_bytes(b"x")
+        with patch.object(sm.virsh, "execute_shell", return_value=_result()) as shell:
+            sm._restore_preserved_overlays([(str(overlay), str(backup))])
+        cmd = shell.call_args.args[0]
+        assert cmd.startswith("rm -f")
+        assert "sudo " not in cmd
+
 
 class TestSnapshotRestore:
     """End-to-end wiring for snapshot_restore (regression: 057eb7d)."""
@@ -343,7 +410,7 @@ class TestSnapshotRestore:
              patch.object(sm, "_restore_preserved_overlays") as restore:
             assert sm.snapshot_restore("vm01", "snap1") is True
 
-        preserve.assert_called_once_with("vm01")
+        preserve.assert_called_once_with("vm01", "snap1")
         execute.assert_called_once()
         assert execute.call_args.args[0] == "snapshot-revert"
         restore.assert_called_once_with(preserved_pairs)

--- a/tests/test_manager_core.py
+++ b/tests/test_manager_core.py
@@ -274,3 +274,197 @@ class TestGetProviderConfigWithRuntime:
         mgr.runtime = "docker-compose"
         enriched = mgr.get_provider_config_with_runtime({"uri": "qemu:///system"})
         assert enriched["runtime"] == "docker-compose"
+
+
+class TestCheckTemplatesForClusters:
+    """
+    Regression for the recovery path when a template's libvirt domain
+    exists but its backing qcow2 has been deleted. The check must
+    detect this and rebuild the template with ``force=True`` so that
+    cloudinit.create_template's destroy+undefine path runs.
+    """
+
+    @staticmethod
+    def _mgr_with_template(tmp_path: Path):
+        from unittest.mock import MagicMock, patch as _patch
+        with _patch("boxman.manager.BoxmanCache"):
+            m = BoxmanManager()
+        m.config = {
+            'project': 'demo',
+            'templates': {
+                'tpl1': {
+                    'name': 'rocky-template',
+                    'image': 'file:///tmp/x.qcow2',
+                },
+            },
+            'clusters': {
+                'cluster_1': {
+                    'workdir': str(tmp_path),
+                    'base_image': 'rocky-template',
+                    'vms': {'node01': {}},
+                },
+            },
+        }
+        m._provider = MagicMock()
+        m._provider.provider_config = {}
+        return m
+
+    def test_broken_template_triggers_force_rebuild(self, tmp_path: Path):
+        """Domain exists + disks missing → rebuild via force=True."""
+        from unittest.mock import patch as _patch
+        m = self._mgr_with_template(tmp_path)
+        m._provider.vm_exists.return_value = True
+        m._provider.template_disks_present.return_value = False
+
+        captured: list = []
+
+        def fake_impl(*args, **kwargs):
+            captured.append((args, kwargs))
+
+        with _patch.object(m, '_create_templates_impl', side_effect=fake_impl):
+            ok = m.ensure_templates_exist()
+        assert ok is True
+        # Exactly one call — for the broken template — with force=True
+        assert len(captured) == 1
+        _args, kwargs = captured[0]
+        assert kwargs.get('force') is True
+        assert kwargs.get('requested') == ['tpl1']
+
+    def test_healthy_template_skips_rebuild(self, tmp_path: Path):
+        from unittest.mock import patch as _patch
+        m = self._mgr_with_template(tmp_path)
+        m._provider.vm_exists.return_value = True
+        m._provider.template_disks_present.return_value = True
+        with _patch.object(m, '_create_templates_impl') as impl:
+            ok = m.ensure_templates_exist()
+        assert ok is True
+        impl.assert_not_called()
+
+    def test_missing_template_force_false(self, tmp_path: Path):
+        """Domain absent → rebuild via the regular force=False path."""
+        from unittest.mock import patch as _patch
+        m = self._mgr_with_template(tmp_path)
+        m._provider.vm_exists.return_value = False  # not registered
+        captured: list = []
+        with _patch.object(m, '_create_templates_impl',
+                           side_effect=lambda *a, **kw: captured.append(kw)):
+            ok = m.ensure_templates_exist()
+        assert ok is True
+        assert len(captured) == 1
+        assert captured[0].get('force') is False
+        assert captured[0].get('requested') == ['tpl1']
+
+
+class TestCloneVmsExitCodeGuard:
+    """
+    Regression: a failed clone subprocess used to leave provision running
+    on past the failure — configure/start/wait-for-IP then ran against
+    VMs that were never defined and the wait-for-IP loop looked like a
+    hang. clone_vms must now raise after joining if any subprocess
+    exited non-zero.
+    """
+
+    @staticmethod
+    def _fake_process(exitcode: int):
+        from unittest.mock import MagicMock
+        proc = MagicMock()
+        proc.exitcode = exitcode
+        proc.start = MagicMock()
+        proc.join = MagicMock()
+        return proc
+
+    def _mgr_with_one_vm(self, tmp_path: Path):
+        with patch("boxman.manager.BoxmanCache"):
+            m = BoxmanManager()
+        m.config = {
+            'project': 'demo',
+            'clusters': {
+                'cluster_1': {
+                    'workdir': str(tmp_path),
+                    'base_image': 'tpl',
+                    'vms': {'node01': {}},
+                },
+            },
+        }
+        # provider must expose provider_config (referenced by storage-pool helper)
+        from unittest.mock import MagicMock
+        m._provider = MagicMock()
+        m._provider.provider_config = {}
+        return m
+
+    def test_raises_when_clone_subprocess_fails(self, tmp_path: Path):
+        from unittest.mock import patch as _patch
+        m = self._mgr_with_one_vm(tmp_path)
+        fake = self._fake_process(exitcode=1)
+        with _patch.object(m, '_ensure_libvirt_storage_pool'), \
+             _patch("boxman.manager.Process", return_value=fake):
+            with pytest.raises(RuntimeError, match="clone failed for 1 VM"):
+                m.clone_vms()
+
+    def test_no_raise_when_all_clones_succeed(self, tmp_path: Path):
+        from unittest.mock import patch as _patch
+        m = self._mgr_with_one_vm(tmp_path)
+        fake = self._fake_process(exitcode=0)
+        with _patch.object(m, '_ensure_libvirt_storage_pool'), \
+             _patch("boxman.manager.Process", return_value=fake):
+            # No exception, no return value either.
+            m.clone_vms()
+
+
+class TestCloneAndConfigureNewVmsExitCodeGuard:
+    """
+    Mirror of TestCloneVmsExitCodeGuard but for the `update` path
+    (_clone_and_configure_new_vms). Same silent-failure bug if any
+    clone subprocess exits non-zero — the configure/start steps would
+    otherwise run against VMs that were never defined.
+    """
+
+    @staticmethod
+    def _fake_process(exitcode: int):
+        from unittest.mock import MagicMock
+        proc = MagicMock()
+        proc.exitcode = exitcode
+        proc.start = MagicMock()
+        proc.join = MagicMock()
+        return proc
+
+    def _mgr_with_one_vm(self, tmp_path: Path):
+        from unittest.mock import MagicMock, patch as _patch
+        with _patch("boxman.manager.BoxmanCache"):
+            m = BoxmanManager()
+        m.config = {
+            'project': 'demo',
+            'clusters': {
+                'cluster_1': {
+                    'workdir': str(tmp_path),
+                    'base_image': 'tpl',
+                    'vms': {'node01': {}},
+                },
+            },
+        }
+        m._provider = MagicMock()
+        m._provider.provider_config = {}
+        return m
+
+    def test_raises_when_clone_subprocess_fails(self, tmp_path: Path):
+        from unittest.mock import patch as _patch
+        m = self._mgr_with_one_vm(tmp_path)
+        fake = self._fake_process(exitcode=1)
+        new_vm_names = {'bprj__demo__bprj_cluster_1_node01'}
+        with _patch.object(m, '_ensure_libvirt_storage_pool'), \
+             _patch("boxman.manager.Process", return_value=fake):
+            with pytest.raises(RuntimeError, match="clone failed for 1 new VM"):
+                m._clone_and_configure_new_vms(new_vm_names)
+
+    def test_no_raise_when_all_clones_succeed(self, tmp_path: Path):
+        """When clones succeed, control should move into the configure
+        phase — patch _configure_and_start_vm so we don't depend on the
+        rest of the orchestration."""
+        from unittest.mock import patch as _patch
+        m = self._mgr_with_one_vm(tmp_path)
+        fake = self._fake_process(exitcode=0)
+        new_vm_names = {'bprj__demo__bprj_cluster_1_node01'}
+        with _patch.object(m, '_ensure_libvirt_storage_pool'), \
+             _patch.object(m, '_configure_and_start_vm'), \
+             _patch("boxman.manager.Process", return_value=fake):
+            m._clone_and_configure_new_vms(new_vm_names)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -54,7 +54,7 @@ class TestSnapshotOverlayPreservation_057eb7d:
 
         call_order: list[str] = []
 
-        def record_preserve(_vm):
+        def record_preserve(_vm, _snap):
             call_order.append("preserve")
             return [("/overlay.qcow2", "/overlay.qcow2.preserve")]
 
@@ -88,11 +88,13 @@ class TestSnapshotOverlayPreservation_057eb7d:
         c = tmp_path / "c.qcow2"
         c.write_bytes(b"x")
 
+        # revert to the oldest snapshot preserves it and both newer ones
         with patch.object(
             sm, "_get_snapshot_overlay_files",
             return_value={"s1": [str(a)], "s2": [str(b)], "s3": [str(c)]},
-        ), patch.object(sm.virsh, "execute_shell", return_value=_result()) as shell:
-            sm._preserve_snapshot_overlays("vm01")
+        ), patch.object(sm, "_chain_order", return_value=["s1", "s2", "s3"]), \
+                patch.object(sm.virsh, "execute_shell", return_value=_result()) as shell:
+            sm._preserve_snapshot_overlays("vm01", "s1")
 
         assert shell.call_count == 1
         cmd = shell.call_args.args[0]
@@ -225,6 +227,33 @@ class TestSudoSkipCommands_380b776:
             "sudo_skip_commands": ["virsh"],
         })
         assert cmd._should_use_sudo_for_command("/usr/bin/virsh list") is False
+
+
+class TestRmNeverSudo:
+    """`rm` must never be sudo-wrapped: unlinking needs dir-write perms, not
+    root. Hosts whose sudoers lacks a passwordless `rm` rule would otherwise
+    fail snapshot cleanup silently and leak overlay/.preserve files."""
+
+    def test_rm_not_sudo_even_with_use_sudo_true(self):
+        cmd = LibVirtCommandBase(provider_config={"use_sudo": True})
+        assert cmd._should_use_sudo_for_command("rm -f '/ws/x.preserve'") is False
+
+    def test_rm_not_sudo_full_path(self):
+        cmd = LibVirtCommandBase(provider_config={"use_sudo": True})
+        assert cmd._should_use_sudo_for_command("/bin/rm -f '/ws/x'") is False
+
+    def test_force_sudo_can_still_override_rm(self):
+        """An explicit force_sudo_commands entry still wins (escape hatch)."""
+        cmd = LibVirtCommandBase(provider_config={
+            "use_sudo": True,
+            "force_sudo_commands": ["rm"],
+        })
+        assert cmd._should_use_sudo_for_command("rm -f '/ws/x'") is True
+
+    def test_other_commands_still_sudo(self):
+        """The never-sudo rule is scoped to rm; qemu-img still gets sudo."""
+        cmd = LibVirtCommandBase(provider_config={"use_sudo": True})
+        assert cmd._should_use_sudo_for_command("qemu-img info /x") is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Makes `boxman snapshot restore` dramatically faster on clusters with many snapshots, and fixes two cleanup bugs surfaced along the way.

### 1. `perf(snapshot)`: preserve only target-and-newer overlays on restore
`snapshot_restore` wrapped `virsh snapshot-revert` in a preserve→revert→restore dance that `rsync`-copied **every overlay of every snapshot** aside before each revert, then restored the few libvirt actually deleted and `rm`'d the rest. But a revert only ever recreates the **target** snapshot's own overlays, so copying the whole chain is wasted work that scales with snapshot count × overlay size.

Now `_preserve_snapshot_overlays` backs up only the target snapshot's overlays plus any newer ones in the chain (reusing `_chain_order` / `_get_snapshot_overlay_files`), falling back to "preserve all" if the target isn't found in the chain.

**Measured** on a 10-VM / 9-snapshot cluster restoring the latest snapshot:
| | old | new |
|---|---|---|
| overlay files copied aside | 540 (~21 GB) | 60 (~30 MB) |
| cleanup `rm`s | 480 | 0 |
| wall-clock | 51.1 s | 23.3 s |

### 2. `fix(snapshot)`: never `sudo` the cleanup `rm`
Unlinking a file needs write permission on its (boxman-owned) parent directory, not root. On hosts whose sudoers lacks a passwordless `rm` rule, the `sudo rm` cleanup failed silently (`execute_shell(warn=True)`) and leaked `.preserve`/overlay files. `rm` is now in a never-sudo set in `LibVirtCommandBase`; `rsync`/`qemu-img`/`zstd` still use sudo where they genuinely need root.

### 3. `fix(destroy)`: undefine snapshots atomically instead of per-snapshot delete
`DestroyVM.remove()` iterated `virsh snapshot-delete` per snapshot before undefining. For external snapshots with saved memory state on a running or **paused** domain, that pile-ups `cannot acquire state change lock` timeouts that can wedge the domain until libvirtd is restarted (it also used `is_vm_running()`, which misses the "paused" state). `remove()` now delegates to the existing `force_undefine_vm()` — force-kill anything still alive, then a single atomic `undefine --snapshots-metadata --remove-all-storage`.

## Testing
- `make test` — 954 unit tests pass (new tests cover the narrowing, the never-sudo `rm` rule, and the destroy path never issuing per-snapshot `snapshot-delete`).
- **Live-verified** end-to-end on libvirt/KVM: restoring the latest of 9 snapshots on 10 VMs (51s→23s); and destroying a running VM with 2 memory snapshots in 4 s with zero lock-timeouts and clean removal (shared base template left intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Note on PR scope
`origin/main` was behind local `main` by one commit, so this PR also includes the pre-existing `6060918` **fix(provision): auto-recover from broken templates and abort on clone failure** (`manager.py`, `session.py`, `tests/test_manager_core.py`, `tests/test_libvirt_session.py`). It is intentionally included so `origin/main` catches up to local `main`; it is unrelated to the snapshot changes above.
