### PR TITLE
feat(direct_vm): support virt_install_extra_args in DirectInstallVM

### DIFF
--- a/src/boxman/providers/libvirt/direct_vm.py
+++ b/src/boxman/providers/libvirt/direct_vm.py
@@ -130,6 +130,8 @@ class DirectInstallVM:
         parts.append("--graphics=vnc")
         parts.append("--noautoconsole")
         parts.append("--wait=0")
+        for extra in self.info.get("virt_install_extra_args", []):
+            parts.append(extra)
 
         cmd = " ".join(parts)
         cmd = self.virt_install._wrap_for_runtime(cmd)


### PR DESCRIPTION
## Summary
- Adds `virt_install_extra_args` support to `DirectInstallVM`, mirroring the same feature already present in `template_manager.py`.
- Lets `conf.yml` VM entries pass arbitrary extra `virt-install` flags, e.g. adding a QEMU guest agent channel for Talos VMs:

```yaml
virt_install_extra_args:
  - "--channel unix,target_type=virtio,name=org.qemu.guest_agent.0"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)