### PR TITLE
fix(ssh): resolve relative cluster ssh_config against workspace root

### DIFF
--- a/src/boxman/utils/env_loader.py
+++ b/src/boxman/utils/env_loader.py
@@ -87,9 +87,10 @@ def load_workspace_env(
        ``inventory``, ``salt_master``, ``ansible_config``) override any
        sourced values.
     4. The same keys declared under the *cluster* (``cluster_config``) are
-       layered on top of the workspace ones, so a ``run --cluster <name>``
-       (or ``ssh --cluster``) targets that cluster's own inventory / gateway
-       / ssh_config rather than the shared workspace defaults. This is what
+       layered on top of the workspace ones, so a ``boxman run --cluster
+       <name>`` (or ``boxman ssh --cluster``) targets that cluster's own
+       inventory / gateway / ssh_config rather than the shared workspace
+       defaults. This is what
        makes multi-cluster projects inventory-isolated at the operations
        layer. A relative cluster ``inventory`` / ``ansible_config`` is resolved
        against the cluster's ``workdir`` (tasks usually run from

--- a/src/boxman/utils/env_loader.py
+++ b/src/boxman/utils/env_loader.py
@@ -91,11 +91,14 @@ def load_workspace_env(
        (or ``ssh --cluster``) targets that cluster's own inventory / gateway
        / ssh_config rather than the shared workspace defaults. This is what
        makes multi-cluster projects inventory-isolated at the operations
-       layer. A relative cluster ``inventory`` / ``ssh_config`` /
-       ``ansible_config`` is resolved against the cluster's ``workdir`` (tasks
-       usually run from ``workspace.path``, so a bare relative path would
-       otherwise miss), and a repointed ``INVENTORY`` is mirrored to
-       ``ANSIBLE_INVENTORY`` (which ansible actually reads).
+       layer. A relative cluster ``inventory`` / ``ansible_config`` is resolved
+       against the cluster's ``workdir`` (tasks usually run from
+       ``workspace.path``, so a bare relative path would otherwise miss). A
+       relative cluster ``ssh_config`` instead resolves against the workspace
+       root, because ``write_ssh_config`` writes a single shared ssh_config
+       there (``base = workspace.path or cluster.workdir``) rather than one per
+       cluster. A repointed ``INVENTORY`` is mirrored to ``ANSIBLE_INVENTORY``
+       (which ansible actually reads).
 
     Args:
         cluster_config: A single cluster's configuration dict (from conf.yml).
