### PR TITLE
docs(dc-provider): Phase 0 — ratified decisions D1-D8, ADR-001, netfilter spike

### DIFF
--- a/boxes/dc-provider-staging/README.md
+++ b/boxes/dc-provider-staging/README.md
@@ -8,7 +8,7 @@ place to test every change across the epic's phases. A single Ubuntu 24.04 VM
 | capability | why |
 |---|---|
 | docker + compose v2 | provider lifecycle work (phases 3–7), netfilter spike ([#48](https://github.com/mherkazandjian/boxman/issues/48)) |
-| libvirt/qemu-kvm + virtinst (nested — template built with `--cpu host-passthrough`) | hybrid VM↔container e2e (phases 4/8): boxman *inside* the VM provisions nested VMs next to containers |
+| libvirt/qemu-kvm + virtinst (nested KVM — verified: `vmx` exposed via virt-install's default host-model CPU) | hybrid VM↔container e2e (phases 4/8): boxman *inside* the VM provisions nested VMs next to containers |
 | git, make, python3 + pip/venv | clone boxman, install it, run the test suite inside |
 | `br_netfilter` loaded at boot | spike scenarios manipulate `bridge-nf-call-iptables` |
 
@@ -59,7 +59,7 @@ $SSH 'lsmod | grep br_netfilter'                 # netfilter module loaded
 ## Run the Phase 0 netfilter spike
 
 ```bash
-$SSH 'cd ~/boxman && git fetch origin dc-provider/phase-0-design-closure && git checkout dc-provider/phase-0-design-closure'
+$SSH 'cd ~/boxman && git fetch origin feat/docker-compose-provider && git checkout feat/docker-compose-provider'
 $SSH 'cd ~/boxman && sudo bash doc/docker-compose-provider/spike/poc.sh --with-docker-restart --emulate-docker-policy'
 ```
 

--- a/boxes/dc-provider-staging/README.md
+++ b/boxes/dc-provider-staging/README.md
@@ -39,14 +39,14 @@ boxman up            # first run: downloads the cloud image, builds the
 ## Bootstrap (once per fresh VM)
 
 ```bash
-SSH="ssh -F ~/workspaces/boxmandev/dc-provider-staging/staging/ssh_config stage01"
+SSH="ssh -F ~/workspaces/boxmandev/dc-provider-staging/ssh_config staging_stage01"
 $SSH 'git clone https://github.com/mherkazandjian/boxman.git ~/boxman'
 $SSH 'cd ~/boxman && python3 -m venv ~/.venv-boxman && ~/.venv-boxman/bin/pip install -e . pytest'
 $SSH 'cd ~/boxman && PYTHONPATH=src ~/.venv-boxman/bin/python -m pytest tests/ -m unit -q'   # sanity
 ```
 
-*(the ssh_config path is printed by `boxman up`; adjust if your workspace
-differs)*
+*(the exact ssh_config path + host alias are printed at the end of
+`boxman up` — the alias is `<cluster>_<vm>`, i.e. `staging_stage01`)*
 
 ## Sanity checks inside
 

--- a/boxes/dc-provider-staging/README.md
+++ b/boxes/dc-provider-staging/README.md
@@ -1,0 +1,86 @@
+# dc-provider-staging
+
+The **staging/testing environment** for the docker-compose provider epic
+([#42](https://github.com/mherkazandjian/boxman/issues/42)) — the de facto
+place to test every change across the epic's phases. A single Ubuntu 24.04 VM
+(`stage01`) pre-baked with:
+
+| capability | why |
+|---|---|
+| docker + compose v2 | provider lifecycle work (phases 3–7), netfilter spike ([#48](https://github.com/mherkazandjian/boxman/issues/48)) |
+| libvirt/qemu-kvm + virtinst (nested — template built with `--cpu host-passthrough`) | hybrid VM↔container e2e (phases 4/8): boxman *inside* the VM provisions nested VMs next to containers |
+| git, make, python3 + pip/venv | clone boxman, install it, run the test suite inside |
+| `br_netfilter` loaded at boot | spike scenarios manipulate `bridge-nf-call-iptables` |
+
+Being a VM, it's **disposable and snapshot-resettable**: destructive tests
+(docker restarts, iptables surgery, sysctl flips) never touch your host.
+
+## Prerequisites (host)
+
+- libvirt/KVM working without sudo (`virsh -c qemu:///system list`)
+- boxman on python ≥ 3.10. No system python 3.10+? User-space fix:
+
+  ```bash
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  uv python install 3.12 && uv venv ~/.venvs/boxman --python 3.12
+  VIRTUAL_ENV=~/.venvs/boxman uv pip install -e <path-to-boxman-repo>
+  export PATH=~/.venvs/boxman/bin:$PATH
+  ```
+
+## Bring it up
+
+```bash
+cd boxes/dc-provider-staging
+boxman up            # first run: downloads the cloud image, builds the
+                     # template (installs docker+libvirt inside — takes a
+                     # few minutes), clones + starts stage01
+```
+
+## Bootstrap (once per fresh VM)
+
+```bash
+SSH="ssh -F ~/workspaces/boxmandev/dc-provider-staging/staging/ssh_config stage01"
+$SSH 'git clone https://github.com/mherkazandjian/boxman.git ~/boxman'
+$SSH 'cd ~/boxman && python3 -m venv ~/.venv-boxman && ~/.venv-boxman/bin/pip install -e . pytest'
+$SSH 'cd ~/boxman && PYTHONPATH=src ~/.venv-boxman/bin/python -m pytest tests/ -m unit -q'   # sanity
+```
+
+*(the ssh_config path is printed by `boxman up`; adjust if your workspace
+differs)*
+
+## Sanity checks inside
+
+```bash
+$SSH 'docker run --rm hello-world | tail -2'     # docker works
+$SSH 'egrep -c "vmx|svm" /proc/cpuinfo'          # nested virt exposed (>0)
+$SSH 'lsmod | grep br_netfilter'                 # netfilter module loaded
+```
+
+## Run the Phase 0 netfilter spike
+
+```bash
+$SSH 'cd ~/boxman && git fetch origin dc-provider/phase-0-design-closure && git checkout dc-provider/phase-0-design-closure'
+$SSH 'cd ~/boxman && sudo bash doc/docker-compose-provider/spike/poc.sh --with-docker-restart --emulate-docker-policy'
+```
+
+Paste the output into `doc/docker-compose-provider/spike/findings.md`.
+
+## Snapshot workflow (the point of this box)
+
+```bash
+# after bootstrap, freeze the known-good state:
+boxman snapshot take pristine
+
+# ...hack, test, break things inside...
+
+# reset to known-good between destructive runs:
+boxman snapshot restore pristine
+```
+
+## Teardown
+
+```bash
+boxman destroy
+```
+
+The base template + downloaded image stay cached for the next `boxman up`.

--- a/boxes/dc-provider-staging/conf.yml
+++ b/boxes/dc-provider-staging/conf.yml
@@ -1,0 +1,163 @@
+---
+# dc-provider-staging
+#
+# The staging/testing VM for the docker-compose provider epic (#42).
+# One Ubuntu 24.04 VM pre-baked with everything the epic's phases need:
+#
+#   - docker + compose v2            (phases 3-7, netfilter spike #48)
+#   - libvirt/qemu-kvm + virtinst    (phase 4/8 nested hybrid e2e)
+#   - git/make/python3/pip/venv      (running boxman + its test suite inside)
+#   - br_netfilter loaded at boot    (spike scenarios need it)
+#
+# The template is built with --cpu host-passthrough so nested KVM works
+# (verify inside with: egrep -c 'vmx|svm' /proc/cpuinfo).
+#
+# Workflow: `boxman up`, bootstrap per README.md, snapshot the pristine
+# state, then restore between destructive test runs.
+version: '1.0'
+project: dc_provider_staging
+provider:
+  libvirt:
+    uri: qemu:///system
+    use_sudo: False
+    virt_install_cmd: '/usr/bin/virt-install'
+    virt_clone_cmd: '/usr/bin/virt-clone'
+    virsh_cmd: '/usr/bin/virsh'
+    verbose: True
+
+templates:
+  template1:
+    name: dc-staging-ubuntu-24.04-base-template
+    image:
+      uri: http://cloud-images-archive.ubuntu.com/releases/noble/release-20240423/ubuntu-24.04-server-cloudimg-amd64.img
+      checksum: sha256:32a9d30d18803da72f5936cf2b7b9efcb4d0bb63c67933f17e3bdfd1751de3f3
+    disk_size: 40G
+    os_variant: ubuntu24.04
+    memory: 4096
+    vcpus: 4
+    virt_install_extra_args:
+      - '--cpu host-passthrough'
+    cloudinit_done_marker: /var/log/dc-staging-cloudinit.log
+    cloudinit: |
+      #cloud-config
+      hostname: dc-staging
+      manage_etc_hosts: true
+
+      network:
+        version: 2
+        ethernets:
+          default:
+            match:
+              name: "en*"
+            dhcp4: true
+            dhcp6: false
+
+      users:
+        - name: ubuntu
+          lock_passwd: false
+          groups: [sudo]
+          sudo: "ALL=(ALL) NOPASSWD:ALL"
+          shell: /bin/bash
+
+      chpasswd:
+        expire: false
+        list: |
+          ubuntu:ubuntu
+
+      ssh_pwauth: true
+      package_update: true
+      packages:
+        - qemu-guest-agent
+        - openssh-server
+        - git
+        - make
+        - curl
+        - python3-pip
+        - python3-venv
+        - iptables
+        - docker.io
+        - docker-compose-v2
+        - qemu-kvm
+        - libvirt-daemon-system
+        - virtinst
+        - genisoimage
+
+      write_files:
+        - path: /etc/systemd/system/systemd-networkd-wait-online.service.d/override.conf
+          permissions: "0644"
+          content: |
+            [Service]
+            ExecStart=
+            ExecStart=/usr/lib/systemd/systemd-networkd-wait-online --any
+        - path: /etc/modules-load.d/br_netfilter.conf
+          permissions: "0644"
+          content: |
+            br_netfilter
+
+      runcmd:
+        - rm -f /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
+        - rm -f /etc/cloud/cloud.cfg.d/subiquity-disable-cloudinit-networking.cfg
+        - systemctl daemon-reload
+        - systemctl enable --now qemu-guest-agent
+        - netplan generate || true
+        - netplan apply || true
+        - dhclient -v || true
+        - [ systemctl, enable, --now, qemu-guest-agent ]
+        # create admin user via shell commands (same recipe as the tiny box)
+        - [ sh, -c, "groupadd -f admin" ]
+        - [ sh, -c, "id admin >/dev/null 2>&1 || useradd -m -d /admin -s /bin/bash -g admin -G sudo admin" ]
+        - [ sh, -c, "echo 'admin ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/admin" ]
+        - [ sh, -c, "chmod 0440 /etc/sudoers.d/admin" ]
+        - [ sh, -c, "echo 'admin:{{ env("BOXMAN_ADMIN_PASS", default="boxman") }}' | chpasswd" ]
+        - [ sh, -c, "mkdir -p /admin/.ssh && chmod 700 /admin/.ssh && chown -R admin:admin /admin /admin/.ssh" ]
+        # epic-specific: docker + libvirt ready for both users, br_netfilter live
+        - [ sh, -c, "usermod -aG docker,libvirt,kvm admin" ]
+        - [ sh, -c, "usermod -aG docker,libvirt,kvm ubuntu" ]
+        - [ systemctl, enable, --now, docker ]
+        - [ sh, -c, "systemctl enable --now libvirtd || true" ]
+        - [ sh, -c, "modprobe br_netfilter || true" ]
+        - [ sh, -c, "echo ran at $(date -Is) >> /var/log/dc-staging-cloudinit.log" ]
+
+workspace:
+  path: ~/workspaces/boxmandev/dc-provider-staging
+
+clusters:
+  staging:
+    base_image: dc-staging-ubuntu-24.04-base-template
+    proxy_host: localhost
+    admin_user: admin
+    admin_pass: {{ env("BOXMAN_ADMIN_PASS", default="boxman") }}
+    admin_key_name: id_ed25519_boxman    # generated automatically at provisioning time
+    ssh_config: ssh_config               # generated automatically at provisioning time
+
+    networks:
+      mgmt:
+        mode: nat
+        bridge:
+          stp: 'on'
+          delay: '0'
+        mac: '52:54:00:00:77:01'
+        ip:
+          address: '192.168.77.1'
+          netmask: '255.255.255.0'
+          dhcp:
+            range:
+              start: '192.168.77.2'
+              end: '192.168.77.254'
+        enable: True
+        autostart: True
+
+    vms:
+      stage01:
+        hostname: stage01
+        cpus:
+          sockets: 1
+          cores: 4
+          threads: 2
+        memory: 12288
+        max_vcpus: 16
+        max_memory: 32768
+        network_adapters:
+          - name: adapter_1
+            link_state: 'up'
+            network_source: 'mgmt'

--- a/boxes/dc-provider-staging/conf.yml
+++ b/boxes/dc-provider-staging/conf.yml
@@ -9,8 +9,11 @@
 #   - git/make/python3/pip/venv      (running boxman + its test suite inside)
 #   - br_netfilter loaded at boot    (spike scenarios need it)
 #
-# The template is built with --cpu host-passthrough so nested KVM works
-# (verify inside with: egrep -c 'vmx|svm' /proc/cpuinfo).
+# Nested KVM: verified working (vmx exposed in the guest) via virt-install's
+# default host-model CPU. Note: virt_install_extra_args is currently silently
+# ignored on the cloud-init template path (boxman hard-codes its virt-install
+# args there — see the #48 drift log); the key is kept for when boxman honors
+# it. Verify inside with: egrep -c 'vmx|svm' /proc/cpuinfo.
 #
 # Workflow: `boxman up`, bootstrap per README.md, snapshot the pristine
 # state, then restore between destructive test runs.
@@ -35,6 +38,8 @@ templates:
     os_variant: ubuntu24.04
     memory: 4096
     vcpus: 4
+    # currently a no-op on the cloud-init template path (see #48 drift log);
+    # kept so the intent applies automatically once boxman supports it
     virt_install_extra_args:
       - '--cpu host-passthrough'
     cloudinit_done_marker: /var/log/dc-staging-cloudinit.log

--- a/doc/docker-compose-provider/README.md
+++ b/doc/docker-compose-provider/README.md
@@ -65,7 +65,8 @@ Open these files with [draw.io](https://app.diagrams.net/) or any compatible edi
 
 - **[implementation-plan.md](implementation-plan.md)** - Phased plan grounded against `main`; one tracking issue per phase (#48–#57)
 - **[adr-001-per-cluster-provider.md](adr-001-per-cluster-provider.md)** - ADR: provider granularity is per-cluster, not per-box
-- **[spike/](spike/)** - Netfilter spike: `poc.sh` scenario matrix + `findings.md` (scoped per-bridge rules vs the global `bridge-nf-call-iptables=0`)
+- **[spike/](spike/)** - Netfilter spike: `poc.sh` scenario matrix + `findings.md` (**run 2026-07-13 — scoped per-bridge rules confirmed** vs the global `bridge-nf-call-iptables=0`)
+- **[../../boxes/dc-provider-staging/](../../boxes/dc-provider-staging/)** - The epic's staging/testing VM (docker + nested libvirt pre-baked, snapshot-resettable)
 
 ## Key Design Decisions
 

--- a/doc/docker-compose-provider/README.md
+++ b/doc/docker-compose-provider/README.md
@@ -102,8 +102,8 @@ Shared bridges keep `bridge-nf-call-iptables=1`; per-bridge physdev accept rules
 
 ## Next Steps
 
-1. Run the netfilter spike ([spike/poc.sh](spike/poc.sh)) on a docker lab host and fill in [spike/findings.md](spike/findings.md)
-2. Merge the design PR — closes Phase 0 ([#48](https://github.com/mherkazandjian/boxman/issues/48))
+1. ~~Run the netfilter spike~~ — executed 2026-07-13 in the staging VM ([spike/findings.md](spike/findings.md))
+2. Merge the Phase 0 PR into the epic feature branch `feat/docker-compose-provider` — closes Phase 0 ([#48](https://github.com/mherkazandjian/boxman/issues/48)); the feature branch accumulates all phases and merges into `main` after one final epic review
 3. Begin Phase 1 — provider registry ([#49](https://github.com/mherkazandjian/boxman/issues/49))
 
 ## Related Issues

--- a/doc/docker-compose-provider/README.md
+++ b/doc/docker-compose-provider/README.md
@@ -61,6 +61,12 @@ Open these files with [draw.io](https://app.diagrams.net/) or any compatible edi
   - Environment variables and secrets
   - Task definitions
 
+### Implementation Plan & Decisions
+
+- **[implementation-plan.md](implementation-plan.md)** - Phased plan grounded against `main`; one tracking issue per phase (#48–#57)
+- **[adr-001-per-cluster-provider.md](adr-001-per-cluster-provider.md)** - ADR: provider granularity is per-cluster, not per-box
+- **[spike/](spike/)** - Netfilter spike: `poc.sh` scenario matrix + `findings.md` (scoped per-bridge rules vs the global `bridge-nf-call-iptables=0`)
+
 ## Key Design Decisions
 
 ### 1. Per-Cluster Provider Model
@@ -77,6 +83,9 @@ Containers attach to host-level Linux bridges via macvlan, providing full L2 adj
 - v2.0 configs with libvirt-only produce identical behavior to v1.0
 - Mixed providers are new functionality in v2.0
 
+### 5. Scoped Netfilter Rules (no global disable)
+Shared bridges keep `bridge-nf-call-iptables=1`; per-bridge physdev accept rules allow lab frames. The former global disable is an explicit, discouraged opt-in (decision D8 in [design.md](design.md), evidence in [spike/findings.md](spike/findings.md)).
+
 ## Implementation Phases
 
 1. **Phase 0**: Design & Validation (this phase)
@@ -92,11 +101,11 @@ Containers attach to host-level Linux bridges via macvlan, providing full L2 adj
 
 ## Next Steps
 
-1. Review design documents with the team
-2. Validate architecture diagrams
-3. Test example configuration
-4. Begin Phase 1 implementation (Provider Registry)
+1. Run the netfilter spike ([spike/poc.sh](spike/poc.sh)) on a docker lab host and fill in [spike/findings.md](spike/findings.md)
+2. Merge the design PR — closes Phase 0 ([#48](https://github.com/mherkazandjian/boxman/issues/48))
+3. Begin Phase 1 — provider registry ([#49](https://github.com/mherkazandjian/boxman/issues/49))
 
 ## Related Issues
 
-- GitHub Issue #42: [master plan for adding docker compose as a provider](https://github.com/Orski174/boxman/issues/42)
+- Epic — GitHub Issue [#42](https://github.com/mherkazandjian/boxman/issues/42): master plan for adding docker compose as a provider
+- Phase tracking issues: [#48](https://github.com/mherkazandjian/boxman/issues/48)–[#57](https://github.com/mherkazandjian/boxman/issues/57) (one per phase, see [implementation-plan.md](implementation-plan.md))

--- a/doc/docker-compose-provider/adr-001-per-cluster-provider.md
+++ b/doc/docker-compose-provider/adr-001-per-cluster-provider.md
@@ -1,0 +1,54 @@
+# ADR-001: Provider granularity is per-cluster, not per-box
+
+- Status: **accepted** (2026-07-13, ratified on [#48](https://github.com/mherkazandjian/boxman/issues/48))
+- Epic: [#42](https://github.com/mherkazandjian/boxman/issues/42)
+
+## Context
+
+Issue #42 asks to "explore the design of having a per-cluster provider —
+and/or a per-box provider". Config schema v2.0 introduces a `provider:` key;
+this ADR fixes the level at which it may appear.
+
+## Options considered
+
+1. **Per-cluster provider** — every box in a cluster is provisioned by the
+   cluster's single provider.
+2. **Per-box provider** — each box may name its own provider; a cluster can
+   mix VMs and containers.
+3. Both (per-cluster default, per-box override).
+
+## Decision
+
+**Per-cluster only** (option 1).
+
+A cluster is boxman's lifecycle unit, and every mechanism that makes a cluster
+useful is cluster-scoped:
+
+- one docker-compose *project* / one libvirt session per cluster — up, down,
+  destroy operate on the unit;
+- cluster-internal networks are defined per cluster;
+- ansible inventory groups, generated ssh config, and snapshot operations
+  group by cluster;
+- the generated `docker-compose.yml` is one file per cluster — a per-box
+  provider would fragment it.
+
+The topology per-box would buy is already expressible: *a box of another
+provider is a one-box cluster*. Mixed VM/container projects work today in the
+design via multiple clusters sharing `shared_networks` for L2 adjacency.
+
+## Consequences
+
+- `provider:` is valid only at cluster level (and as the top-level default);
+  a `provider:` key inside a box definition is a config error (enforced in
+  Phase 2, [#50](https://github.com/mherkazandjian/boxman/issues/50)).
+- Provider dispatch in the manager resolves per cluster
+  (Phase 1, [#49](https://github.com/mherkazandjian/boxman/issues/49)).
+- Docs teach the one-box-cluster pattern for "just one container next to my
+  VMs" use cases.
+
+## Revisit if
+
+A real topology demonstrates that the one-box-cluster workaround fails —
+e.g. boxes of different providers that must share a *cluster-internal*
+network or a single lifecycle ordering that cross-cluster dependencies
+cannot express. Reopen against #42 with the concrete case.

--- a/doc/docker-compose-provider/design.md
+++ b/doc/docker-compose-provider/design.md
@@ -644,6 +644,6 @@ Questions" section.
 
 ## Next Steps
 
-1. Run the netfilter spike ([spike/poc.sh](spike/poc.sh)) on a docker lab host and record [spike/findings.md](spike/findings.md)
-2. Merge this design (PR → `main`), closing Phase 0 ([#48](https://github.com/mherkazandjian/boxman/issues/48))
+1. ~~Run the netfilter spike~~ — executed 2026-07-13 in the staging VM; results in [spike/findings.md](spike/findings.md)
+2. Merge the Phase 0 PR into the epic feature branch `feat/docker-compose-provider`, closing Phase 0 ([#48](https://github.com/mherkazandjian/boxman/issues/48)). The feature branch accumulates all phase work; a single final review merges it into `main` at epic end.
 3. Begin Phase 1 — provider registry ([#49](https://github.com/mherkazandjian/boxman/issues/49)); full phase map in [implementation-plan.md](implementation-plan.md)

--- a/doc/docker-compose-provider/design.md
+++ b/doc/docker-compose-provider/design.md
@@ -13,6 +13,7 @@ This document describes the design for adding docker-compose as a first-class pr
 5. [Volume Management](#volume-management)
 6. [Implementation Phases](#implementation-phases)
 7. [Breaking Changes & Versioning](#breaking-changes--versioning)
+8. [Decisions (Phase 0)](#decisions-phase-0)
 
 ---
 
@@ -230,7 +231,7 @@ shared_networks:
   app_bridge:
     bridge: br-app
     stp: false
-    disable_netfilter: true
+    disable_netfilter: false   # default — scoped per-bridge rules instead (decision D8)
 
 clusters:
   compute:
@@ -360,7 +361,7 @@ graph LR
 ```mermaid
 graph TB
     subgraph SharedNetworks["Shared Networks (L2)"]
-        SB1["br-app<br/>shared_bridges.py<br/>bridge-nf-call-iptables=0"]
+        SB1["br-app<br/>shared_bridges.py<br/>scoped physdev accept rules (D8)"]
     end
     
     subgraph LibvirtIsolation["Libvirt Cluster Networks"]
@@ -383,6 +384,25 @@ graph TB
     LN1 -.->|Isolated| VM
     DN1 -.->|Isolated| Container
 ```
+
+### Netfilter Policy (decision D8)
+
+`shared_bridges.ensure()` keeps the host-global `bridge-nf-call-iptables`
+**untouched** by default. Lab frames on a shared bridge are allowed by an
+idempotent per-bridge rule instead:
+
+```
+iptables -I FORWARD 1 -i <bridge> -o <bridge> -m physdev --physdev-is-bridged -j ACCEPT
+```
+
+(on docker hosts the `DOCKER-USER` chain is preferred if the spike confirms it
+works and persists across docker restarts). Rationale: the previous global
+`bridge-nf-call-iptables=0` weakens docker/k8s bridge filtering host-wide, is
+never restored, and a docker/kubelet restart silently reverts it — breaking
+the lab. `disable_netfilter: true` remains available as an explicit opt-in
+with a loud warning. Evidence: [spike/findings.md](spike/findings.md);
+implementation: Phase 4
+([#52](https://github.com/mherkazandjian/boxman/issues/52)).
 
 ---
 
@@ -599,23 +619,28 @@ def normalize_v2_config(config):
 
 ---
 
-## Open Questions
+## Decisions (Phase 0)
 
-1. **Container health checks**: Should boxman wait for container health checks before proceeding (like it waits for VM IPs)? Or just wait for `docker compose ps` to show `running`?
+Ratified on [#48](https://github.com/mherkazandjian/boxman/issues/48). See also
+[adr-001-per-cluster-provider.md](adr-001-per-cluster-provider.md) and
+[spike/findings.md](spike/findings.md). These supersede the former "Open
+Questions" section.
 
-2. **Container SSH**: Should boxman generate SSH config entries for containers (via `docker exec`), or only for VMs? The `boxman ssh` command would need a different code path for containers.
-
-3. **Snapshot semantics**: `docker commit` creates an image from a running container — this is different from libvirt's external snapshots with qcow2 overlays. Should we document the difference, or abstract it?
-
-4. **Build context**: When a box has `build: { context: ./api }`, the build context path is relative to the conf.yml directory. Should boxman resolve this, or pass it through to docker compose?
-
-5. **Compose file location**: Generated `docker-compose.yml` goes under `<cluster_workdir>/docker-compose.yml`. Should it also be written to `.boxman/` alongside the runtime assets?
+| # | Question | Decision |
+|---|---|---|
+| D1 | Container readiness | `docker compose up --wait` + per-cluster `readiness_timeout` (default 120s): waits for `healthy` when a healthcheck exists, `running` otherwise — no custom polling loop. |
+| D2 | Container access | `boxman ssh <cluster>.<box>` transparently uses `docker exec -it` — no sshd sidecars. Ansible reaches containers via the `community.docker` connection plugin. `write_ssh_config` stays VM-only. |
+| D3 | Snapshot semantics | `docker commit`-backed: `take` commits + tags `boxman/<project>_<box>:<snap>`; `restore` regenerates the compose file with snapshot tags + `up --force-recreate`; `list`/`delete` = image ls/rmi + metadata JSON in the cluster workdir. **Volumes are not snapshotted** — documented loudly. |
+| D4 | `build.context` | Resolved by boxman to an absolute path (relative to the conf.yml directory) at generation time — the generated compose file lives in the cluster workdir, so passing relative paths through would silently break. |
+| D5 | Compose file location | `<cluster_workdir>/docker-compose.yml` — inspectable and hand-runnable (`docker compose -f … ps`), same debuggability philosophy as the `.rendered.yml` dump. |
+| D6 | Provider granularity | Per-cluster only; per-box rejected ([ADR-001](adr-001-per-cluster-provider.md)). A box of another provider is a one-box cluster. |
+| D7 | Compose passthrough | `compose_extra:` escape hatch (per-box and per-cluster), deep-merged verbatim into the generated file — keeps the boxman dialect small without blocking on unsupported compose features. |
+| D8 | Netfilter | Shared bridges keep host-global `bridge-nf-call-iptables` untouched by default (`disable_netfilter` defaults to `false`); per-bridge scoped physdev accept rules allow lab frames. Global disable = explicit opt-in with loud warning. See [Netfilter Policy](#netfilter-policy-decision-d8). Implemented in Phase 4 ([#52](https://github.com/mherkazandjian/boxman/issues/52)). |
 
 ---
 
 ## Next Steps
 
-1. Review this design document with the team
-2. Validate the architecture diagrams
-3. Create example conf.yml for acceptance testing
-4. Begin Phase 1 implementation (Provider Registry)
+1. Run the netfilter spike ([spike/poc.sh](spike/poc.sh)) on a docker lab host and record [spike/findings.md](spike/findings.md)
+2. Merge this design (PR → `main`), closing Phase 0 ([#48](https://github.com/mherkazandjian/boxman/issues/48))
+3. Begin Phase 1 — provider registry ([#49](https://github.com/mherkazandjian/boxman/issues/49)); full phase map in [implementation-plan.md](implementation-plan.md)

--- a/doc/docker-compose-provider/design.md
+++ b/doc/docker-compose-provider/design.md
@@ -395,13 +395,16 @@ idempotent per-bridge rule instead:
 iptables -I FORWARD 1 -i <bridge> -o <bridge> -m physdev --physdev-is-bridged -j ACCEPT
 ```
 
-(on docker hosts the `DOCKER-USER` chain is preferred if the spike confirms it
-works and persists across docker restarts). Rationale: the previous global
-`bridge-nf-call-iptables=0` weakens docker/k8s bridge filtering host-wide, is
-never restored, and a docker/kubelet restart silently reverts it — breaking
-the lab. `disable_netfilter: true` remains available as an explicit opt-in
-with a loud warning. Evidence: [spike/findings.md](spike/findings.md);
-implementation: Phase 4
+(`FORWARD` is the default — it works without docker; the `DOCKER-USER` chain
+is a spike-validated alternative on docker hosts and survives docker
+restarts). Rationale: the previous global `bridge-nf-call-iptables=0` weakens
+docker/k8s bridge filtering host-wide, is never restored, and silently
+reverts on any reboot (the `br_netfilter` module defaults the sysctl to 1 on
+load) or on kubernetes hosts (kubelet enforces `=1`) — breaking the lab.
+Spike note: modern docker (29.x) itself does *not* reset it on daemon
+restart. `disable_netfilter: true` remains available as an explicit opt-in
+with a loud warning. Evidence: [spike/findings.md](spike/findings.md)
+(executed 2026-07-13, all scenarios pass); implementation: Phase 4
 ([#52](https://github.com/mherkazandjian/boxman/issues/52)).
 
 ---

--- a/doc/docker-compose-provider/example-conf.yml
+++ b/doc/docker-compose-provider/example-conf.yml
@@ -13,12 +13,15 @@ provider:
   docker-compose:
     project_name: hybrid_web_app
 
-# Shared networks for L2 connectivity between VMs and containers
+# Shared networks for L2 connectivity between VMs and containers.
+# Netfilter stays enabled host-wide; boxman inserts scoped per-bridge
+# accept rules instead (design.md decision D8). Setting
+# disable_netfilter: true is an explicit, discouraged opt-in.
 shared_networks:
   app_bridge:
     bridge: br-app
     stp: false
-    disable_netfilter: true
+    disable_netfilter: false
 
 # Workspace configuration
 workspace:

--- a/doc/docker-compose-provider/spike/findings.md
+++ b/doc/docker-compose-provider/spike/findings.md
@@ -1,0 +1,60 @@
+# Netfilter spike — findings
+
+Phase 0 deliverable — issue [#48](https://github.com/mherkazandjian/boxman/issues/48) (epic #42).
+Produced by [`poc.sh`](poc.sh); run it on a docker lab host and record results here.
+
+## Question
+
+Can boxman keep the host-global `bridge-nf-call-iptables=1` and still pass
+VM↔container L2 traffic on a shared bridge, using **per-bridge scoped iptables
+rules** instead of the global disable currently performed by
+`src/boxman/netlab/shared_bridges.py`?
+
+## Environment
+
+<!-- paste the "=== environment ===" block from the poc.sh output -->
+
+```
+(pending — run: sudo bash poc.sh --with-docker-restart --emulate-docker-policy)
+```
+
+## Results
+
+<!-- paste the "=== summary ===" table from the poc.sh output -->
+
+| scenario | expected | actual | verdict |
+|---|---|---|---|
+| 1-baseline-nf1 | blocked | *(pending)* | |
+| 2-global-disable | works | *(pending)* | |
+| 3-scoped-forward | works | *(pending)* | |
+| 4-docker-user | works | *(pending)* | |
+| 4b-du-survives-restart | works | *(pending)* | |
+| 5-restart-flips-nf | (info) | *(pending)* | |
+| 6a–6e macvlan legs | see script | *(pending)* | |
+| 7-idempotent-insert | works | *(pending)* | |
+
+## Pre-registered recommendation (confirm or amend after the run)
+
+Phase 4 ([#52](https://github.com/mherkazandjian/boxman/issues/52)) changes
+`shared_bridges.ensure()` to:
+
+1. Keep `bridge-nf-call-iptables` **untouched** by default
+   (`disable_netfilter` default flips to `false`).
+2. Per shared bridge, insert an idempotent scoped accept rule
+   (`iptables -C` before `-I`):
+
+   ```
+   iptables -I FORWARD 1 -i <bridge> -o <bridge> -m physdev --physdev-is-bridged -j ACCEPT
+   ```
+
+   On docker hosts, prefer the same rule in the `DOCKER-USER` chain if
+   scenario 4/4b confirms it works and survives docker restarts.
+3. Keep the global `bridge-nf-call-iptables=0` path as an **explicit opt-in**
+   (`disable_netfilter: true`) with a loud warning about its host-global,
+   docker/k8s-weakening, restart-fragile nature (scenario 5 evidence).
+
+## Notes per scenario
+
+*(fill in anything surprising — especially 6a/6b if macvlan-via-bridge-parent
+frames turn out not to traverse FORWARD the way veth-bridged frames do, and
+6d/6e for the host↔macvlan shim demo)*

--- a/doc/docker-compose-provider/spike/findings.md
+++ b/doc/docker-compose-provider/spike/findings.md
@@ -1,7 +1,8 @@
 # Netfilter spike — findings
 
 Phase 0 deliverable — issue [#48](https://github.com/mherkazandjian/boxman/issues/48) (epic #42).
-Produced by [`poc.sh`](poc.sh); run it on a docker lab host and record results here.
+Produced by [`poc.sh`](poc.sh), executed 2026-07-13 inside the epic's staging VM
+([`boxes/dc-provider-staging`](../../../boxes/dc-provider-staging/) — itself provisioned by boxman).
 
 ## Question
 
@@ -10,30 +11,62 @@ VM↔container L2 traffic on a shared bridge, using **per-bridge scoped iptables
 rules** instead of the global disable currently performed by
 `src/boxman/netlab/shared_bridges.py`?
 
+**Answer: yes — confirmed on all counts.**
+
 ## Environment
 
-<!-- paste the "=== environment ===" block from the poc.sh output -->
+```
+6.8.0-31-generic
+iptables v1.8.10 (nf_tables)
+Docker version 29.1.3, build 29.1.3-0ubuntu3~24.04.2
+PRETTY_NAME="Ubuntu 24.04 LTS"
+initial bridge-nf-call-iptables=1, FORWARD policy=ACCEPT (docker policy DROP emulated)
+```
 
-```
-(pending — run: sudo bash poc.sh --with-docker-restart --emulate-docker-policy)
-```
+Invocation: `sudo bash poc.sh --with-docker-restart --emulate-docker-policy`
 
 ## Results
 
-<!-- paste the "=== summary ===" table from the poc.sh output -->
-
 | scenario | expected | actual | verdict |
 |---|---|---|---|
-| 1-baseline-nf1 | blocked | *(pending)* | |
-| 2-global-disable | works | *(pending)* | |
-| 3-scoped-forward | works | *(pending)* | |
-| 4-docker-user | works | *(pending)* | |
-| 4b-du-survives-restart | works | *(pending)* | |
-| 5-restart-flips-nf | (info) | *(pending)* | |
-| 6a–6e macvlan legs | see script | *(pending)* | |
-| 7-idempotent-insert | works | *(pending)* | |
+| 1-baseline-nf1 | blocked | blocked | as-expected |
+| 2-global-disable | works | works | as-expected |
+| 3-scoped-forward | works | works | as-expected |
+| 4-docker-user | works | works | as-expected |
+| 4b-du-survives-restart | works | works | as-expected |
+| 5-restart-flips-nf | (info) | **nf=0 — did NOT flip back** | info |
+| 6a-mv-ct→vm | works | works | as-expected |
+| 6b-vm→mv-ct | works | works | as-expected |
+| 6c-arp-resolves | works | works | as-expected |
+| 6d-host→mv (caveat) | blocked | blocked | as-expected |
+| 6e-host→mv via shim | works | works | as-expected |
+| 7-idempotent-insert | works | works | as-expected |
 
-## Pre-registered recommendation (confirm or amend after the run)
+## Notes per scenario
+
+- **1** proves the problem is real: with `bridge-nf-call-iptables=1` and a
+  docker-style `FORWARD` DROP policy, bridged VM↔container frames are dropped.
+- **3 / 4 / 4b**: the scoped rule works in both `FORWARD` and `DOCKER-USER`,
+  and the `DOCKER-USER` copy **survives a docker restart** (docker creates but
+  does not flush that chain).
+- **5 — fragility claim narrowed**: on this stack (docker 29.1.3, Ubuntu
+  24.04) a docker daemon restart does **not** reset `bridge-nf-call-iptables`
+  to 1 — the original "docker restart silently reverts it" claim does not
+  reproduce with modern docker. The global-disable approach is still fragile,
+  just via different vectors: **any reboot reverts it** (the `br_netfilter`
+  module defaults the sysctl to 1 on load), and **kubelet hard-sets it to 1**
+  on kubernetes hosts. The host-wide-weakening objection is unaffected.
+- **6a–6c**: full L2 adjacency between a macvlan-attached container
+  (`parent=<bridge>`) and a bridge-attached "VM" netns under the target state
+  (`nf=1` + scoped rule): ping both directions, ARP neighbor entries resolve.
+- **6d/6e**: the documented macvlan limitation — the host cannot reach a
+  macvlan child through the parent directly; a `macvlan mode=bridge` shim
+  interface restores host↔container reachability. Boxman does not need the
+  shim for VM↔container traffic; document it for users who want host access.
+- **7**: the `iptables -C`-before-`-I` pattern is idempotent — safe for
+  repeated `shared_bridges.ensure()` calls.
+
+## Recommendation (confirmed)
 
 Phase 4 ([#52](https://github.com/mherkazandjian/boxman/issues/52)) changes
 `shared_bridges.ensure()` to:
@@ -47,14 +80,10 @@ Phase 4 ([#52](https://github.com/mherkazandjian/boxman/issues/52)) changes
    iptables -I FORWARD 1 -i <bridge> -o <bridge> -m physdev --physdev-is-bridged -j ACCEPT
    ```
 
-   On docker hosts, prefer the same rule in the `DOCKER-USER` chain if
-   scenario 4/4b confirms it works and survives docker restarts.
+   Both `FORWARD` and `DOCKER-USER` placements are validated; `FORWARD` is the
+   default (works without docker), `DOCKER-USER` is a validated alternative on
+   docker hosts (survives docker restarts).
 3. Keep the global `bridge-nf-call-iptables=0` path as an **explicit opt-in**
-   (`disable_netfilter: true`) with a loud warning about its host-global,
-   docker/k8s-weakening, restart-fragile nature (scenario 5 evidence).
-
-## Notes per scenario
-
-*(fill in anything surprising — especially 6a/6b if macvlan-via-bridge-parent
-frames turn out not to traverse FORWARD the way veth-bridged frames do, and
-6d/6e for the host↔macvlan shim demo)*
+   (`disable_netfilter: true`) with a loud warning: host-wide weakening of
+   docker/k8s bridge filtering, reverted by any reboot (module-load default)
+   and by kubelet.

--- a/doc/docker-compose-provider/spike/poc.sh
+++ b/doc/docker-compose-provider/spike/poc.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+#
+# Netfilter/iptables spike for the docker-compose provider.
+# Phase 0 deliverable — issue #48 (epic #42).
+#
+# Question answered empirically: can boxman keep the host-global
+# bridge-nf-call-iptables=1 and still pass VM<->container L2 traffic on a
+# shared bridge, using per-bridge scoped iptables rules instead of the
+# global disable currently done by src/boxman/netlab/shared_bridges.py?
+#
+# Usage (run on a lab host, ideally one with docker installed):
+#   sudo bash poc.sh                          # non-disruptive scenarios
+#   sudo bash poc.sh --with-docker-restart    # + docker restart scenarios (4b, 5)
+#   sudo bash poc.sh --emulate-docker-policy  # force FORWARD policy DROP when
+#                                             # the host lacks docker's default
+#   sudo bash poc.sh --keep                   # keep artifacts for inspection
+#
+# Everything the script creates is prefixed "spike" and torn down on exit
+# (unless --keep). The bridge-nf-call-iptables value and FORWARD policy are
+# restored to their initial state.
+#
+# Record the output in findings.md next to this script.
+
+set -u
+
+# ── constants ────────────────────────────────────────────────────────────
+BR=br-spike
+NS_VM=spike-vm          # stand-in for a libvirt VM (netns + veth)
+NS_CT=spike-ct          # stand-in for a container (netns + veth)
+IP_VM=10.99.0.11
+IP_CT=10.99.0.12
+SUBNET=10.99.0.0/24
+MACVLAN_NET=spike-macvlan
+MACVLAN_CT=spike-mvct
+IP_MV=10.99.0.66
+HOST_BR_IP=10.99.0.1/24
+SHIM=spike-shim
+SHIM_IP=10.99.0.2/32
+NF=/proc/sys/net/bridge/bridge-nf-call-iptables
+
+WITH_DOCKER_RESTART=0
+EMULATE_POLICY=0
+KEEP=0
+for arg in "$@"; do
+    case "$arg" in
+        --with-docker-restart)   WITH_DOCKER_RESTART=1 ;;
+        --emulate-docker-policy) EMULATE_POLICY=1 ;;
+        --keep)                  KEEP=1 ;;
+        *) echo "unknown flag: $arg" >&2; exit 64 ;;
+    esac
+done
+
+[ "$(id -u)" -eq 0 ] || { echo "must run as root (sudo)" >&2; exit 77; }
+
+# ── result bookkeeping ───────────────────────────────────────────────────
+declare -a RESULTS=()
+record() {  # record <scenario> <expected> <actual>
+    local verdict
+    if [ "$2" = "$3" ]; then verdict="as-expected"
+    elif [ "$2" = "n/a" ]; then verdict="info"
+    else verdict="DIFFERS"; fi
+    RESULTS+=("$1|$2|$3|$verdict")
+    printf '  -> %-28s expected=%-12s actual=%-12s [%s]\n' "$1" "$2" "$3" "$verdict"
+}
+skip() { RESULTS+=("$1|$2|skipped|skip"); printf '  -> %-28s SKIPPED (%s)\n' "$1" "$3"; }
+
+# ── helpers ──────────────────────────────────────────────────────────────
+vm_ping_ct()   { ip netns exec "$NS_VM" ping -c1 -W1 "$IP_CT" >/dev/null 2>&1; }
+vm_ping_mv()   { ip netns exec "$NS_VM" ping -c1 -W1 "$IP_MV" >/dev/null 2>&1; }
+mv_ping_vm()   { docker exec "$MACVLAN_CT" ping -c1 -W1 "$IP_VM" >/dev/null 2>&1; }
+host_ping_mv() { ping -c1 -W1 "$IP_MV" >/dev/null 2>&1; }
+verdict_of()   { if "$@"; then echo works; else echo blocked; fi; }
+
+FWD_RULE=(-i "$BR" -o "$BR" -m physdev --physdev-is-bridged -j ACCEPT)
+add_fwd_rule() { iptables -C FORWARD "${FWD_RULE[@]}" 2>/dev/null || iptables -I FORWARD 1 "${FWD_RULE[@]}"; }
+del_fwd_rule() { while iptables -C FORWARD "${FWD_RULE[@]}" 2>/dev/null; do iptables -D FORWARD "${FWD_RULE[@]}"; done; }
+have_docker_user() { iptables -nL DOCKER-USER >/dev/null 2>&1; }
+add_du_rule()  { iptables -C DOCKER-USER "${FWD_RULE[@]}" 2>/dev/null || iptables -I DOCKER-USER 1 "${FWD_RULE[@]}"; }
+del_du_rule()  { while iptables -C DOCKER-USER "${FWD_RULE[@]}" 2>/dev/null; do iptables -D DOCKER-USER "${FWD_RULE[@]}"; done; }
+
+restart_docker() { systemctl restart docker 2>/dev/null || service docker restart; sleep 3; }
+
+# ── cleanup ──────────────────────────────────────────────────────────────
+cleanup() {
+    [ "$KEEP" -eq 1 ] && { echo "--keep: leaving spike artifacts in place"; return; }
+    echo "cleaning up..."
+    del_fwd_rule || true
+    have_docker_user && del_du_rule || true
+    docker rm -f "$MACVLAN_CT"      >/dev/null 2>&1 || true
+    docker network rm "$MACVLAN_NET" >/dev/null 2>&1 || true
+    ip link del "$SHIM"             >/dev/null 2>&1 || true
+    ip netns del "$NS_VM"           >/dev/null 2>&1 || true
+    ip netns del "$NS_CT"           >/dev/null 2>&1 || true
+    ip link del "$BR"               >/dev/null 2>&1 || true
+    [ -n "${ORIG_NF:-}" ] && [ -e "$NF" ] && echo "$ORIG_NF" > "$NF"
+    [ "${POLICY_EMULATED:-0}" -eq 1 ] && iptables -P FORWARD "$ORIG_FWD_POLICY"
+}
+trap cleanup EXIT
+
+# ── environment capture (paste into findings.md) ────────────────────────
+echo "=== environment ==="
+uname -r
+iptables --version
+command -v docker >/dev/null && docker --version || echo "docker: not installed"
+grep -h PRETTY_NAME /etc/os-release 2>/dev/null || true
+
+# ── setup ────────────────────────────────────────────────────────────────
+echo "=== setup ==="
+modprobe br_netfilter 2>/dev/null || true
+[ -e "$NF" ] || { echo "br_netfilter unavailable — spike meaningless without it" >&2; exit 1; }
+ORIG_NF=$(cat "$NF")
+ORIG_FWD_POLICY=$(iptables -S FORWARD | awk '/^-P FORWARD/{print $3}')
+echo "initial bridge-nf-call-iptables=$ORIG_NF, FORWARD policy=$ORIG_FWD_POLICY"
+
+HAVE_DOCKER=0
+command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1 && HAVE_DOCKER=1
+
+POLICY_EMULATED=0
+if [ "$ORIG_FWD_POLICY" != "DROP" ]; then
+    if [ "$EMULATE_POLICY" -eq 1 ]; then
+        echo "emulating docker's FORWARD policy DROP (restored on exit)"
+        iptables -P FORWARD DROP
+        POLICY_EMULATED=1
+    else
+        echo "NOTE: FORWARD policy is $ORIG_FWD_POLICY (docker hosts use DROP);"
+        echo "      baseline blockage may not reproduce — rerun with --emulate-docker-policy"
+    fi
+fi
+
+ip link add name "$BR" type bridge
+ip link set dev "$BR" up
+for pair in "$NS_VM:$IP_VM" "$NS_CT:$IP_CT"; do
+    ns=${pair%%:*}; ip=${pair##*:}
+    ip netns add "$ns"
+    ip link add "${ns}-h" type veth peer name "${ns}-n"
+    ip link set "${ns}-n" netns "$ns"
+    ip link set "${ns}-h" master "$BR" up
+    ip -n "$ns" addr add "$ip/24" dev "${ns}-n"
+    ip -n "$ns" link set "${ns}-n" up
+    ip -n "$ns" link set lo up
+done
+echo "bridge $BR with $NS_VM($IP_VM) and $NS_CT($IP_CT) attached"
+
+# ── scenario 1: baseline — nf=1, no rules → expect blocked ───────────────
+echo "=== scenario 1: baseline (nf-call-iptables=1, no rules) ==="
+echo 1 > "$NF"
+if [ "$ORIG_FWD_POLICY" = "DROP" ] || [ "$POLICY_EMULATED" -eq 1 ]; then
+    record "1-baseline-nf1" "blocked" "$(verdict_of vm_ping_ct)"
+else
+    skip "1-baseline-nf1" "blocked" "FORWARD policy not DROP on this host"
+fi
+
+# ── scenario 2: current behavior — global nf=0 → expect works ────────────
+echo "=== scenario 2: global bridge-nf-call-iptables=0 (current boxman default) ==="
+echo 0 > "$NF"
+record "2-global-disable" "works" "$(verdict_of vm_ping_ct)"
+echo 1 > "$NF"
+
+# ── scenario 3: target state — nf=1 + scoped FORWARD rule → works ────────
+echo "=== scenario 3: nf=1 + scoped physdev rule in FORWARD (target state) ==="
+add_fwd_rule
+record "3-scoped-forward" "works" "$(verdict_of vm_ping_ct)"
+del_fwd_rule
+
+# ── scenario 4: DOCKER-USER variant ──────────────────────────────────────
+echo "=== scenario 4: nf=1 + scoped rule in DOCKER-USER ==="
+if have_docker_user; then
+    add_du_rule
+    record "4-docker-user" "works" "$(verdict_of vm_ping_ct)"
+    if [ "$WITH_DOCKER_RESTART" -eq 1 ] && [ "$HAVE_DOCKER" -eq 1 ]; then
+        restart_docker
+        if iptables -C DOCKER-USER "${FWD_RULE[@]}" 2>/dev/null; then persisted=works; else persisted=blocked; fi
+        record "4b-du-survives-restart" "works" "$persisted"
+    else
+        skip "4b-du-survives-restart" "works" "needs --with-docker-restart"
+    fi
+    del_du_rule
+else
+    skip "4-docker-user" "works" "DOCKER-USER chain absent (docker not installed?)"
+fi
+
+# ── scenario 5: fragility — nf=0, restart docker, does it flip back? ─────
+echo "=== scenario 5: docker restart flips nf-call-iptables back? ==="
+if [ "$WITH_DOCKER_RESTART" -eq 1 ] && [ "$HAVE_DOCKER" -eq 1 ]; then
+    echo 0 > "$NF"
+    restart_docker
+    record "5-restart-flips-nf" "n/a" "nf=$(cat "$NF")"
+    echo 1 > "$NF"
+else
+    skip "5-restart-flips-nf" "n/a" "needs --with-docker-restart and docker"
+fi
+
+# ── scenario 6: macvlan container on the bridge ──────────────────────────
+echo "=== scenario 6: docker macvlan(parent=$BR) container <-> netns 'VM' ==="
+if [ "$HAVE_DOCKER" -eq 1 ]; then
+    if docker network create -d macvlan --subnet="$SUBNET" --ip-range=10.99.0.64/26 \
+           --gateway="${HOST_BR_IP%/*}" -o parent="$BR" "$MACVLAN_NET" >/dev/null 2>&1 \
+       && docker run -d --rm --name "$MACVLAN_CT" --network "$MACVLAN_NET" \
+           --ip "$IP_MV" alpine:3 sleep 600 >/dev/null 2>&1; then
+        add_fwd_rule                       # target state active
+        record "6a-mv-ct->vm"  "works" "$(verdict_of mv_ping_vm)"
+        record "6b-vm->mv-ct"  "works" "$(verdict_of vm_ping_mv)"
+        # L2 proof: neighbor entry for the container MAC must exist in the VM ns
+        if ip -n "$NS_VM" neigh show "$IP_MV" 2>/dev/null | grep -qv FAILED \
+           && [ -n "$(ip -n "$NS_VM" neigh show "$IP_MV" 2>/dev/null)" ]; then
+            record "6c-arp-resolves" "works" "works"
+        else
+            record "6c-arp-resolves" "works" "blocked"
+        fi
+        # host<->macvlan caveat: host IP on the parent cannot reach the child...
+        ip addr add "$HOST_BR_IP" dev "$BR"
+        record "6d-host->mv (caveat)" "blocked" "$(verdict_of host_ping_mv)"
+        # ...unless via a macvlan shim on the same parent
+        ip link add "$SHIM" link "$BR" type macvlan mode bridge
+        ip addr add "$SHIM_IP" dev "$SHIM"
+        ip link set "$SHIM" up
+        ip route add "$IP_MV/32" dev "$SHIM"
+        record "6e-host->mv via shim" "works" "$(verdict_of host_ping_mv)"
+        ip route del "$IP_MV/32" dev "$SHIM" 2>/dev/null || true
+        ip link del "$SHIM"
+        ip addr del "$HOST_BR_IP" dev "$BR"
+        del_fwd_rule
+    else
+        skip "6-macvlan" "works" "macvlan net/container creation failed (image pull?)"
+    fi
+else
+    skip "6-macvlan" "works" "docker not available"
+fi
+
+# ── scenario 7: idempotency of the rule-management pattern ───────────────
+echo "=== scenario 7: iptables -C check-before-insert is idempotent ==="
+add_fwd_rule; add_fwd_rule
+count=$(iptables -S FORWARD | grep -cF -- "--physdev-is-bridged" || true)
+[ "$count" -eq 1 ] && record "7-idempotent-insert" "works" "works" \
+                   || record "7-idempotent-insert" "works" "blocked"
+del_fwd_rule
+
+# ── summary ──────────────────────────────────────────────────────────────
+echo
+echo "=== summary (paste into findings.md) ==="
+printf '%-28s %-12s %-14s %s\n' "scenario" "expected" "actual" "verdict"
+mismatch=0
+for r in "${RESULTS[@]}"; do
+    IFS='|' read -r s e a v <<<"$r"
+    printf '%-28s %-12s %-14s %s\n' "$s" "$e" "$a" "$v"
+    [ "$v" = "DIFFERS" ] && mismatch=1
+done
+exit $mismatch

--- a/doc/docker-compose-provider/spike/poc.sh
+++ b/doc/docker-compose-provider/spike/poc.sh
@@ -230,7 +230,7 @@ fi
 # ── scenario 7: idempotency of the rule-management pattern ───────────────
 echo "=== scenario 7: iptables -C check-before-insert is idempotent ==="
 add_fwd_rule; add_fwd_rule
-count=$(iptables -S FORWARD | grep -cF -- "--physdev-is-bridged" || true)
+count=$(iptables -S FORWARD | grep -cF -- "-i $BR -o $BR -m physdev --physdev-is-bridged -j ACCEPT" || true)
 [ "$count" -eq 1 ] && record "7-idempotent-insert" "works" "works" \
                    || record "7-idempotent-insert" "works" "blocked"
 del_fwd_rule


### PR DESCRIPTION
Part of #48 (Phase 0 — design closure). Targets the epic feature branch `feat/docker-compose-provider` — all phase PRs accumulate there; one final epic review merges it into `main`.

## What's here

- **Decisions D1–D8** in `design.md` (former "Open Questions"), ratified on #48: readiness via `docker compose up --wait`; container access via `docker exec` (no sshd sidecars); `docker commit`-backed snapshots (volumes excluded, documented); `build.context` resolved absolute; compose file at `<cluster_workdir>/docker-compose.yml`; per-cluster provider granularity; `compose_extra:` passthrough; **scoped per-bridge netfilter rules replacing the global `bridge-nf-call-iptables=0` default**.
- **ADR-001** — per-cluster provider, per-box rejected (revisit-if clause).
- **Netfilter spike — executed 2026-07-13, all 12 scenarios pass** (`spike/poc.sh` + `spike/findings.md`). Truth-correction: docker 29.x does *not* reset the sysctl on restart; real fragility = reboots (module default) + kubelet.
- **`boxes/dc-provider-staging`** — the epic's staging/testing VM (docker + compose v2, nested KVM verified, br_netfilter at boot, snapshot-resettable). Provisioned by boxman itself; the spike ran inside it; 740 unit tests green in-VM.
- README: epic link fixed to `mherkazandjian/boxman#42`; new docs linked; `disable_netfilter: false` documented as the target default.
- Review fixes: honest nested-virt wording (`virt_install_extra_args` is currently a no-op on the cloud-init template path — see #48 drift log), epic-branch flow in next-steps, tightened spike idempotency check.

Closes #48 follow-up happens on the issue (drift retro) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)