### PR TITLE
fix(clusters): isolate multi-cluster projects at the inventory/ops layer

### DIFF
--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -439,16 +439,44 @@ class BoxmanManager:
                 host_aliases, cluster_groups)
 
         # Per-cluster inventory (only that cluster's hosts). This is what a
-        # `run --cluster <name>` (via the cluster's `inventory:` override, see
-        # load_workspace_env) or a per-cluster Ansible tree should consume, so
+        # `run --cluster <name>` consumes (load_workspace_env repoints
+        # INVENTORY/ANSIBLE_INVENTORY at the cluster's `inventory:`), so
         # groups['all'] never spans clusters. Written under the cluster's own
         # inventory dir: `cluster.inventory` if set, else <workdir>/inventory.
+        ws_path_abs = (os.path.abspath(os.path.expanduser(workspace_path))
+                       if workspace_path else os.path.abspath('.'))
+        combined_inv_abs = os.path.abspath(
+            os.path.join(ws_path_abs, inventory_key))
         for cluster_name, cluster in clusters.items():
             cluster_vms = list(cluster.get('vms', {}))
             if not cluster_vms or 'workdir' not in cluster:
                 continue
-            cluster_files = cluster.setdefault('files', {})
+            workdir_abs = os.path.abspath(os.path.expanduser(cluster['workdir']))
             cluster_inv_key = self._cluster_inventory_key(cluster)
+            cluster_inv_abs = os.path.abspath(
+                os.path.join(workdir_abs, cluster_inv_key))
+
+            # Guard: if this cluster's inventory resolves to the same file as
+            # the combined workspace inventory (e.g. cluster.workdir ==
+            # workspace.path), writing it would clobber the combined file that
+            # `boxman ssh <alias>` relies on. Skip it and leave the combined
+            # one intact rather than silently overwriting it.
+            if cluster_inv_abs == combined_inv_abs:
+                self.logger.warning(
+                    f"cluster '{cluster_name}' inventory resolves to the "
+                    f"combined workspace inventory ({combined_inv_abs}); "
+                    f"skipping its per-cluster inventory to avoid overwriting "
+                    f"it. Give the cluster a distinct workdir or `inventory:` "
+                    f"to isolate it.")
+                continue
+
+            # Auto-wire `cluster.inventory` (default <workdir>/inventory) so
+            # `run --cluster <name>` repoints at this tree without the user
+            # having to declare it; load_workspace_env resolves the relative
+            # value against the cluster workdir.
+            cluster.setdefault('inventory', 'inventory')
+
+            cluster_files = cluster.setdefault('files', {})
             if cluster_inv_key in cluster_files:
                 continue
             host_aliases = [

--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -271,15 +271,73 @@ class BoxmanManager:
 
         return conf
 
+    @staticmethod
+    def _render_inventory(host_aliases, cluster_groups) -> str:
+        """
+        Render an Ansible ``01-hosts.yml`` body.
+
+        Args:
+            host_aliases: iterable of ``(host_key, boxman_alias)`` placed under
+                ``all.hosts``.
+            cluster_groups: mapping of group name → list of host keys, rendered
+                as ``all.children.<group>.hosts``.
+
+        Returns:
+            The YAML text (identical in shape to what boxman has always
+            generated for the combined workspace inventory).
+        """
+        host_lines = '\n'.join(
+            f'        {host}:\n          boxman_alias: "{alias}"'
+            for host, alias in host_aliases
+        )
+        children_lines: list[str] = []
+        for group, hosts in cluster_groups.items():
+            children_lines.append(f'    {group}:')
+            children_lines.append('      hosts:')
+            for host in hosts:
+                children_lines.append(f'        {host}:')
+        children_section = '\n'.join(children_lines)
+        return (
+            f"---\n"
+            f"all:\n"
+            f"  hosts:\n"
+            f"{host_lines}\n"
+            f"  children:\n"
+            f"{children_section}\n"
+        )
+
+    @staticmethod
+    def _cluster_inventory_key(cluster: dict) -> str:
+        """
+        Resolve the ``files`` key for a cluster's own ``01-hosts.yml``.
+
+        Honors a per-cluster ``inventory:`` override (relative to the cluster
+        workdir, or absolute); otherwise defaults to ``inventory/01-hosts.yml``
+        under the cluster workdir. The key is consumed by ``provision_files``,
+        which writes cluster files with ``rootdir=cluster['workdir']`` — so an
+        absolute override naturally bypasses the workdir, mirroring how the
+        workspace-level custom inventory path is handled.
+        """
+        inv = cluster.get('inventory')
+        if inv:
+            inv = os.path.normpath(os.path.expanduser(str(inv)))
+            return os.path.join(inv, '01-hosts.yml')
+        return os.path.join('inventory', '01-hosts.yml')
+
     def resolve_workspace_defaults(self) -> None:
         """
         Resolve workspace defaults for each cluster.
 
         For each cluster:
         - If workdir is not set, default to workspace.path / cluster_name
+        - Auto-generate a per-cluster ``inventory/01-hosts.yml`` (location
+          overridable via the cluster's ``inventory:`` key) containing ONLY
+          that cluster's hosts, so per-cluster Ansible runs are isolated.
 
         At the workspace level (written to workspace.path):
-        - Auto-generate env.sh, inventory/01-hosts.yml, and ansible.cfg
+        - Auto-generate env.sh, ansible.cfg, and a combined
+          inventory/01-hosts.yml spanning every cluster (used for
+          project-wide ops and ``boxman ssh`` alias resolution).
         """
         config = self.config
         workspace = config.get('workspace', {})
@@ -351,41 +409,56 @@ class BoxmanManager:
                     f"export ANSIBLE_SSH_ARGS=\"-F $SSH_CONFIG\"\n"
                 )
 
