### PR TITLE
fix(images): push OCI images by basename to avoid oras absolute-path rejection

### DIFF
--- a/src/boxman/providers/libvirt/oci_push.py
+++ b/src/boxman/providers/libvirt/oci_push.py
@@ -48,7 +48,7 @@ def _oras_push(
         RuntimeError: If file validation fails or oras push command fails.
         FileNotFoundError: Wrapped as RuntimeError when oras is not on PATH.
     """
-    qcow2_file = Path(qcow2_path)
+    qcow2_file = Path(os.path.expanduser(qcow2_path))
     if not qcow2_file.is_file():
         raise RuntimeError(f"qcow2 file not found: {qcow2_path}")
 
@@ -63,23 +63,27 @@ def _oras_push(
     # Pairing a symlink-resolved directory with the symlink's own basename would
     # point oras at a non-existent file, and "same directory" should mean the
     # directory the files were placed in, not their symlink targets.
-    qcow2_abs = Path(os.path.abspath(qcow2_path))
-    work_dir = str(qcow2_abs.parent)
+    qcow2_abs = Path(os.path.abspath(qcow2_file))
+    work_dir = qcow2_abs.parent
     files_to_push = [qcow2_abs.name]
 
     if metadata_path is not None:
-        metadata_arg = Path(metadata_path)
-        # A bare relative metadata path is interpreted as co-located with the
-        # qcow2 (honouring the co-location contract below), not resolved against
-        # the process CWD — otherwise `--metadata vmimage.json` would only work
-        # when invoked from the qcow2's own directory.
+        metadata_arg = Path(os.path.expanduser(metadata_path))
+        # A relative metadata path is interpreted relative to the qcow2's
+        # directory (honouring the co-location contract below), not the process
+        # CWD — otherwise `--metadata vmimage.json` would only work when invoked
+        # from the qcow2's own directory. The full relative path is kept (not
+        # just its basename), so one that escapes that directory (e.g.
+        # `sub/vmimage.json`) fails the same-directory check with a clear error
+        # instead of being silently flattened onto a same-named file next to the
+        # qcow2.
         if metadata_arg.is_absolute():
-            metadata_abs = Path(os.path.abspath(metadata_path))
+            metadata_abs = Path(os.path.abspath(metadata_arg))
         else:
-            metadata_abs = qcow2_abs.parent / metadata_arg.name
+            metadata_abs = Path(os.path.normpath(work_dir / metadata_arg))
         if not metadata_abs.is_file():
             raise RuntimeError(f"metadata file not found: {metadata_path}")
-        if str(metadata_abs.parent) != work_dir:
+        if metadata_abs.parent != work_dir:
             raise RuntimeError(
                 "qcow2 and metadata must be in the same directory to push "
                 f"(qcow2 dir: {work_dir}, metadata: {metadata_abs})")
@@ -90,7 +94,7 @@ def _oras_push(
     try:
         result = subprocess.run(
             cmd,
-            cwd=work_dir,
+            cwd=str(work_dir),
             check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/src/boxman/providers/libvirt/oci_push.py
+++ b/src/boxman/providers/libvirt/oci_push.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 from typing import Optional
@@ -56,19 +57,33 @@ def _oras_push(
     # path traversal on pull. Push from the file's directory using basenames so
     # the titles are clean relative names (e.g. 'disk.qcow2') that the pull side
     # recreates safely.
-    work_dir = str(qcow2_file.resolve().parent)
-    files_to_push = [qcow2_file.name]
+    #
+    # Use absolute-but-unresolved paths (os.path.abspath does not follow
+    # symlinks): cwd + basename then name *exactly* the file the user passed.
+    # Pairing a symlink-resolved directory with the symlink's own basename would
+    # point oras at a non-existent file, and "same directory" should mean the
+    # directory the files were placed in, not their symlink targets.
+    qcow2_abs = Path(os.path.abspath(qcow2_path))
+    work_dir = str(qcow2_abs.parent)
+    files_to_push = [qcow2_abs.name]
 
     if metadata_path is not None:
-        metadata_file = Path(metadata_path)
-        if not metadata_file.is_file():
+        metadata_arg = Path(metadata_path)
+        # A bare relative metadata path is interpreted as co-located with the
+        # qcow2 (honouring the co-location contract below), not resolved against
+        # the process CWD — otherwise `--metadata vmimage.json` would only work
+        # when invoked from the qcow2's own directory.
+        if metadata_arg.is_absolute():
+            metadata_abs = Path(os.path.abspath(metadata_path))
+        else:
+            metadata_abs = qcow2_abs.parent / metadata_arg.name
+        if not metadata_abs.is_file():
             raise RuntimeError(f"metadata file not found: {metadata_path}")
-        if str(metadata_file.resolve().parent) != work_dir:
+        if str(metadata_abs.parent) != work_dir:
             raise RuntimeError(
                 "qcow2 and metadata must be in the same directory to push "
-                f"(qcow2 dir: {work_dir}, metadata dir: "
-                f"{metadata_file.resolve().parent})")
-        files_to_push.append(metadata_file.name)
+                f"(qcow2 dir: {work_dir}, metadata: {metadata_abs})")
+        files_to_push.append(metadata_abs.name)
 
     cmd = ["oras", "push", image_ref] + files_to_push
 

--- a/src/boxman/providers/libvirt/oci_push.py
+++ b/src/boxman/providers/libvirt/oci_push.py
@@ -51,19 +51,31 @@ def _oras_push(
     if not qcow2_file.is_file():
         raise RuntimeError(f"qcow2 file not found: {qcow2_path}")
 
-    files_to_push = [str(qcow2_file)]
+    # oras rejects absolute file paths: the path becomes the artifact's layer
+    # title (org.opencontainers.image.title) and an absolute title would enable
+    # path traversal on pull. Push from the file's directory using basenames so
+    # the titles are clean relative names (e.g. 'disk.qcow2') that the pull side
+    # recreates safely.
+    work_dir = str(qcow2_file.resolve().parent)
+    files_to_push = [qcow2_file.name]
 
     if metadata_path is not None:
         metadata_file = Path(metadata_path)
         if not metadata_file.is_file():
             raise RuntimeError(f"metadata file not found: {metadata_path}")
-        files_to_push.append(str(metadata_file))
+        if str(metadata_file.resolve().parent) != work_dir:
+            raise RuntimeError(
+                "qcow2 and metadata must be in the same directory to push "
+                f"(qcow2 dir: {work_dir}, metadata dir: "
+                f"{metadata_file.resolve().parent})")
+        files_to_push.append(metadata_file.name)
 
     cmd = ["oras", "push", image_ref] + files_to_push
 
     try:
         result = subprocess.run(
             cmd,
+            cwd=work_dir,
             check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/tests/test_libvirt_oci_push.py
+++ b/tests/test_libvirt_oci_push.py
@@ -166,6 +166,46 @@ class TestPushOciImage:
         assert fake.last_cmd[3] == "disk.qcow2"
         assert (Path(cwd) / fake.last_cmd[3]).is_file()
 
+    def test_relative_metadata_with_subdir_rejected(self, tmp_path: Path, monkeypatch):
+        """A relative --metadata with directory components keeps its full path
+        and is rejected by the co-location check — it is NOT flattened onto a
+        same-named decoy sitting next to the qcow2."""
+        qcow2 = tmp_path / "disk.qcow2"
+        qcow2.write_bytes(b"qcow2 data")
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "vmimage.json").write_text("{}")
+        # a decoy with the same basename right next to the qcow2
+        (tmp_path / "vmimage.json").write_text('{"decoy": true}')
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(RuntimeError, match="same directory"):
+            push_oci_image(
+                image_ref="registry.com/repo:tag",
+                qcow2_path=str(qcow2),
+                metadata_path="sub/vmimage.json",
+            )
+
+    def test_tilde_metadata_expanded(self, tmp_path: Path, monkeypatch):
+        """A `~`-prefixed metadata path is expanded before the absoluteness
+        check (so it is not treated as a literal `~` directory)."""
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        qcow2 = home / "disk.qcow2"
+        qcow2.write_bytes(b"qcow2 data")
+        (home / "vmimage.json").write_text("{}")
+        fake = _FakeRun(returncode=0)
+        with patch(
+            "boxman.providers.libvirt.oci_push.subprocess.run", side_effect=fake
+        ):
+            push_oci_image(
+                image_ref="registry.com/repo:tag",
+                qcow2_path=str(qcow2),
+                metadata_path="~/vmimage.json",
+            )
+        assert "vmimage.json" in fake.last_cmd
+        assert fake.last_kwargs.get("cwd") == str(home)
+
     def test_missing_qcow2_raises(self):
         with pytest.raises(RuntimeError, match="qcow2 file not found"):
             push_oci_image(

--- a/tests/test_libvirt_oci_push.py
+++ b/tests/test_libvirt_oci_push.py
@@ -94,6 +94,78 @@ class TestPushOciImage:
                 metadata_path=str(metadata),
             )
 
+    def test_relative_metadata_resolved_against_qcow2_dir(self, tmp_path: Path, monkeypatch):
+        """A bare relative --metadata is co-located with the qcow2, not the CWD.
+
+        Invoking from an unrelated directory must still find vmimage.json sitting
+        next to the qcow2 (the co-location contract), not raise 'not found'.
+        """
+        qcow2 = tmp_path / "disk.qcow2"
+        metadata = tmp_path / "vmimage.json"
+        qcow2.write_bytes(b"qcow2 data")
+        metadata.write_text("{}")
+        other = tmp_path / "elsewhere"
+        other.mkdir()
+        monkeypatch.chdir(other)
+        fake = _FakeRun(returncode=0)
+        with patch(
+            "boxman.providers.libvirt.oci_push.subprocess.run", side_effect=fake
+        ):
+            push_oci_image(
+                image_ref="registry.com/repo:tag",
+                qcow2_path=str(qcow2),
+                metadata_path="vmimage.json",  # bare, NOT relative to the CWD
+            )
+        assert fake.last_kwargs.get("cwd") == os.path.dirname(
+            os.path.abspath(str(qcow2))
+        )
+        assert "disk.qcow2" in fake.last_cmd
+        assert "vmimage.json" in fake.last_cmd
+
+    def test_symlink_qcow2_basename_resolvable_from_cwd(self, tmp_path: Path):
+        """cwd and basename must come from the same (unresolved) path.
+
+        A symlink whose name/dir differ from its target previously paired a
+        resolved cwd with the symlink's basename, naming a file that does not
+        exist there.
+        """
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        target = real_dir / "disk.qcow2"
+        target.write_bytes(b"qcow2 data")
+        link_dir = tmp_path / "links"
+        link_dir.mkdir()
+        link = link_dir / "mydisk.qcow2"
+        link.symlink_to(target)
+        fake = _FakeRun(returncode=0)
+        with patch(
+            "boxman.providers.libvirt.oci_push.subprocess.run", side_effect=fake
+        ):
+            push_oci_image(image_ref="registry.com/repo:tag", qcow2_path=str(link))
+        cwd = fake.last_kwargs.get("cwd")
+        pushed = fake.last_cmd[3]
+        assert pushed == "mydisk.qcow2"
+        assert cwd == str(link_dir)
+        # basename must actually open relative to cwd (oras follows the symlink)
+        assert (Path(cwd) / pushed).is_file()
+
+    def test_relative_qcow2_from_other_cwd(self, tmp_path: Path, monkeypatch):
+        """A relative qcow2 path anchors to the process CWD; cwd+basename then
+        resolve to the real file regardless of where oras is launched from."""
+        data = tmp_path / "data"
+        data.mkdir()
+        (data / "disk.qcow2").write_bytes(b"qcow2 data")
+        monkeypatch.chdir(data)
+        fake = _FakeRun(returncode=0)
+        with patch(
+            "boxman.providers.libvirt.oci_push.subprocess.run", side_effect=fake
+        ):
+            push_oci_image(image_ref="registry.com/repo:tag", qcow2_path="disk.qcow2")
+        cwd = fake.last_kwargs.get("cwd")
+        assert cwd == str(data)
+        assert fake.last_cmd[3] == "disk.qcow2"
+        assert (Path(cwd) / fake.last_cmd[3]).is_file()
+
     def test_missing_qcow2_raises(self):
         with pytest.raises(RuntimeError, match="qcow2 file not found"):
             push_oci_image(

--- a/tests/test_libvirt_oci_push.py
+++ b/tests/test_libvirt_oci_push.py
@@ -55,7 +55,9 @@ class TestPushOciImage:
         assert fake.last_cmd[:3] == ["oras", "push", "registry.com/repo:tag"]
         # pushed by basename from the file's dir (oras rejects absolute paths)
         assert fake.last_cmd[3] == "disk.qcow2"
-        assert fake.last_kwargs.get("cwd") == str(qcow2.resolve().parent)
+        assert fake.last_kwargs.get("cwd") == os.path.dirname(
+            os.path.abspath(str(qcow2))
+        )
         assert str(qcow2) not in fake.last_cmd  # no absolute path leaks in
 
     def test_qcow2_and_metadata(self, tmp_path: Path):
@@ -75,7 +77,9 @@ class TestPushOciImage:
         assert fake.last_cmd[:3] == ["oras", "push", "registry.com/repo:v1.0"]
         assert "disk.qcow2" in fake.last_cmd
         assert "vmimage.json" in fake.last_cmd
-        assert fake.last_kwargs.get("cwd") == str(qcow2.resolve().parent)
+        assert fake.last_kwargs.get("cwd") == os.path.dirname(
+            os.path.abspath(str(qcow2))
+        )
         # only basenames, never absolute paths (oras rejects those)
         assert str(qcow2) not in fake.last_cmd
         assert str(metadata) not in fake.last_cmd

--- a/tests/test_libvirt_oci_push.py
+++ b/tests/test_libvirt_oci_push.py
@@ -32,9 +32,10 @@ class _FakeRun:
         self.stdout = stdout
         self.stderr = stderr
 
-    def __call__(self, cmd, **_kwargs):
+    def __call__(self, cmd, **kwargs):
         # Stash the most recent invocation so tests can inspect it.
         self.last_cmd = cmd
+        self.last_kwargs = kwargs
         return SimpleNamespace(
             returncode=self.returncode, stdout=self.stdout, stderr=self.stderr
         )
@@ -52,7 +53,10 @@ class TestPushOciImage:
         ):
             push_oci_image(image_ref="registry.com/repo:tag", qcow2_path=str(qcow2))
         assert fake.last_cmd[:3] == ["oras", "push", "registry.com/repo:tag"]
-        assert fake.last_cmd[3] == str(qcow2)
+        # pushed by basename from the file's dir (oras rejects absolute paths)
+        assert fake.last_cmd[3] == "disk.qcow2"
+        assert fake.last_kwargs.get("cwd") == str(qcow2.resolve().parent)
+        assert str(qcow2) not in fake.last_cmd  # no absolute path leaks in
 
     def test_qcow2_and_metadata(self, tmp_path: Path):
         qcow2 = tmp_path / "disk.qcow2"
@@ -69,8 +73,26 @@ class TestPushOciImage:
                 metadata_path=str(metadata),
             )
         assert fake.last_cmd[:3] == ["oras", "push", "registry.com/repo:v1.0"]
-        assert str(qcow2) in fake.last_cmd
-        assert str(metadata) in fake.last_cmd
+        assert "disk.qcow2" in fake.last_cmd
+        assert "vmimage.json" in fake.last_cmd
+        assert fake.last_kwargs.get("cwd") == str(qcow2.resolve().parent)
+        # only basenames, never absolute paths (oras rejects those)
+        assert str(qcow2) not in fake.last_cmd
+        assert str(metadata) not in fake.last_cmd
+
+    def test_metadata_in_different_dir_raises(self, tmp_path: Path):
+        qcow2 = tmp_path / "disk.qcow2"
+        qcow2.write_bytes(b"qcow2 data")
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        metadata = sub / "vmimage.json"
+        metadata.write_text("{}")
+        with pytest.raises(RuntimeError, match="same directory"):
+            push_oci_image(
+                image_ref="registry.com/repo:tag",
+                qcow2_path=str(qcow2),
+                metadata_path=str(metadata),
+            )
 
     def test_missing_qcow2_raises(self):
         with pytest.raises(RuntimeError, match="qcow2 file not found"):


### PR DESCRIPTION
## Summary
`boxman image push <ref> --qcow2 /abs/path/disk.qcow2` failed with `Error: absolute file path detected`. oras refuses absolute file paths because the path becomes the artifact layer title (`org.opencontainers.image.title`), and an absolute title would enable path traversal when the image is pulled.

## Fix
- Run `oras push` from the qcow2's own directory and pass **basenames**, so layer titles are clean relative names (e.g. `disk.qcow2`) that the pull side recreates safely.
- Require the qcow2 and optional metadata file to live in the **same directory** (clear `RuntimeError` otherwise).

## Testing
- `tests/test_libvirt_oci_push.py`: asserts the `cwd` and basename-only argv, that no absolute path leaks into the command, and the different-directory rejection. **10 passed.**

## How this was found
Surfaced end-to-end while pushing a real Ubuntu 24.04 qcow2 to Docker Hub to provision the new `boxes/tiny-libvirt-ubuntu-24.04-oci` box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)