@@ -107,6 +110,14 @@ def load_workspace_env(
     env_vars: dict[str, str] = {}
     workspace_config = workspace_config or {}
     workdir = os.path.expanduser(cluster_config.get("workdir", "."))
+    # A relative cluster ``ssh_config`` resolves against the workspace root,
+    # because ``write_ssh_config`` writes one shared ssh_config there
+    # (``base = workspace.path or cluster.workdir``) rather than per cluster.
+    ws_path = (
+        os.path.expanduser(workspace_config["path"])
+        if workspace_config.get("path")
+        else None
+    )
 
     # 1. Source explicit env_file from workspace config
     env_file = workspace_config.get("env_file")
@@ -149,7 +160,7 @@ def load_workspace_env(
         "ansible_config": "ANSIBLE_CONFIG",
     }
 
-    def _apply(source: dict, base: str | None) -> None:
+    def _apply(source: dict, base: str | None, ssh_base: str | None = None) -> None:
         for yaml_key, env_key in value_overrides.items():
             if yaml_key in source:
                 env_vars[env_key] = os.path.expanduser(str(source[yaml_key]))
@@ -157,8 +168,15 @@ def load_workspace_env(
             if yaml_key not in source:
                 continue
             val = os.path.expanduser(str(source[yaml_key]))
-            if base and not os.path.isabs(val):
-                val = os.path.normpath(os.path.join(base, val))
+            # ssh_config is shared at the workspace root (write_ssh_config uses
+            # base = workspace.path or cluster.workdir and groups all clusters
+            # onto one file), unlike inventory which is written per-cluster. So
+            # a relative cluster ssh_config resolves against ssh_base (the
+            # workspace root); resolving it against the cluster workdir would
+            # point `boxman ssh` / `run` at a file that was never created.
+            resolve_base = ssh_base if (env_key == "SSH_CONFIG" and ssh_base) else base
+            if resolve_base and not os.path.isabs(val):
+                val = os.path.normpath(os.path.join(resolve_base, val))
             env_vars[env_key] = val
             # ansible consults ANSIBLE_INVENTORY (which env.sh seeds from
             # INVENTORY); keep it in step so a repointed inventory actually
@@ -167,6 +185,6 @@ def load_workspace_env(
                 env_vars["ANSIBLE_INVENTORY"] = val
 
     _apply(workspace_config, None)
-    _apply(cluster_config, workdir)
+    _apply(cluster_config, workdir, ssh_base=ws_path or workdir)
 
     return env_vars

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -158,6 +158,37 @@ class TestLoadWorkspaceEnv:
         result = load_workspace_env(cluster, workspace)
         assert result["INVENTORY"] == "shared_inventory"
 
+    def test_cluster_ssh_config_resolves_against_workspace_root(self, tmp_path):
+        """A relative cluster ssh_config resolves against workspace.path (where
+        write_ssh_config writes the single shared file), NOT the per-cluster
+        workdir — otherwise `boxman ssh`/`run` reference a file never created."""
+        ws = tmp_path
+        cluster = {
+            "workdir": str(ws / "cluster_1"),
+            "ssh_config": "ssh_config",
+            "inventory": "inventory",
+        }
+        workspace = {"path": str(ws)}
+        result = load_workspace_env(cluster, workspace)
+        assert result["SSH_CONFIG"] == str(ws / "ssh_config")
+        # inventory stays per-cluster (workdir) — multi-cluster isolation intact
+        assert result["INVENTORY"] == str(ws / "cluster_1" / "inventory")
+
+    def test_cluster_ssh_config_without_workspace_path_uses_workdir(self, tmp_path):
+        """Without workspace.path, ssh_config falls back to the cluster workdir,
+        mirroring write_ssh_config's `base = workspace.path or cluster.workdir`."""
+        cluster = {"workdir": str(tmp_path), "ssh_config": "ssh_config"}
+        result = load_workspace_env(cluster, {})
+        assert result["SSH_CONFIG"] == str(tmp_path / "ssh_config")
+
+    def test_cluster_absolute_ssh_config_left_untouched(self, tmp_path):
+        """An absolute cluster ssh_config is used as-is, not joined to anything."""
+        abs_cfg = str(tmp_path / "elsewhere" / "ssh_config")
+        cluster = {"workdir": str(tmp_path / "cluster_1"), "ssh_config": abs_cfg}
+        workspace = {"path": str(tmp_path)}
+        result = load_workspace_env(cluster, workspace)
+        assert result["SSH_CONFIG"] == abs_cfg
+
 
 # ---------------------------------------------------------------------------
 # TaskRunner tests

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -189,6 +189,17 @@ class TestLoadWorkspaceEnv:
         result = load_workspace_env(cluster, workspace)
         assert result["SSH_CONFIG"] == abs_cfg
 
+    def test_workspace_level_relative_ssh_config_stays_unresolved(self):
+        """A workspace-level (non-cluster) relative ssh_config is applied with
+        base=None and left as-is. The ssh_base workspace-root resolution only
+        kicks in for a *cluster* override; write_ssh_config never consumes a
+        workspace-level ssh_config, so there is nothing to anchor it to here."""
+        result = load_workspace_env(
+            cluster_config={"workdir": "/some/workdir"},
+            workspace_config={"path": "/ws", "ssh_config": "ssh_config"},
+        )
+        assert result["SSH_CONFIG"] == "ssh_config"
+
 
 # ---------------------------------------------------------------------------
 # TaskRunner tests


### PR DESCRIPTION
## Summary
`boxman ssh` / `run --cluster` failed with:

```
Can't open user config file .../cluster_1/ssh_config: No such file or directory
```

`SSH_CONFIG` was resolved against the per-cluster workdir, but `write_ssh_config` writes a **single shared** ssh_config at the workspace root (`base = workspace.path or cluster.workdir`). This is a regression introduced with the multi-cluster isolation work in #34.

## Fix
- Resolve a relative cluster `ssh_config` against the **workspace root**, while leaving `inventory` / `ansible_config` **per-cluster** — so #34's multi-cluster inventory isolation is preserved.

## Testing
- Added tests: workspace-root resolution, no-workspace-path fallback to workdir, absolute-path passthrough.
- Full non-integration suite green (**1025 passed**); verified live via `boxman ssh` on a provisioned box (now reads `<workspace>/ssh_config`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)