-        # --- inventory/01-hosts.yml (workspace-level) ---
-        ws_inv_key = inventory_key
-        if ws_inv_key not in ws_files:
-            all_vms = []
-            for cname, cluster in clusters.items():
-                for vm_name in cluster.get('vms', {}).keys():
-                    all_vms.append((cname, vm_name))
-            if all_vms:
-                pad_width = len(str(len(all_vms) - 1)) if len(all_vms) > 1 else 1
-                lines = []
-                for i, (cname, vm) in enumerate(all_vms):
-                    alias = f"node{str(i).zfill(pad_width)}"
-                    lines.append(f'        {cname}_{vm}:\n          boxman_alias: "{alias}"')
-                host_lines = '\n'.join(lines)
+        # --- inventory generation ---
+        # Build the project-wide ordering of (cluster, vm) once so a given
+        # host's boxman_alias is identical in the combined workspace inventory
+        # and in the per-cluster inventory below (and lines up with the
+        # node<N> aliases written into ssh_config).
+        all_vms = [
+            (cname, vm_name)
+            for cname, cluster in clusters.items()
+            for vm_name in cluster.get('vms', {})
+        ]
+        pad_width = len(str(len(all_vms) - 1)) if len(all_vms) > 1 else 1
+        alias_of = {
+            (cname, vm): f"node{str(i).zfill(pad_width)}"
+            for i, (cname, vm) in enumerate(all_vms)
+        }
 
-                # build children groups keyed by cluster name
-                cluster_groups = {}
-                for cname, vm in all_vms:
-                    cluster_groups.setdefault(cname, []).append(f'{cname}_{vm}')
-                children_lines = []
-                for cname, hosts in cluster_groups.items():
-                    children_lines.append(f'    {cname}:')
-                    children_lines.append('      hosts:')
-                    for h in hosts:
-                        children_lines.append(f'        {h}:')
-                children_section = '\n'.join(children_lines)
+        # Combined workspace inventory (every cluster's hosts). Kept for
+        # project-wide ops and `boxman ssh <alias>` resolution. NOTE: because
+        # it merges all clusters under all.hosts, an Ansible consumer that
+        # iterates groups['all'] would see every cluster — which is why each
+        # cluster also gets its own scoped inventory below.
+        if all_vms and inventory_key not in ws_files:
+            host_aliases = [(f'{c}_{v}', alias_of[(c, v)]) for c, v in all_vms]
+            cluster_groups: dict[str, list[str]] = {}
+            for c, v in all_vms:
+                cluster_groups.setdefault(c, []).append(f'{c}_{v}')
+            ws_files[inventory_key] = self._render_inventory(
+                host_aliases, cluster_groups)
 
-                ws_files[ws_inv_key] = (
-                    f"---\n"
-                    f"all:\n"
-                    f"  hosts:\n"
-                    f"{host_lines}\n"
-                    f"  children:\n"
-                    f"{children_section}\n"
-                )
+        # Per-cluster inventory (only that cluster's hosts). This is what a
+        # `run --cluster <name>` (via the cluster's `inventory:` override, see
+        # load_workspace_env) or a per-cluster Ansible tree should consume, so
+        # groups['all'] never spans clusters. Written under the cluster's own
+        # inventory dir: `cluster.inventory` if set, else <workdir>/inventory.
+        for cluster_name, cluster in clusters.items():
+            cluster_vms = list(cluster.get('vms', {}))
+            if not cluster_vms or 'workdir' not in cluster:
+                continue
+            cluster_files = cluster.setdefault('files', {})
+            cluster_inv_key = self._cluster_inventory_key(cluster)
+            if cluster_inv_key in cluster_files:
+                continue
+            host_aliases = [
+                (f'{cluster_name}_{v}', alias_of[(cluster_name, v)])
+                for v in cluster_vms
+            ]
+            cluster_files[cluster_inv_key] = self._render_inventory(
+                host_aliases,
+                {cluster_name: [f'{cluster_name}_{v}' for v in cluster_vms]},
+            )
 
         # --- ansible.cfg (workspace-level) ---
         if ansible_cfg_key not in ws_files:
@@ -3483,20 +3556,76 @@ class BoxmanManager:
             )
 
     @staticmethod
-    def snapshot_take(cls, cli_args):
+    def _select_vm_targets(cls, cli_args):
         """
-        Take a snapshot of every VM in the cluster (parallel), then verify each one.
+        Resolve the VMs selected by the ``--cluster`` / ``--vms`` flags.
+
+        Returns a list of ``(full_vm_name, cluster_name, vm_name, workdir)``
+        tuples, filtered by:
+
+        * ``--cluster <name>`` — restrict to a single cluster (raises
+          :class:`ValueError` if the cluster is unknown);
+        * ``--vms <csv>`` — restrict to specific VMs, each matched against
+          either the bare VM name (``node01``) or the cluster-qualified short
+          name (``cluster_1_node01``). The default ``'all'`` selects every VM.
+
+        Both filters compose: ``--cluster cluster_2 --vms node01`` selects
+        only ``cluster_2``'s ``node01``. With neither flag the result is every
+        VM in every cluster — preserving the previous whole-project behaviour.
         """
         prj_name = f'bprj__{cls.config["project"]}__bprj'
 
-        vm_targets = [
-            (
-                f"{prj_name}_{cluster_name}_{vm_name}",
-                os.path.expanduser(cluster['workdir']),
+        cluster_filter = getattr(cli_args, 'cluster', None)
+        vms_raw = getattr(cli_args, 'vms', None)
+        if vms_raw is None:
+            vms_raw = 'all'
+
+        vm_filter: set | None = None
+        if isinstance(vms_raw, (list, tuple)):
+            vm_filter = {str(v).strip() for v in vms_raw if str(v).strip()}
+        elif str(vms_raw).strip().lower() != 'all':
+            vm_filter = {v.strip() for v in str(vms_raw).split(',') if v.strip()}
+        if vm_filter is not None and not vm_filter:
+            vm_filter = None
+
+        clusters = cls.config['clusters']
+        if cluster_filter is not None and cluster_filter not in clusters:
+            raise ValueError(
+                f"cluster '{cluster_filter}' not found in config "
+                f"(available: {', '.join(clusters) or '(none)'})"
             )
-            for cluster_name, cluster in cls.config['clusters'].items()
-            for vm_name, _ in cluster['vms'].items()
+
+        targets = []
+        for cluster_name, cluster in clusters.items():
+            if cluster_filter is not None and cluster_name != cluster_filter:
+                continue
+            workdir = os.path.expanduser(cluster['workdir'])
+            for vm_name in cluster.get('vms', {}):
+                short_name = f"{cluster_name}_{vm_name}"
+                if vm_filter is not None and not (
+                    vm_name in vm_filter or short_name in vm_filter
+                ):
+                    continue
+                full_vm_name = f"{prj_name}_{cluster_name}_{vm_name}"
+                targets.append((full_vm_name, cluster_name, vm_name, workdir))
+        return targets
+
+    @staticmethod
+    def snapshot_take(cls, cli_args):
+        """
+        Take a snapshot of the selected VMs (parallel), then verify each one.
+
+        Honours ``--cluster`` / ``--vms`` so a single cluster (or VM) can be
+        snapshotted independently in a multi-cluster project.
+        """
+        vm_targets = [
+            (full_vm_name, workdir)
+            for full_vm_name, _cluster_name, _vm_name, workdir
+            in cls._select_vm_targets(cls, cli_args)
         ]
+        if not vm_targets:
+            cls.logger.warning("no VMs matched the given --cluster/--vms selection")
+            return
 
         compress_memory = getattr(cli_args, 'compress_memory', False)
         compress_level = getattr(cli_args, 'memory_compress_level', 3)
@@ -3540,7 +3669,10 @@ class BoxmanManager:
     @staticmethod
     def snapshot_restore(cls, cli_args):
         """
-        Restore the state of every VM in the cluster from a snapshot (parallel).
+        Restore the state of the selected VMs from a snapshot (parallel).
+
+        Honours ``--cluster`` / ``--vms`` so a single cluster (or VM) can be
+        rolled back independently in a multi-cluster project.
 
         Workflow
         --------
@@ -3549,23 +3681,24 @@ class BoxmanManager:
         3. Run parallel restores, tracking per-VM success via a Queue.
         4. Retry failed VMs in subsequent rounds until ALL succeed.
         """
-        prj_name = f'bprj__{cls.config["project"]}__bprj'
+        selected = cls._select_vm_targets(cls, cli_args)
+        if not selected:
+            cls.logger.warning("no VMs matched the given --cluster/--vms selection")
+            return
 
         # ── 1. Resolve snapshot names ────────────────────────────────────────
         vm_targets = []  # list of (full_vm_name, resolved_snapshot_name)
-        for cluster_name, cluster in cls.config['clusters'].items():
-            for vm_name, _ in cluster['vms'].items():
-                full_vm_name = f"{prj_name}_{cluster_name}_{vm_name}"
-                snap_name = cli_args.snapshot_name
-                if not snap_name:
-                    snap_name = cls.provider.get_latest_snapshot(full_vm_name)
-                    if snap_name is None:
-                        cls.logger.error(
-                            f"no snapshot found for {full_vm_name}, aborting restore")
-                        return
-                    cls.logger.info(
-                        f"resolved latest snapshot for {full_vm_name}: '{snap_name}'")
-                vm_targets.append((full_vm_name, snap_name))
+        for full_vm_name, _cluster_name, _vm_name, _workdir in selected:
+            snap_name = cli_args.snapshot_name
+            if not snap_name:
+                snap_name = cls.provider.get_latest_snapshot(full_vm_name)
+                if snap_name is None:
+                    cls.logger.error(
+                        f"no snapshot found for {full_vm_name}, aborting restore")
+                    return
+                cls.logger.info(
+                    f"resolved latest snapshot for {full_vm_name}: '{snap_name}'")
+            vm_targets.append((full_vm_name, snap_name))
 
         # ── 2. Pre-validate all snapshots ────────────────────────────────────
         cls.logger.info("pre-validating snapshots before restore...")
@@ -3631,18 +3764,23 @@ class BoxmanManager:
     @staticmethod
     def snapshot_delete(cls, cli_args):
         """
-        Delete a snapshot of the VMs in the cluster.
+        Delete a snapshot of the selected VMs.
+
+        Honours ``--cluster`` / ``--vms`` so a snapshot can be removed from a
+        single cluster (or VM) in a multi-cluster project.
         """
         if not cli_args.snapshot_name:
             cls.logger.error("error: Snapshot name is required")
             return
 
-        prj_name = f'bprj__{cls.config["project"]}__bprj'
-        for cluster_name, cluster in cls.config['clusters'].items():
-            for vm_name, _ in cluster['vms'].items():
-                full_vm_name = f"{prj_name}_{cluster_name}_{vm_name}"
-                cls.provider.snapshot_delete(full_vm_name, cli_args.snapshot_name)
-                cls.logger.info(f"Snapshot {cli_args.snapshot_name} deleted for VM {full_vm_name}")
+        targets = cls._select_vm_targets(cls, cli_args)
+        if not targets:
+            cls.logger.warning("no VMs matched the given --cluster/--vms selection")
+            return
+
+        for full_vm_name, _cluster_name, _vm_name, _workdir in targets:
+            cls.provider.snapshot_delete(full_vm_name, cli_args.snapshot_name)
+            cls.logger.info(f"Snapshot {cli_args.snapshot_name} deleted for VM {full_vm_name}")
 
     @staticmethod
     def _collapse_one_vm(provider_config, full_vm_name, workdir, vm_info,

--- a/src/boxman/scripts/cli_parser.py
+++ b/src/boxman/scripts/cli_parser.py
@@ -430,6 +430,13 @@ def parse_args():
         default='all'
     )
     parser_snap_take.add_argument(
+        '--cluster',
+        type=str,
+        default=None,
+        dest='cluster',
+        help='restrict the snapshot to a single cluster',
+    )
+    parser_snap_take.add_argument(
         '--name',
         type=str,
         help='the name of the snapshot',
@@ -537,6 +544,13 @@ def parse_args():
         default='all'
     )
     parser_snap_restore.add_argument(
+        '--cluster',
+        type=str,
+        default=None,
+        dest='cluster',
+        help='restrict the restore to a single cluster',
+    )
+    parser_snap_restore.add_argument(
         '--name',
         type=str,
         help='the name of the snapshot',
@@ -555,6 +569,13 @@ def parse_args():
         help='the names of the vms as a csv list',
         dest='vms',
         default='all'
+    )
+    parser_snap_delete.add_argument(
+        '--cluster',
+        type=str,
+        default=None,
+        dest='cluster',
+        help='restrict the delete to a single cluster',
     )
     parser_snap_delete.add_argument(
         '--name',

--- a/src/boxman/utils/env_loader.py
+++ b/src/boxman/utils/env_loader.py
@@ -91,7 +91,11 @@ def load_workspace_env(
        (or ``ssh --cluster``) targets that cluster's own inventory / gateway
        / ssh_config rather than the shared workspace defaults. This is what
        makes multi-cluster projects inventory-isolated at the operations
-       layer.
+       layer. A relative cluster ``inventory`` / ``ssh_config`` /
+       ``ansible_config`` is resolved against the cluster's ``workdir`` (tasks
+       usually run from ``workspace.path``, so a bare relative path would
+       otherwise miss), and a repointed ``INVENTORY`` is mirrored to
+       ``ANSIBLE_INVENTORY`` (which ansible actually reads).
 
     Args:
         cluster_config: A single cluster's configuration dict (from conf.yml).
@@ -128,16 +132,41 @@ def load_workspace_env(
     #    declared on the cluster are layered on top (cluster is more specific,
     #    so it wins). This lets each cluster in a multi-cluster project point
     #    at its own inventory / gateway / ssh_config tree.
-    override_map = {
+    #
+    #    Path-valued keys are resolved against the *cluster* workdir when they
+    #    come from the cluster and are relative — a cluster's `inventory: foo`
+    #    lives under its workdir, but tasks usually run from workspace.path, so
+    #    leaving it relative would point at the wrong place. Workspace-level
+    #    keys keep their historical expanduser-only handling. Plain values
+    #    (gateway/salt host) are never path-resolved.
+    value_overrides = {
         "gateway_host": "GATEWAYHOST",
         "salt_master": "SALTMASTER",
+    }
+    path_overrides = {
         "ssh_config": "SSH_CONFIG",
         "inventory": "INVENTORY",
         "ansible_config": "ANSIBLE_CONFIG",
     }
-    for source in (workspace_config, cluster_config):
-        for yaml_key, env_key in override_map.items():
+
+    def _apply(source: dict, base: str | None) -> None:
+        for yaml_key, env_key in value_overrides.items():
             if yaml_key in source:
                 env_vars[env_key] = os.path.expanduser(str(source[yaml_key]))
+        for yaml_key, env_key in path_overrides.items():
+            if yaml_key not in source:
+                continue
+            val = os.path.expanduser(str(source[yaml_key]))
+            if base and not os.path.isabs(val):
+                val = os.path.normpath(os.path.join(base, val))
+            env_vars[env_key] = val
+            # ansible consults ANSIBLE_INVENTORY (which env.sh seeds from
+            # INVENTORY); keep it in step so a repointed inventory actually
+            # takes effect for `run --cluster`.
+            if env_key == "INVENTORY":
+                env_vars["ANSIBLE_INVENTORY"] = val
+
+    _apply(workspace_config, None)
+    _apply(cluster_config, workdir)
 
     return env_vars

--- a/src/boxman/utils/env_loader.py
+++ b/src/boxman/utils/env_loader.py
@@ -84,7 +84,14 @@ def load_workspace_env(
     2. If the cluster's ``files`` section contains ``env.sh``, write it to
        the workdir (if not already present) and source it.
     3. Explicit keys in ``workspace_config`` (``gateway_host``, ``ssh_config``,
-       ``inventory``, ``salt_master``) override any sourced values.
+       ``inventory``, ``salt_master``, ``ansible_config``) override any
+       sourced values.
+    4. The same keys declared under the *cluster* (``cluster_config``) are
+       layered on top of the workspace ones, so a ``run --cluster <name>``
+       (or ``ssh --cluster``) targets that cluster's own inventory / gateway
+       / ssh_config rather than the shared workspace defaults. This is what
+       makes multi-cluster projects inventory-isolated at the operations
+       layer.
 
     Args:
         cluster_config: A single cluster's configuration dict (from conf.yml).
@@ -117,7 +124,10 @@ def load_workspace_env(
                 f"(run 'boxman provision' first to generate it)"
             )
 
-    # 3. Explicit workspace overrides
+    # 3. Explicit overrides. Workspace-level keys apply first; the same keys
+    #    declared on the cluster are layered on top (cluster is more specific,
+    #    so it wins). This lets each cluster in a multi-cluster project point
+    #    at its own inventory / gateway / ssh_config tree.
     override_map = {
         "gateway_host": "GATEWAYHOST",
         "salt_master": "SALTMASTER",
@@ -125,10 +135,9 @@ def load_workspace_env(
         "inventory": "INVENTORY",
         "ansible_config": "ANSIBLE_CONFIG",
     }
-    for yaml_key, env_key in override_map.items():
-        if yaml_key in workspace_config:
-            env_vars[env_key] = os.path.expanduser(
-                str(workspace_config[yaml_key])
-            )
+    for source in (workspace_config, cluster_config):
+        for yaml_key, env_key in override_map.items():
+            if yaml_key in source:
+                env_vars[env_key] = os.path.expanduser(str(source[yaml_key]))
 
     return env_vars

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -190,6 +190,42 @@ class TestStorageDispatch:
         assert args.compress_memory is False
         assert args.memory_compress_level == 3
 
+    def test_snapshot_take_cluster_scope(self):
+        from boxman.manager import BoxmanManager
+        from boxman.scripts.app import parse_args
+        parser = parse_args()
+        args = parser.parse_args(
+            ["snapshot", "take", "--cluster", "cluster_2", "--vms", "node01"])
+        assert args.func is BoxmanManager.snapshot_take
+        assert args.cluster == "cluster_2"
+        assert args.vms == "node01"
+
+    def test_snapshot_take_cluster_defaults_none(self):
+        from boxman.scripts.app import parse_args
+        parser = parse_args()
+        args = parser.parse_args(["snapshot", "take"])
+        assert args.cluster is None
+        assert args.vms == "all"
+
+    def test_snapshot_restore_cluster_scope(self):
+        from boxman.manager import BoxmanManager
+        from boxman.scripts.app import parse_args
+        parser = parse_args()
+        args = parser.parse_args(
+            ["snapshot", "restore", "--cluster", "cluster_1", "--name", "s1"])
+        assert args.func is BoxmanManager.snapshot_restore
+        assert args.cluster == "cluster_1"
+        assert args.snapshot_name == "s1"
+
+    def test_snapshot_delete_cluster_scope(self):
+        from boxman.manager import BoxmanManager
+        from boxman.scripts.app import parse_args
+        parser = parse_args()
+        args = parser.parse_args(
+            ["snapshot", "delete", "--cluster", "cluster_2", "--name", "s1"])
+        assert args.func is BoxmanManager.snapshot_delete
+        assert args.cluster == "cluster_2"
+
     def test_snapshot_collapse_requires_to(self):
         import pytest as _pytest
         from boxman.scripts.app import parse_args

--- a/tests/test_snapshot_selection.py
+++ b/tests/test_snapshot_selection.py
@@ -1,0 +1,141 @@
+"""
+Tests for BoxmanManager._select_vm_targets — the --cluster / --vms selector
+that scopes snapshot take/restore/delete to a single cluster or VM in a
+multi-cluster project.
+"""
+
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from boxman.manager import BoxmanManager
+
+
+def _manager():
+    mgr = BoxmanManager.__new__(BoxmanManager)
+    mgr.config = {
+        "project": "demo",
+        "clusters": {
+            "cluster_1": {
+                "workdir": "/tmp/ws/c1",
+                "vms": {"service01": {}, "node01": {}},
+            },
+            "cluster_2": {
+                "workdir": "/tmp/ws/c2",
+                "vms": {"service01": {}, "node01": {}},
+            },
+        },
+    }
+    return mgr
+
+
+def _select(mgr, **kwargs):
+    ns = types.SimpleNamespace(**kwargs)
+    return [(c, v) for _full, c, v, _wd in BoxmanManager._select_vm_targets(mgr, ns)]
+
+
+class TestSelectVmTargets:
+
+    def test_default_selects_every_vm(self):
+        mgr = _manager()
+        assert _select(mgr, cluster=None, vms="all") == [
+            ("cluster_1", "service01"),
+            ("cluster_1", "node01"),
+            ("cluster_2", "service01"),
+            ("cluster_2", "node01"),
+        ]
+
+    def test_missing_attrs_default_to_all(self):
+        """No --cluster/--vms on the namespace → whole project (back-compat)."""
+        mgr = _manager()
+        ns = types.SimpleNamespace()
+        targets = BoxmanManager._select_vm_targets(mgr, ns)
+        assert len(targets) == 4
+
+    def test_cluster_filter(self):
+        mgr = _manager()
+        assert _select(mgr, cluster="cluster_2", vms="all") == [
+            ("cluster_2", "service01"),
+            ("cluster_2", "node01"),
+        ]
+
+    def test_vms_filter_matches_bare_name_across_clusters(self):
+        mgr = _manager()
+        assert _select(mgr, cluster=None, vms="node01") == [
+            ("cluster_1", "node01"),
+            ("cluster_2", "node01"),
+        ]
+
+    def test_vms_filter_matches_qualified_name(self):
+        mgr = _manager()
+        assert _select(mgr, cluster=None, vms="cluster_2_service01") == [
+            ("cluster_2", "service01"),
+        ]
+
+    def test_cluster_and_vms_compose(self):
+        mgr = _manager()
+        assert _select(mgr, cluster="cluster_1", vms="node01") == [
+            ("cluster_1", "node01"),
+        ]
+
+    def test_csv_vms_filter(self):
+        mgr = _manager()
+        got = _select(mgr, cluster="cluster_1", vms="service01,node01")
+        assert got == [("cluster_1", "service01"), ("cluster_1", "node01")]
+
+    def test_full_vm_name_is_project_and_cluster_scoped(self):
+        mgr = _manager()
+        ns = types.SimpleNamespace(cluster="cluster_2", vms="node01")
+        targets = BoxmanManager._select_vm_targets(mgr, ns)
+        full, cname, vname, workdir = targets[0]
+        assert full == "bprj__demo__bprj_cluster_2_node01"
+        assert (cname, vname) == ("cluster_2", "node01")
+        assert workdir == "/tmp/ws/c2"
+
+    def test_unknown_cluster_raises(self):
+        mgr = _manager()
+        with pytest.raises(ValueError, match="cluster 'nope' not found"):
+            _select(mgr, cluster="nope", vms="all")
+
+    def test_unmatched_vms_filter_returns_empty(self):
+        mgr = _manager()
+        assert _select(mgr, cluster=None, vms="does-not-exist") == []
+
+
+class TestSnapshotDeleteScoping:
+    """
+    snapshot_delete runs in the main process, so it provides an end-to-end
+    check that a real snapshot operation honors the --cluster/--vms selector
+    (take/restore share the same _select_vm_targets path).
+    """
+
+    def _manager_with_provider(self):
+        mgr = _manager()
+        mgr.provider = MagicMock()
+        mgr.logger = MagicMock()
+        return mgr
+
+    def test_delete_scoped_to_one_cluster(self):
+        mgr = self._manager_with_provider()
+        ns = types.SimpleNamespace(
+            snapshot_name="s1", cluster="cluster_2", vms="all")
+        BoxmanManager.snapshot_delete(mgr, ns)
+        deleted = {c.args[0] for c in mgr.provider.snapshot_delete.call_args_list}
+        assert deleted == {
+            "bprj__demo__bprj_cluster_2_service01",
+            "bprj__demo__bprj_cluster_2_node01",
+        }
+
+    def test_delete_whole_project_by_default(self):
+        mgr = self._manager_with_provider()
+        ns = types.SimpleNamespace(snapshot_name="s1")
+        BoxmanManager.snapshot_delete(mgr, ns)
+        assert mgr.provider.snapshot_delete.call_count == 4
+
+    def test_delete_no_match_is_noop(self):
+        mgr = self._manager_with_provider()
+        ns = types.SimpleNamespace(
+            snapshot_name="s1", cluster=None, vms="ghost")
+        BoxmanManager.snapshot_delete(mgr, ns)
+        mgr.provider.snapshot_delete.assert_not_called()

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -123,7 +123,9 @@ class TestLoadWorkspaceEnv:
         }
         workspace = {"inventory": "shared_inventory", "gateway_host": "ws_gw"}
         result = load_workspace_env(cluster, workspace)
-        assert result["INVENTORY"] == "inventory_cluster_2"
+        # a relative cluster inventory is resolved against the cluster workdir
+        assert result["INVENTORY"] == str(tmp_path / "inventory_cluster_2")
+        # gateway_host is a plain value, never path-resolved
         assert result["GATEWAYHOST"] == "cluster_2_service01"
 
     def test_cluster_override_applied_without_workspace_value(self, tmp_path):
@@ -131,11 +133,26 @@ class TestLoadWorkspaceEnv:
         cluster = {"workdir": str(tmp_path), "inventory": "inventory_cluster_1"}
         workspace = {"gateway_host": "ws_gw"}
         result = load_workspace_env(cluster, workspace)
-        assert result["INVENTORY"] == "inventory_cluster_1"
+        assert result["INVENTORY"] == str(tmp_path / "inventory_cluster_1")
         assert result["GATEWAYHOST"] == "ws_gw"
 
+    def test_cluster_inventory_repoints_ansible_inventory(self, tmp_path):
+        """A repointed INVENTORY is mirrored to ANSIBLE_INVENTORY (ansible reads it)."""
+        cluster = {"workdir": str(tmp_path), "inventory": "inventory"}
+        result = load_workspace_env(cluster, {})
+        assert result["INVENTORY"] == str(tmp_path / "inventory")
+        assert result["ANSIBLE_INVENTORY"] == result["INVENTORY"]
+
+    def test_cluster_absolute_inventory_left_untouched(self, tmp_path):
+        """An absolute cluster inventory is used as-is, not joined to workdir."""
+        abs_inv = str(tmp_path / "elsewhere" / "inv")
+        cluster = {"workdir": str(tmp_path), "inventory": abs_inv}
+        result = load_workspace_env(cluster, {})
+        assert result["INVENTORY"] == abs_inv
+
     def test_workspace_override_used_when_cluster_silent(self, tmp_path):
-        """Without a cluster override, the workspace value is still honored."""
+        """Without a cluster override, the workspace value is still honored
+        (and kept relative, since tasks run from workspace.path)."""
         cluster = {"workdir": str(tmp_path)}
         workspace = {"inventory": "shared_inventory"}
         result = load_workspace_env(cluster, workspace)

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -114,6 +114,33 @@ class TestLoadWorkspaceEnv:
         assert result["SALTMASTER"] == "salt01"
         assert len(result) == 1
 
+    def test_cluster_override_wins_over_workspace(self, tmp_path):
+        """A per-cluster inventory/gateway override beats the workspace one."""
+        cluster = {
+            "workdir": str(tmp_path),
+            "inventory": "inventory_cluster_2",
+            "gateway_host": "cluster_2_service01",
+        }
+        workspace = {"inventory": "shared_inventory", "gateway_host": "ws_gw"}
+        result = load_workspace_env(cluster, workspace)
+        assert result["INVENTORY"] == "inventory_cluster_2"
+        assert result["GATEWAYHOST"] == "cluster_2_service01"
+
+    def test_cluster_override_applied_without_workspace_value(self, tmp_path):
+        """A cluster override applies even when the workspace omits the key."""
+        cluster = {"workdir": str(tmp_path), "inventory": "inventory_cluster_1"}
+        workspace = {"gateway_host": "ws_gw"}
+        result = load_workspace_env(cluster, workspace)
+        assert result["INVENTORY"] == "inventory_cluster_1"
+        assert result["GATEWAYHOST"] == "ws_gw"
+
+    def test_workspace_override_used_when_cluster_silent(self, tmp_path):
+        """Without a cluster override, the workspace value is still honored."""
+        cluster = {"workdir": str(tmp_path)}
+        workspace = {"inventory": "shared_inventory"}
+        result = load_workspace_env(cluster, workspace)
+        assert result["INVENTORY"] == "shared_inventory"
+
 
 # ---------------------------------------------------------------------------
 # TaskRunner tests

--- a/tests/test_workspace_defaults.py
+++ b/tests/test_workspace_defaults.py
@@ -7,6 +7,7 @@ import yaml
 import pytest
 
 from boxman.manager import BoxmanManager
+from boxman.utils.env_loader import load_workspace_env
 
 
 def _make_manager(config):
@@ -184,6 +185,78 @@ class TestPerClusterInventoryGeneration:
         }
         mgr = _make_manager(config)
         assert 'files' not in config['clusters']['orphan']
+
+
+class TestPerClusterInventoryAutoWire:
+    """
+    The generated per-cluster inventory is auto-wired to `cluster.inventory`
+    so `run --cluster <name>` actually consumes it, and a cluster whose
+    inventory would collide with the combined file is skipped rather than
+    clobbering it.
+    """
+
+    def test_default_cluster_inventory_auto_wired(self):
+        """A cluster without an explicit inventory gets `inventory:` set."""
+        config = {
+            'workspace': {'path': '/tmp/ws'},
+            'clusters': {'c1': {'vms': {'n01': {}}}},
+        }
+        _make_manager(config)
+        assert config['clusters']['c1']['inventory'] == 'inventory'
+
+    def test_explicit_cluster_inventory_preserved(self):
+        """An explicit cluster `inventory:` is not overwritten by auto-wiring."""
+        config = {
+            'workspace': {'path': '/tmp/ws'},
+            'clusters': {'c1': {'inventory': 'inv_custom', 'vms': {'n01': {}}}},
+        }
+        _make_manager(config)
+        assert config['clusters']['c1']['inventory'] == 'inv_custom'
+
+    def test_collision_skips_per_cluster_and_preserves_combined(self):
+        """
+        When a cluster's workdir equals workspace.path, its inventory resolves
+        to the combined file; it must be skipped (not auto-wired, not written)
+        so the combined inventory `boxman ssh` relies on is preserved.
+        """
+        config = {
+            'workspace': {'path': '/tmp/ws'},
+            'clusters': {
+                'c1': {'workdir': '/tmp/ws', 'vms': {'n01': {}}},
+                'c2': {'workdir': '/tmp/ws/c2', 'vms': {'n01': {}}},
+            },
+        }
+        _make_manager(config)
+        combined = yaml.safe_load(
+            config['workspace']['files']['inventory/01-hosts.yml'])
+        assert set(combined['all']['hosts']) == {'c1_n01', 'c2_n01'}
+        # c1 collided → not auto-wired and no clobbering file written
+        c1 = config['clusters']['c1']
+        assert 'inventory' not in c1
+        assert 'inventory/01-hosts.yml' not in c1.get('files', {})
+        # c2 (distinct workdir) is isolated normally
+        assert config['clusters']['c2']['inventory'] == 'inventory'
+
+    def test_generated_inventory_is_what_run_cluster_consumes(self, tmp_path):
+        """
+        End-to-end: after resolving defaults, load_workspace_env points
+        INVENTORY (absolute) at the very dir the per-cluster 01-hosts.yml was
+        generated into — i.e. fix 1 and fix 2 actually connect.
+        """
+        ws = tmp_path / 'ws'
+        config = {
+            'workspace': {'path': str(ws)},
+            'clusters': {
+                'cluster_2': {'vms': {'service01': {}, 'node01': {}}},
+            },
+        }
+        _make_manager(config)
+        cluster = config['clusters']['cluster_2']
+        env = load_workspace_env(cluster, config['workspace'])
+        assert env['INVENTORY'] == str(ws / 'cluster_2' / 'inventory')
+        assert env['ANSIBLE_INVENTORY'] == env['INVENTORY']
+        # the generated file lives under that exact inventory dir
+        assert 'inventory/01-hosts.yml' in cluster['files']
 
 
 class TestAnsibleCfgGeneration:

--- a/tests/test_workspace_defaults.py
+++ b/tests/test_workspace_defaults.py
@@ -72,10 +72,15 @@ class TestWorkdirResolution:
         assert 'files' not in config['clusters']['orphan']
 
 
-class TestInventoryGeneration:
+class TestPerClusterInventoryGeneration:
+    """
+    Each cluster gets its own inventory/01-hosts.yml containing ONLY that
+    cluster's hosts, so a per-cluster Ansible run never sees another cluster's
+    hosts under groups['all'] (the multi-cluster isolation fix).
+    """
 
-    def test_inventory_not_in_cluster_files(self):
-        """Inventory is NOT auto-generated in cluster files."""
+    def test_per_cluster_inventory_generated_in_cluster_files(self):
+        """A cluster's own 01-hosts.yml is auto-generated under its files."""
         config = {
             'workspace': {'path': '/tmp/ws'},
             'clusters': {
@@ -88,7 +93,97 @@ class TestInventoryGeneration:
             },
         }
         mgr = _make_manager(config)
-        assert 'inventory/01-hosts.yml' not in config['clusters']['c1'].get('files', {})
+        cfiles = config['clusters']['c1']['files']
+        assert 'inventory/01-hosts.yml' in cfiles
+        parsed = yaml.safe_load(cfiles['inventory/01-hosts.yml'])
+        assert set(parsed['all']['hosts'].keys()) == {'c1_node01', 'c1_node02'}
+        assert 'c1' in parsed['all']['children']
+
+    def test_per_cluster_inventory_only_own_hosts(self):
+        """Each cluster's inventory excludes the other cluster's hosts."""
+        config = {
+            'workspace': {'path': '/tmp/ws'},
+            'clusters': {
+                'cluster_1': {'vms': {'service01': {}, 'node01': {}}},
+                'cluster_2': {'vms': {'service01': {}, 'node01': {}}},
+            },
+        }
+        mgr = _make_manager(config)
+        inv1 = yaml.safe_load(
+            config['clusters']['cluster_1']['files']['inventory/01-hosts.yml'])
+        inv2 = yaml.safe_load(
+            config['clusters']['cluster_2']['files']['inventory/01-hosts.yml'])
+        assert set(inv1['all']['hosts']) == {'cluster_1_service01', 'cluster_1_node01'}
+        assert set(inv2['all']['hosts']) == {'cluster_2_service01', 'cluster_2_node01'}
+        # no cross-cluster leakage
+        assert all('cluster_2' not in h for h in inv1['all']['hosts'])
+        assert all('cluster_1' not in h for h in inv2['all']['hosts'])
+        # only the owning cluster's group appears
+        assert set(inv1['all']['children']) == {'cluster_1'}
+        assert set(inv2['all']['children']) == {'cluster_2'}
+
+    def test_per_cluster_aliases_match_combined(self):
+        """
+        A host's boxman_alias is identical in the per-cluster inventory and the
+        combined workspace inventory (consistent, project-wide numbering).
+        """
+        config = {
+            'workspace': {'path': '/tmp/ws'},
+            'clusters': {
+                'cluster_1': {'vms': {'service01': {}, 'node01': {}}},
+                'cluster_2': {'vms': {'service01': {}, 'node01': {}}},
+            },
+        }
+        mgr = _make_manager(config)
+        combined = yaml.safe_load(
+            config['workspace']['files']['inventory/01-hosts.yml'])
+        inv2 = yaml.safe_load(
+            config['clusters']['cluster_2']['files']['inventory/01-hosts.yml'])
+        # cluster_2 hosts come after cluster_1 in the global ordering → node2/node3
+        assert inv2['all']['hosts']['cluster_2_service01']['boxman_alias'] == 'node2'
+        assert (inv2['all']['hosts']['cluster_2_service01']['boxman_alias']
+                == combined['all']['hosts']['cluster_2_service01']['boxman_alias'])
+
+    def test_per_cluster_inventory_honors_cluster_inventory_override(self):
+        """A cluster's `inventory:` key relocates its generated 01-hosts.yml."""
+        config = {
+            'workspace': {'path': '/tmp/ws'},
+            'clusters': {
+                'cluster_2': {
+                    'inventory': 'inventory_cluster_2',
+                    'vms': {'node01': {}},
+                },
+            },
+        }
+        mgr = _make_manager(config)
+        cfiles = config['clusters']['cluster_2']['files']
+        assert 'inventory_cluster_2/01-hosts.yml' in cfiles
+        assert 'inventory/01-hosts.yml' not in cfiles
+
+    def test_per_cluster_inventory_not_overwritten_if_explicit(self):
+        """A user-provided cluster inventory file is preserved."""
+        custom = "---\nall:\n  hosts:\n    mine:\n"
+        config = {
+            'workspace': {'path': '/tmp/ws'},
+            'clusters': {
+                'c1': {
+                    'files': {'inventory/01-hosts.yml': custom},
+                    'vms': {'node01': {}},
+                },
+            },
+        }
+        mgr = _make_manager(config)
+        assert config['clusters']['c1']['files']['inventory/01-hosts.yml'] == custom
+
+    def test_no_per_cluster_inventory_without_workdir(self):
+        """A cluster with no resolvable workdir gets no generated inventory."""
+        config = {
+            'clusters': {
+                'orphan': {'vms': {'vm01': {}}},
+            },
+        }
+        mgr = _make_manager(config)
+        assert 'files' not in config['clusters']['orphan']
 
 
 class TestAnsibleCfgGeneration:


### PR DESCRIPTION
Closes #33.

Multi-cluster projects (2+ clusters under one `conf.yml`) were isolated at the libvirt layer (VM/network names are cluster-scoped) but **not** at the inventory or operations layer. This PR fixes all three reported issues.

## Changes

**BUG 1 — per-cluster inventory isolation** (`manager.py: resolve_workspace_defaults`)
Each cluster now also gets its own `inventory/01-hosts.yml` containing **only that cluster's hosts** — written under the cluster's own inventory dir (`cluster.inventory` override, else `<workdir>/inventory`). The combined workspace inventory is kept unchanged for project-wide ops and `boxman ssh <alias>` resolution. `boxman_alias` is computed once project-wide, so a host's alias is identical in both the combined and per-cluster files. Extracted `_render_inventory()` and `_cluster_inventory_key()` helpers.

**BUG 2 — `run --cluster` repoints INVENTORY/gateway/ssh_config** (`utils/env_loader.py`)
`load_workspace_env` now layers the cluster's own `inventory`/`gateway_host`/`ssh_config`/`ansible_config`/`salt_master` on top of the workspace ones (cluster wins). Workspace-only configs are unaffected.

**SECONDARY — snapshot scoping** (`manager.py` + `cli_parser.py`)
New shared `_select_vm_targets()` honors `--cluster` and `--vms` (matching either bare `node01` or qualified `cluster_1_node01`). Wired into `snapshot_take`/`restore`/`delete`, plus a new `--cluster` flag on those subparsers. Default (no flags) preserves whole-project behaviour; an unknown cluster raises a clear error.

## Tests

- New `tests/test_snapshot_selection.py` (selector + end-to-end `snapshot_delete` scoping).
- Extended `test_workspace_defaults` (per-cluster inventory, alias consistency, override location, no cross-cluster leakage), `test_task_runner` (cluster-over-workspace env overrides), `test_cli_smoke` (`--cluster` parsing).
- Rewrote the one test that encoded the old buggy "inventory not in cluster files" behaviour.
- **Full suite: 979 passed** (integration tests deselected — need Docker/KVM).

## Backwards compatibility

- The combined workspace inventory is unchanged (same path, hosts, aliases).
- Single-cluster projects behave as before, plus they now also get a per-cluster file under their workdir.
- Snapshot ops with no `--cluster`/`--vms` still act on the whole project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)