### PR TITLE
[dc-provider] Phase 2: config schema v2.0 — version key, boxes:, per-cluster provider:

### DIFF
--- a/doc/docker-compose-provider/config-schema.md
+++ b/doc/docker-compose-provider/config-schema.md
@@ -21,9 +21,15 @@ of the on-disk schema version.
 | `version:` value | Behaviour |
 |---|---|
 | absent | treated as **v1.0** — returned unchanged |
-| `'1.0'` | **v1.0** — returned unchanged |
-| `'2.0'` | **v2.0** — normalized (see below) |
+| `'1.0'` (or unquoted `1` / `1.0`) | **v1.0** — returned unchanged |
+| `'2.0'` (or unquoted `2` / `2.0`) | **v2.0** — normalized (see below) |
 | anything else | `ConfigError: unsupported config version: '<x>' (supported: '1.0', '2.0')` → CLI logs it and exits 2 |
+
+The value is compared as a string, so unquoted YAML numerics are accepted
+(`version: 2` and `version: 2.0` both select v2.0). **Quoting is still
+recommended** — write `version: '2.0'` — to avoid surprises from YAML's
+numeric coercion (e.g. a future `version: 2.10` would parse as the float
+`2.1`).
 
 ## What v2.0 adds
 
@@ -52,10 +58,40 @@ For each cluster, the effective provider is
 | libvirt | ✓ | ✓ | **`ConfigError`** — ambiguous, declare one |
 | docker-compose | ✓ | – | `boxes:` kept as-is (consumed by the Phase 3 `DockerComposeSession`) |
 | docker-compose | – | ✓ | **`ConfigError`** — docker-compose clusters must use `boxes:` |
+| `virtualbox` | any | any | **`ConfigError`** — not supported under v2.0 yet; use `version: '1.0'` + `vms:` |
+| unknown / typo | any | any | **`ConfigError`** — unknown provider (guards against silent empty clusters) |
+
+Only `libvirt` and `docker-compose` are wired for v2.0. The legacy
+`virtualbox` provider stays on v1.0 syntax for now, and an unknown value
+(e.g. a typo `libvrit`) is rejected rather than left to silently provision
+an empty cluster.
+
+A **per-box `provider:`** key is also rejected (`ConfigError`) — providers
+are a cluster-level concern (ADR-001), so `boxes: { web: { provider: … } }`
+is a config error, not a silently-ignored field.
 
 A v1.0 config that uses `boxes:` gets a one-line warning (nothing reads
-`boxes:` in v1.0, so the cluster would otherwise silently appear empty) —
-provisioning behaviour is unchanged.
+`boxes:` in v1.0, so those boxes are silently ignored — including in a
+partial migration that still has a sibling `vms:`) — provisioning behaviour
+is unchanged.
+
+### Not yet runnable: docker-compose / mixed configs
+
+A v2.0 config with a docker-compose cluster **parses and normalizes**, but
+is **not runnable until Phase 3** (`DockerComposeSession`). Running
+`boxman provision` / `up` on one exits **2** at session build with the
+friendly "docker-compose provider … lands in Phase 3 (#51)" message (the
+registry has no docker-compose session yet), rather than provisioning
+anything. Pure-libvirt v2.0 configs are fully runnable.
+
+### Why `boxman conf` still shows `boxes:`
+
+Normalization (`boxes:` → `vms:`) happens on the in-memory config **after**
+the `.rendered.yml` debug dump is written. `boxman conf` and `.rendered.yml`
+therefore intentionally show the **pre-normalization** shape — a fidelity
+view of what you wrote (`boxes:`), not boxman's internal `vms:` form. This
+is by design; the internal normalization is what the provisioning flows act
+on.
 
 ## Templating caveat for compose values (`environment:`, `command:`)
 

--- a/doc/docker-compose-provider/config-schema.md
+++ b/doc/docker-compose-provider/config-schema.md
@@ -1,0 +1,113 @@
+# Boxman configuration schema — versioning (v1.0 & v2.0)
+
+Boxman project configs (`conf.yml`) carry an optional top-level `version:`
+key. It selects how boxman interprets the rest of the file. **v1.0 is
+supported indefinitely and is unaffected by this document** — everything
+below is additive.
+
+This is the reference for the schema-version handling introduced in
+Phase 2 of the docker-compose provider epic
+([#50](https://github.com/mherkazandjian/boxman/issues/50)). It lives
+alongside [`design.md`](./design.md) (see *Configuration Schema v2.0* and
+*Breaking Changes & Versioning*).
+
+## Version detection
+
+`BoxmanManager.load_config` renders the Jinja template, parses the YAML,
+then calls `_apply_config_version(conf)` before returning — so **every
+downstream consumer sees the internal (v1.0-shaped) config**, regardless
+of the on-disk schema version.
+
+| `version:` value | Behaviour |
+|---|---|
+| absent | treated as **v1.0** — returned unchanged |
+| `'1.0'` | **v1.0** — returned unchanged |
+| `'2.0'` | **v2.0** — normalized (see below) |
+| anything else | `ConfigError: unsupported config version: '<x>' (supported: '1.0', '2.0')` → CLI logs it and exits 2 |
+
+## What v2.0 adds
+
+1. **`boxes:` as the generic per-cluster key.** v1.0 uses `vms:`; v2.0
+   uses `boxes:` (a VM *or* a container is a "box"). For **libvirt**
+   clusters boxman renames `boxes:` → `vms:` at load time, so the entire
+   existing libvirt code path is untouched.
+2. **Per-cluster `provider:`.** Each cluster may declare its own
+   `provider:` (`libvirt` or `docker-compose`). It defaults to the
+   **top-level primary provider** (the first key under the top-level
+   `provider:` mapping). This key is already honoured by the Phase 1
+   provider registry (`provider_type_for_cluster`).
+
+A v2.0 config that uses only libvirt behaves **exactly** like its v1.0
+equivalent.
+
+## Normalization rules (compatibility matrix)
+
+For each cluster, the effective provider is
+`cluster.get('provider') or <top-level primary provider>`. Then:
+
+| cluster provider | `boxes:` | `vms:` | result |
+|---|:---:|:---:|---|
+| libvirt | ✓ | – | `boxes:` renamed to `vms:` |
+| libvirt | – | ✓ | accepted with a **deprecation warning** (prefer `boxes:`) |
+| libvirt | ✓ | ✓ | **`ConfigError`** — ambiguous, declare one |
+| docker-compose | ✓ | – | `boxes:` kept as-is (consumed by the Phase 3 `DockerComposeSession`) |
+| docker-compose | – | ✓ | **`ConfigError`** — docker-compose clusters must use `boxes:` |
+
+A v1.0 config that uses `boxes:` gets a one-line warning (nothing reads
+`boxes:` in v1.0, so the cluster would otherwise silently appear empty) —
+provisioning behaviour is unchanged.
+
+## Templating caveat for compose values (`environment:`, `command:`)
+
+`load_config` pre-processes bare `{{ name }}` tokens into `{name}` task
+placeholders before Jinja render (see the comment block in
+`load_config`). This is a **whole-file** text substitution with no
+awareness of YAML structure, so it also touches docker-compose cluster
+blocks.
+
+Safe / unsafe forms inside a compose `environment:` or `command:` value:
+
+| Form | Matched by preprocessing? | Verdict |
+|---|---|---|
+| `${VAR}`, `$${VAR}` | no (`$`/braces differ) | **safe** — use these for compose-time interpolation |
+| `{{ env("VAR") }}`, `{{ a.b }}`, `{{ x \| y }}` | no (contains non-word chars) | **safe** — rendered by Jinja as usual |
+| `{{ word }}` (a single bare word) | **yes** → rewritten to `{word}` | **avoid** — becomes the literal string `{word}` |
+
+**Rule of thumb:** in docker-compose clusters, use `${VAR}` /
+`$${VAR}` for interpolation and never a bare single-word `{{ word }}`.
+(A structure-aware exemption for compose blocks is deferred to Phase 3,
+where these values are actually consumed.)
+
+## Examples
+
+v1.0 (unchanged, supported indefinitely):
+
+```yaml
+project: my_lab
+provider:
+  libvirt:
+    uri: qemu:///system
+clusters:
+  compute:
+    vms:
+      node01:
+        hostname: node01
+```
+
+v2.0, libvirt-only (behaves identically to the v1.0 above):
+
+```yaml
+version: '2.0'
+project: my_lab
+provider:
+  libvirt:
+    uri: qemu:///system
+clusters:
+  compute:
+    boxes:
+      node01:
+        hostname: node01
+```
+
+v2.0, mixed providers: see
+[`example-conf.yml`](./example-conf.yml).

--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -20,7 +20,7 @@ from boxman.config_cache import BoxmanCache
 from boxman.exceptions import ConfigError
 from boxman.image_cache import ImageCache
 from boxman.netlab import ContainerlabManager, shared_bridges
-from boxman.providers import primary_provider_type
+from boxman.providers import PROVIDERS, primary_provider_type
 from boxman.providers.libvirt.commands import VirshCommand
 from boxman.runtime import RuntimeBase, create_runtime
 from boxman.task_runner import TaskRunner
@@ -446,15 +446,25 @@ class BoxmanManager:
         Dispatch on the config's ``version:`` key and return the config in
         boxman's internal (v1.0) shape.
 
-        - No ``version:`` key or ``'1.0'`` → returned unchanged (v1.0 is
-          supported indefinitely and stays byte-identical).
-        - ``'2.0'`` → :meth:`normalize_v2_config` (per-cluster
-          ``boxes:``→``vms:`` for libvirt clusters, schema validation).
+        - No ``version:`` key, ``'1.0'`` (or the unquoted YAML numeric
+          ``1`` / ``1.0``) → returned unchanged (v1.0 is supported
+          indefinitely and stays byte-identical).
+        - ``'2.0'`` (or unquoted ``2`` / ``2.0``) → :meth:`normalize_v2_config`
+          (per-cluster ``boxes:``→``vms:`` for libvirt clusters, schema
+          validation).
         - anything else → :class:`~boxman.exceptions.ConfigError`.
 
+        The value is compared as a string so unquoted YAML numerics work:
+        ``version: 2`` and ``version: 2.0`` both select v2.0. Quoting
+        (``version: '2.0'``) is still recommended — see
+        ``doc/docker-compose-provider/config-schema.md``.
+
         Args:
-            conf: The parsed project configuration (may be ``None`` for an
-                empty file).
+            conf: The parsed project configuration. A non-mapping root
+                (``None``, list, scalar — e.g. an empty file) is returned
+                unchanged rather than raising, so malformed input surfaces
+                later through the normal path, not as an ``AttributeError``
+                here.
 
         Returns:
             The version-normalized configuration.
@@ -462,14 +472,14 @@ class BoxmanManager:
         Raises:
             ConfigError: If ``version:`` is set to an unsupported value.
         """
-        if not conf:
+        if not isinstance(conf, dict):
             return conf
 
-        version = str(conf.get('version', '1.0'))
-        if version == '1.0':
+        version = str(conf.get('version', '1.0')).strip()
+        if version in ('1', '1.0'):
             self._warn_on_v1_boxes(conf)
             return conf
-        if version == '2.0':
+        if version in ('2', '2.0'):
             return self.normalize_v2_config(conf)
 
         raise ConfigError(
@@ -481,18 +491,20 @@ class BoxmanManager:
         """
         Warn when a v1.0 config uses the v2.0-only ``boxes:`` key.
 
-        In v1.0 nothing reads ``boxes:``, so such a cluster would silently
-        appear to have no VMs. This is a log-only nudge toward
-        ``version: '2.0'`` — it does not change v1.0 provisioning
-        behaviour.
+        In v1.0 nothing reads ``boxes:``, so such boxes are silently
+        ignored — including in a partial migration where a cluster carries
+        both ``vms:`` (provisioned) and ``boxes:`` (dropped). The warning
+        fires whenever ``boxes:`` is present, regardless of ``vms:``. It is
+        a log-only nudge toward ``version: '2.0'`` and does not change v1.0
+        provisioning behaviour.
         """
         for cluster_name, cluster in (conf.get('clusters') or {}).items():
-            if isinstance(cluster, dict) and 'boxes' in cluster and 'vms' not in cluster:
+            if isinstance(cluster, dict) and 'boxes' in cluster:
                 self.logger.warning(
                     f"cluster '{cluster_name}' uses 'boxes:' but the config "
                     f"is v1.0 — 'boxes:' is only recognised under "
-                    f"version: '2.0'. Add \"version: '2.0'\" or rename "
-                    f"'boxes:' to 'vms:'."
+                    f"version: '2.0', so these boxes are ignored. Add "
+                    f"\"version: '2.0'\" or rename 'boxes:' to 'vms:'."
                 )
 
     def normalize_v2_config(self, conf: dict[str, Any]) -> dict[str, Any]:
@@ -510,8 +522,20 @@ class BoxmanManager:
           both ``boxes:`` and ``vms:`` is ambiguous and rejected.
         - **docker-compose** clusters: ``boxes:`` is kept as-is (consumed
           by the Phase 3 ``DockerComposeSession``); ``vms:`` is rejected.
+        - any **other** provider (the legacy ``virtualbox``, or an unknown
+          value / typo) is rejected — v2.0 supports only ``libvirt`` and
+          ``docker-compose`` today, and silently leaving ``boxes:``
+          untouched would provision an empty cluster.
 
-        The config is mutated in place and also returned.
+        A per-box ``provider:`` key is a config error (ADR-001): providers
+        are declared at the cluster level only.
+
+        The config is **mutated in place** and also returned; it is meant
+        to run once over a freshly parsed config (``load_config`` re-parses
+        each call). Re-running over an already-normalized dict — whose
+        ``boxes:`` were popped but whose ``version:`` stays ``'2.0'`` —
+        would treat the renamed ``vms:`` as a legacy key and emit a
+        spurious deprecation warning.
 
         Args:
             conf: The parsed v2.0 project configuration.
@@ -520,7 +544,8 @@ class BoxmanManager:
             The normalized configuration (same object).
 
         Raises:
-            ConfigError: On an ambiguous or provider-incompatible cluster.
+            ConfigError: On an ambiguous, provider-incompatible, or
+                unknown-provider cluster, or a per-box ``provider:``.
         """
         for cluster_name, cluster in (conf.get('clusters') or {}).items():
             if not isinstance(cluster, dict):
@@ -529,6 +554,11 @@ class BoxmanManager:
             provider = cluster.get('provider') or primary_provider_type(conf)
             has_boxes = 'boxes' in cluster
             has_vms = 'vms' in cluster
+
+            # ADR-001: a `provider:` on an individual box is a config error;
+            # inspect both the boxes: mapping and the legacy vms: mapping.
+            self._reject_per_box_provider(cluster_name, cluster.get('boxes'))
+            self._reject_per_box_provider(cluster_name, cluster.get('vms'))
 
             if provider == 'libvirt':
                 if has_boxes and has_vms:
@@ -547,12 +577,43 @@ class BoxmanManager:
             elif provider == 'docker-compose':
                 if has_vms:
                     raise ConfigError(
-                        f"cluster '{cluster_name}' is a docker-compose "
-                        f"cluster and must use 'boxes:', not 'vms:'."
+                        f"cluster '{cluster_name}' declares 'vms:'; "
+                        f"docker-compose clusters only support 'boxes:'."
                     )
                 # 'boxes:' is kept verbatim for the docker-compose provider.
+            elif provider in PROVIDERS:
+                # a registered provider not yet wired for v2.0 (virtualbox)
+                raise ConfigError(
+                    f"cluster '{cluster_name}': provider '{provider}' is "
+                    f"not supported under config version '2.0' yet — use "
+                    f"version: '1.0' with 'vms:' for '{provider}' clusters."
+                )
+            else:
+                raise ConfigError(
+                    f"cluster '{cluster_name}': unknown provider "
+                    f"'{provider}' (known: {', '.join(sorted(PROVIDERS))})."
+                )
 
         return conf
+
+    @staticmethod
+    def _reject_per_box_provider(cluster_name: str, boxes: Any) -> None:
+        """
+        Raise if any box in *boxes* declares a ``provider:`` key.
+
+        ADR-001 assigns per-box-provider validation to Phase 2: a provider
+        is a cluster-level concern, so a ``provider:`` inside an individual
+        box (which ``provider_type_for_cluster`` would silently ignore) is
+        rejected rather than accepted and dropped.
+        """
+        for box_name, box in (boxes or {}).items():
+            if isinstance(box, dict) and 'provider' in box:
+                raise ConfigError(
+                    f"box '{box_name}' in cluster '{cluster_name}' declares "
+                    f"a 'provider:' key — per-box providers are not "
+                    f"supported (ADR-001); declare 'provider:' on the "
+                    f"cluster instead."
+                )
 
     @staticmethod
     def _render_inventory(host_aliases, cluster_groups) -> str:

--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -17,6 +17,7 @@ from boxman.utils.shell import run
 from boxman import log
 from boxman.abstract.providers import ProviderSession
 from boxman.config_cache import BoxmanCache
+from boxman.exceptions import ConfigError
 from boxman.image_cache import ImageCache
 from boxman.netlab import ContainerlabManager, shared_bridges
 from boxman.providers import primary_provider_type
@@ -432,6 +433,124 @@ class BoxmanManager:
         with open(rendered_path, 'w') as fobj:
             fobj.write(rendered_yaml)
             self.logger.info(f"rendered YAML template written to {rendered_path}")
+
+        # apply schema-version handling (v2.0 boxes:→vms: normalization etc.)
+        # before returning, so every downstream consumer sees the internal
+        # (v1.0-shaped) config regardless of the on-disk schema version.
+        conf = self._apply_config_version(conf)
+
+        return conf
+
+    def _apply_config_version(self, conf: dict[str, Any] | None) -> dict[str, Any] | None:
+        """
+        Dispatch on the config's ``version:`` key and return the config in
+        boxman's internal (v1.0) shape.
+
+        - No ``version:`` key or ``'1.0'`` → returned unchanged (v1.0 is
+          supported indefinitely and stays byte-identical).
+        - ``'2.0'`` → :meth:`normalize_v2_config` (per-cluster
+          ``boxes:``→``vms:`` for libvirt clusters, schema validation).
+        - anything else → :class:`~boxman.exceptions.ConfigError`.
+
+        Args:
+            conf: The parsed project configuration (may be ``None`` for an
+                empty file).
+
+        Returns:
+            The version-normalized configuration.
+
+        Raises:
+            ConfigError: If ``version:`` is set to an unsupported value.
+        """
+        if not conf:
+            return conf
+
+        version = str(conf.get('version', '1.0'))
+        if version == '1.0':
+            self._warn_on_v1_boxes(conf)
+            return conf
+        if version == '2.0':
+            return self.normalize_v2_config(conf)
+
+        raise ConfigError(
+            f"unsupported config version: '{version}' "
+            f"(supported: '1.0', '2.0')"
+        )
+
+    def _warn_on_v1_boxes(self, conf: dict[str, Any]) -> None:
+        """
+        Warn when a v1.0 config uses the v2.0-only ``boxes:`` key.
+
+        In v1.0 nothing reads ``boxes:``, so such a cluster would silently
+        appear to have no VMs. This is a log-only nudge toward
+        ``version: '2.0'`` — it does not change v1.0 provisioning
+        behaviour.
+        """
+        for cluster_name, cluster in (conf.get('clusters') or {}).items():
+            if isinstance(cluster, dict) and 'boxes' in cluster and 'vms' not in cluster:
+                self.logger.warning(
+                    f"cluster '{cluster_name}' uses 'boxes:' but the config "
+                    f"is v1.0 — 'boxes:' is only recognised under "
+                    f"version: '2.0'. Add \"version: '2.0'\" or rename "
+                    f"'boxes:' to 'vms:'."
+                )
+
+    def normalize_v2_config(self, conf: dict[str, Any]) -> dict[str, Any]:
+        """
+        Normalize a v2.0 config into boxman's internal (v1.0) shape.
+
+        For each cluster the effective provider is
+        ``cluster.get('provider') or primary_provider_type(conf)`` (the
+        same resolution :meth:`provider_type_for_cluster` uses). Then, per
+        the design compatibility matrix:
+
+        - **libvirt** clusters: ``boxes:`` is renamed to ``vms:`` so the
+          ~35 existing libvirt call sites are untouched; a cluster still
+          using ``vms:`` is accepted with a deprecation warning; declaring
+          both ``boxes:`` and ``vms:`` is ambiguous and rejected.
+        - **docker-compose** clusters: ``boxes:`` is kept as-is (consumed
+          by the Phase 3 ``DockerComposeSession``); ``vms:`` is rejected.
+
+        The config is mutated in place and also returned.
+
+        Args:
+            conf: The parsed v2.0 project configuration.
+
+        Returns:
+            The normalized configuration (same object).
+
+        Raises:
+            ConfigError: On an ambiguous or provider-incompatible cluster.
+        """
+        for cluster_name, cluster in (conf.get('clusters') or {}).items():
+            if not isinstance(cluster, dict):
+                continue
+
+            provider = cluster.get('provider') or primary_provider_type(conf)
+            has_boxes = 'boxes' in cluster
+            has_vms = 'vms' in cluster
+
+            if provider == 'libvirt':
+                if has_boxes and has_vms:
+                    raise ConfigError(
+                        f"cluster '{cluster_name}' declares both 'boxes:' "
+                        f"and 'vms:' — use one (prefer 'boxes:' in v2.0)."
+                    )
+                if has_boxes:
+                    cluster['vms'] = cluster.pop('boxes')
+                elif has_vms:
+                    self.logger.warning(
+                        f"cluster '{cluster_name}' uses the legacy 'vms:' "
+                        f"key under version: '2.0' — 'boxes:' is the "
+                        f"preferred generic key. 'vms:' remains accepted."
+                    )
+            elif provider == 'docker-compose':
+                if has_vms:
+                    raise ConfigError(
+                        f"cluster '{cluster_name}' is a docker-compose "
+                        f"cluster and must use 'boxes:', not 'vms:'."
+                    )
+                # 'boxes:' is kept verbatim for the docker-compose provider.
 
         return conf
 

--- a/src/boxman/scripts/app.py
+++ b/src/boxman/scripts/app.py
@@ -295,6 +295,11 @@ def main():
     try:
         _main()
     except ConfigError as exc:
+        # A viewer command (e.g. ``snapshot log``) raises the boxman logger
+        # to CRITICAL+1 to silence INFO spam before the config is loaded; if
+        # loading then fails, restore a level that lets this error through so
+        # it is not swallowed (exit 2 with empty output).
+        logging.getLogger('boxman').setLevel(logging.ERROR)
         log.error(str(exc))
         sys.exit(2)
 

--- a/src/boxman/scripts/app.py
+++ b/src/boxman/scripts/app.py
@@ -14,6 +14,7 @@ import yaml
 import boxman
 from boxman import log
 from boxman.abstract.providers import ProviderSession as Session
+from boxman.exceptions import ConfigError
 from boxman.manager import BoxmanManager
 from boxman.providers import create_session, primary_provider_type
 from boxman.providers.libvirt.import_image import ImageImporter
@@ -282,6 +283,23 @@ def load_boxman_config(path: str) -> dict:
 
 
 def main():
+    """
+    CLI entry point.
+
+    Thin wrapper that translates config-schema errors
+    (:class:`~boxman.exceptions.ConfigError`, e.g. an unsupported
+    ``version:`` or an invalid v2.0 cluster) into a clean ``log.error`` +
+    exit 2, instead of surfacing a traceback. All other flow (including
+    the ``sys.exit()`` calls throughout) lives in :func:`_main`.
+    """
+    try:
+        _main()
+    except ConfigError as exc:
+        log.error(str(exc))
+        sys.exit(2)
+
+
+def _main():
 
     arg_parser = parse_args()
     args, remaining = arg_parser.parse_known_args()

--- a/tests/test_boxman_conf.py
+++ b/tests/test_boxman_conf.py
@@ -904,7 +904,7 @@ class TestConfigSchemaV2:
             out = self._mgr()._apply_config_version(cfg)
         assert out['clusters']['c']['vms'] == {'n': {}}
         assert any(
-            "legacy 'vms:'" in r.message or "vms:" in r.message
+            "legacy 'vms:'" in r.message
             for r in captured_logs.records if r.levelno >= logging.WARNING
         )
 
@@ -927,7 +927,7 @@ class TestConfigSchemaV2:
     def test_v2_docker_compose_vms_is_error(self):
         cfg = self._cfg(version='2.0', top_provider='docker-compose',
                         cluster={'provider': 'docker-compose', 'vms': {}})
-        with pytest.raises(ConfigError, match=r"must use 'boxes:', not 'vms:'"):
+        with pytest.raises(ConfigError, match=r"docker-compose clusters only support 'boxes:'"):
             self._mgr()._apply_config_version(cfg)
 
     # --- per-cluster provider defaulting to the top-level primary --------
@@ -1008,3 +1008,169 @@ class TestConfigSchemaV2:
         env = loaded['clusters']['services']['boxes']['web']['environment']
         assert 'DB_HOST=${DB_HOST}' in env
         assert 'ESC=$${LITERAL}' in env
+
+    # --- M1: unquoted numeric versions ------------------------------------
+
+    def test_unquoted_int_version_1_is_v1(self):
+        """`version: 1` (unquoted int) must not hard-fail — pre-PR it was
+        ignored, so it stays on the v1.0 path."""
+        cfg = self._cfg(version=1, cluster={'vms': {'v': {}}})
+        out = self._mgr()._apply_config_version(cfg)
+        assert 'vms' in out['clusters']['c']
+
+    def test_unquoted_int_version_2_is_v2(self):
+        cfg = self._cfg(version=2, top_provider='libvirt',
+                        cluster={'boxes': {'n': {}}})
+        out = self._mgr()._apply_config_version(cfg)
+        assert 'vms' in out['clusters']['c']
+        assert 'boxes' not in out['clusters']['c']
+
+    def test_unquoted_float_version_2_0_is_v2(self):
+        cfg = self._cfg(version=2.0, top_provider='libvirt',
+                        cluster={'boxes': {'n': {}}})
+        out = self._mgr()._apply_config_version(cfg)
+        assert 'vms' in out['clusters']['c']
+
+    def test_load_config_unquoted_version_2(self, tmp_path):
+        """End-to-end: an unquoted `version: 2` file loads as v2.0."""
+        path = tmp_path / 'conf.yml'
+        path.write_text(
+            "version: 2\n"
+            "project: p\n"
+            "provider:\n  libvirt: {}\n"
+            "clusters:\n  c:\n    boxes:\n      n:\n        hostname: n\n"
+        )
+        loaded = BoxmanManager().load_config(str(path))
+        assert loaded['clusters']['c']['vms'] == {'n': {'hostname': 'n'}}
+
+    # --- C1: non-dict / malformed root ------------------------------------
+
+    def test_non_dict_root_returned_unchanged(self):
+        """A non-mapping YAML root must be returned as-is, not raise
+        AttributeError past the clean handler."""
+        assert self._mgr()._apply_config_version(['a', 'b']) == ['a', 'b']
+        assert self._mgr()._apply_config_version("scalar") == "scalar"
+
+    # --- M2/C2: provider validation ---------------------------------------
+
+    def test_virtualbox_provider_rejected_in_v2(self):
+        cfg = self._cfg(version='2.0', top_provider='virtualbox',
+                        cluster={'boxes': {'n': {}}})
+        with pytest.raises(ConfigError, match=r"'virtualbox' is not supported"):
+            self._mgr()._apply_config_version(cfg)
+
+    def test_unknown_provider_rejected(self):
+        cfg = self._cfg(version='2.0', top_provider='libvirt',
+                        cluster={'provider': 'libvrit', 'boxes': {}})
+        with pytest.raises(ConfigError, match=r"unknown provider 'libvrit'"):
+            self._mgr()._apply_config_version(cfg)
+
+    # --- M3: per-box provider is a config error (ADR-001) -----------------
+
+    def test_per_box_provider_in_boxes_rejected(self):
+        cfg = self._cfg(version='2.0', top_provider='libvirt',
+                        cluster={'boxes': {'web': {'provider': 'docker-compose'}}})
+        with pytest.raises(ConfigError, match=r"box 'web'.*'provider:'"):
+            self._mgr()._apply_config_version(cfg)
+
+    def test_per_box_provider_in_legacy_vms_rejected(self):
+        cfg = self._cfg(version='2.0', top_provider='libvirt',
+                        cluster={'vms': {'db': {'provider': 'x'}}})
+        with pytest.raises(ConfigError, match=r"box 'db'.*'provider:'"):
+            self._mgr()._apply_config_version(cfg)
+
+    # --- M5: partial-migration warning ------------------------------------
+
+    def test_v1_partial_migration_boxes_and_vms_warns(self, captured_logs):
+        """v1.0 cluster carrying both `vms:` and `boxes:` — the boxes are
+        silently ignored, so the warning must still fire."""
+        cfg = self._cfg(version='1.0',
+                        cluster={'vms': {'old': {}}, 'boxes': {'new': {}}})
+        with captured_logs.at_level(logging.WARNING, logger='boxman'):
+            self._mgr()._apply_config_version(cfg)
+        assert any(
+            "boxes" in r.message and "ignored" in r.message
+            for r in captured_logs.records
+        )
+
+    # --- N2: docker-compose both-keys message -----------------------------
+
+    def test_dc_both_keys_message_names_docker_compose(self):
+        cfg = self._cfg(version='2.0', top_provider='docker-compose',
+                        cluster={'provider': 'docker-compose',
+                                 'boxes': {}, 'vms': {}})
+        with pytest.raises(ConfigError, match=r"docker-compose clusters only support 'boxes:'"):
+            self._mgr()._apply_config_version(cfg)
+
+    # --- mixed config parses (runnability is Phase 3) ---------------------
+
+    def test_mixed_config_normalizes_without_error(self):
+        """A libvirt-primary config with one dc cluster loads cleanly: the
+        libvirt cluster gets `vms:`, the dc cluster keeps `boxes:`."""
+        cfg = {
+            'version': '2.0',
+            'project': 'mixed',
+            'provider': {'libvirt': {}},
+            'clusters': {
+                'compute': {'boxes': {'n': {}}},
+                'services': {'provider': 'docker-compose', 'boxes': {'web': {}}},
+            },
+        }
+        out = self._mgr().normalize_v2_config(cfg)
+        assert 'vms' in out['clusters']['compute']
+        assert out['clusters']['services']['boxes'] == {'web': {}}
+        assert 'vms' not in out['clusters']['services']
+
+    # --- N1: idempotency caveat -------------------------------------------
+
+    def test_double_normalize_emits_spurious_legacy_warning(self, captured_logs):
+        """Documents the in-place, run-once contract: re-normalizing an
+        already-normalized dict treats the renamed `vms:` as legacy."""
+        cfg = self._cfg(version='2.0', top_provider='libvirt',
+                        cluster={'boxes': {'n': {}}})
+        mgr = self._mgr()
+        mgr.normalize_v2_config(cfg)  # boxes -> vms, no warning
+        with captured_logs.at_level(logging.WARNING, logger='boxman'):
+            mgr.normalize_v2_config(cfg)  # second pass: vms looks legacy
+        assert any("legacy 'vms:'" in r.message for r in captured_logs.records)
+
+
+class TestMainConfigErrorExit:
+    """The ``main()`` wrapper (app.py) turns a ``ConfigError`` from config
+    loading into a clean ``log.error`` + exit 2 — the only behavioural
+    change in app.py for Phase 2 (finding L1), including the M4 fix that the
+    message survives a viewer command's logger suppression."""
+
+    def test_config_error_exits_2_and_logs(self, captured_logs, monkeypatch):
+        from boxman.scripts import app
+
+        def _raise():
+            raise ConfigError('boom-config')
+
+        monkeypatch.setattr(app, '_main', _raise)
+        with captured_logs.at_level(logging.ERROR, logger='boxman'):
+            with pytest.raises(SystemExit) as excinfo:
+                app.main()
+        assert excinfo.value.code == 2
+        assert any('boom-config' in r.message for r in captured_logs.records)
+
+    def test_error_survives_snapshot_log_suppression(self, captured_logs, monkeypatch):
+        """M4: a viewer command raises the boxman logger to CRITICAL+1
+        before load; the wrapper must restore it so the error is emitted."""
+        from boxman.scripts import app
+
+        boxman_logger = logging.getLogger('boxman')
+        previous = boxman_logger.level
+        boxman_logger.setLevel(logging.CRITICAL + 1)
+
+        def _raise():
+            raise ConfigError('shown-anyway')
+
+        try:
+            monkeypatch.setattr(app, '_main', _raise)
+            with pytest.raises(SystemExit) as excinfo:
+                app.main()
+            assert excinfo.value.code == 2
+            assert any('shown-anyway' in r.message for r in captured_logs.records)
+        finally:
+            boxman_logger.setLevel(previous)

--- a/tests/test_boxman_conf.py
+++ b/tests/test_boxman_conf.py
@@ -2,6 +2,7 @@
 Test that --boxman-conf overrides the default ~/.config/boxman/boxman.yml.
 """
 
+import logging
 import os
 import tempfile
 import yaml
@@ -10,6 +11,7 @@ import shutil as _shutil
 
 from boxman.scripts.app import load_boxman_config
 from boxman.manager import BoxmanManager
+from boxman.exceptions import ConfigError
 
 
 class TestBoxmanConfOverride:
@@ -823,3 +825,186 @@ class TestNormalizeOwnership:
         assert "sudo rm -rf" in msg
         assert str(tmp_path) in msg
         assert "password is required" in msg
+
+
+class TestConfigSchemaV2:
+    """
+    Config schema versioning — Phase 2 of the docker-compose provider epic
+    (https://github.com/mherkazandjian/boxman/issues/50).
+
+    ``BoxmanManager.load_config`` dispatches on the top-level ``version:``
+    key and normalizes v2.0 configs into the internal (v1.0) shape:
+    libvirt clusters get ``boxes:`` renamed to ``vms:``; docker-compose
+    clusters keep ``boxes:``; unsupported versions / ambiguous clusters
+    raise :class:`ConfigError`. v1.0 stays byte-identical.
+    """
+
+    @staticmethod
+    def _mgr():
+        return BoxmanManager()
+
+    @staticmethod
+    def _cfg(version=None, top_provider='libvirt', cluster=None):
+        cfg = {'project': 'p', 'clusters': {'c': cluster or {}}}
+        if version is not None:
+            cfg['version'] = version
+        if top_provider is not None:
+            cfg['provider'] = {top_provider: {}}
+        return cfg
+
+    # --- v1.0: unchanged --------------------------------------------------
+
+    def test_v1_no_version_key_returns_unchanged(self):
+        cfg = self._cfg(cluster={'vms': {'v1': {'hostname': 'v1'}}})
+        out = self._mgr()._apply_config_version(cfg)
+        assert out is cfg
+        assert out['clusters']['c'] == {'vms': {'v1': {'hostname': 'v1'}}}
+
+    def test_v1_explicit_version_returns_unchanged(self):
+        cfg = self._cfg(version='1.0', cluster={'vms': {'v1': {}}})
+        out = self._mgr()._apply_config_version(cfg)
+        assert 'vms' in out['clusters']['c']
+        assert 'boxes' not in out['clusters']['c']
+
+    def test_v1_boxes_key_warns(self, captured_logs):
+        cfg = self._cfg(version='1.0', cluster={'boxes': {'b1': {}}})
+        with captured_logs.at_level(logging.WARNING, logger='boxman'):
+            self._mgr()._apply_config_version(cfg)
+        assert any(
+            "boxes" in r.message and "2.0" in r.message
+            for r in captured_logs.records
+        )
+
+    def test_empty_config_is_tolerated(self):
+        assert self._mgr()._apply_config_version(None) is None
+        assert self._mgr()._apply_config_version({}) == {}
+
+    # --- v2.0 libvirt: boxes -> vms --------------------------------------
+
+    def test_v2_libvirt_boxes_renamed_to_vms(self):
+        cfg = self._cfg(version='2.0', top_provider='libvirt',
+                        cluster={'boxes': {'node01': {'hostname': 'node01'}}})
+        out = self._mgr().normalize_v2_config(cfg)
+        assert out['clusters']['c']['vms'] == {'node01': {'hostname': 'node01'}}
+        assert 'boxes' not in out['clusters']['c']
+
+    def test_v2_libvirt_only_equals_v1_shape(self):
+        """AC: a v2.0 libvirt-only config normalizes to the exact internal
+        shape of its v1.0 equivalent."""
+        v2 = self._cfg(version='2.0', cluster={'boxes': {'n': {'memory': 2048}}})
+        v1 = self._cfg(version='1.0', cluster={'vms': {'n': {'memory': 2048}}})
+        out2 = self._mgr()._apply_config_version(v2)
+        out1 = self._mgr()._apply_config_version(v1)
+        assert out2['clusters'] == out1['clusters']
+
+    def test_v2_libvirt_vms_accepted_with_warning(self, captured_logs):
+        cfg = self._cfg(version='2.0', top_provider='libvirt',
+                        cluster={'vms': {'n': {}}})
+        with captured_logs.at_level(logging.WARNING, logger='boxman'):
+            out = self._mgr()._apply_config_version(cfg)
+        assert out['clusters']['c']['vms'] == {'n': {}}
+        assert any(
+            "legacy 'vms:'" in r.message or "vms:" in r.message
+            for r in captured_logs.records if r.levelno >= logging.WARNING
+        )
+
+    def test_v2_libvirt_boxes_and_vms_is_error(self):
+        cfg = self._cfg(version='2.0', top_provider='libvirt',
+                        cluster={'boxes': {}, 'vms': {}})
+        with pytest.raises(ConfigError, match=r"both 'boxes:' and 'vms:'"):
+            self._mgr()._apply_config_version(cfg)
+
+    # --- v2.0 docker-compose: boxes kept ---------------------------------
+
+    def test_v2_docker_compose_keeps_boxes(self):
+        cfg = self._cfg(version='2.0', top_provider='docker-compose',
+                        cluster={'provider': 'docker-compose',
+                                 'boxes': {'web': {'image': 'nginx'}}})
+        out = self._mgr().normalize_v2_config(cfg)
+        assert out['clusters']['c']['boxes'] == {'web': {'image': 'nginx'}}
+        assert 'vms' not in out['clusters']['c']
+
+    def test_v2_docker_compose_vms_is_error(self):
+        cfg = self._cfg(version='2.0', top_provider='docker-compose',
+                        cluster={'provider': 'docker-compose', 'vms': {}})
+        with pytest.raises(ConfigError, match=r"must use 'boxes:', not 'vms:'"):
+            self._mgr()._apply_config_version(cfg)
+
+    # --- per-cluster provider defaulting to the top-level primary --------
+
+    def test_v2_cluster_without_provider_uses_libvirt_primary(self):
+        """Top-level primary is libvirt → an un-annotated cluster is
+        libvirt → boxes renamed to vms."""
+        cfg = self._cfg(version='2.0', top_provider='libvirt',
+                        cluster={'boxes': {'n': {}}})
+        out = self._mgr().normalize_v2_config(cfg)
+        assert 'vms' in out['clusters']['c']
+
+    def test_v2_cluster_without_provider_uses_dc_primary(self):
+        """Top-level primary is docker-compose → an un-annotated cluster is
+        docker-compose → boxes kept as-is."""
+        cfg = self._cfg(version='2.0', top_provider='docker-compose',
+                        cluster={'boxes': {'web': {}}})
+        out = self._mgr().normalize_v2_config(cfg)
+        assert 'boxes' in out['clusters']['c']
+        assert 'vms' not in out['clusters']['c']
+
+    # --- unsupported version ---------------------------------------------
+
+    def test_unsupported_version_raises(self):
+        cfg = self._cfg(version='3.0', cluster={'vms': {}})
+        with pytest.raises(ConfigError, match=r"unsupported config version: '3.0'"):
+            self._mgr()._apply_config_version(cfg)
+
+    def test_unsupported_version_lists_supported(self):
+        cfg = self._cfg(version='banana', cluster={})
+        with pytest.raises(ConfigError, match=r"'1.0', '2.0'"):
+            self._mgr()._apply_config_version(cfg)
+
+    # --- end-to-end through load_config ----------------------------------
+
+    def test_load_config_normalizes_v2_and_writes_rendered(self, tmp_path):
+        conf = {
+            'version': '2.0',
+            'project': 'e2e',
+            'provider': {'libvirt': {'uri': 'qemu:///system'}},
+            'clusters': {'compute': {'boxes': {'node01': {'hostname': 'node01'}}}},
+        }
+        path = tmp_path / 'conf.yml'
+        path.write_text(yaml.dump(conf))
+
+        mgr = BoxmanManager()
+        loaded = mgr.load_config(str(path))
+
+        # v2.0 boxes: normalized to internal vms:
+        assert loaded['clusters']['compute']['vms'] == {'node01': {'hostname': 'node01'}}
+        assert 'boxes' not in loaded['clusters']['compute']
+        # AC: the .rendered.yml debug dump is still written
+        assert (tmp_path / 'conf.rendered.yml').exists()
+
+    def test_load_config_dollar_var_survives_preprocessing(self, tmp_path):
+        """A docker-compose ``${VAR}`` interpolation must survive the bare
+        ``{{ name }}`` -> ``{name}`` task-placeholder preprocessing."""
+        conf = {
+            'version': '2.0',
+            'project': 'compose_env',
+            'provider': {'docker-compose': {}},
+            'clusters': {
+                'services': {
+                    'provider': 'docker-compose',
+                    'boxes': {
+                        'web': {
+                            'image': 'nginx',
+                            'environment': ['DB_HOST=${DB_HOST}', 'ESC=$${LITERAL}'],
+                        }
+                    },
+                }
+            },
+        }
+        path = tmp_path / 'conf.yml'
+        path.write_text(yaml.dump(conf))
+
+        loaded = BoxmanManager().load_config(str(path))
+        env = loaded['clusters']['services']['boxes']['web']['environment']
+        assert 'DB_HOST=${DB_HOST}' in env
+        assert 'ESC=$${LITERAL}' in env


### PR DESCRIPTION
## Phase 2 — config schema v2.0 (#50)

Part of the docker-compose provider epic (#42). Blocked by #49 (merged). Targets `feat/docker-compose-provider`.

### What
Adds versioned configs so a single project can eventually mix libvirt and docker-compose clusters, **without touching v1.0 behaviour**:

- **`version:` key** — absent or `'1.0'` → unchanged; `'2.0'` → normalized; anything else → clean `ConfigError` (exit 2).
- **`boxes:`** as the generic per-cluster key. `BoxmanManager.load_config` normalizes `boxes → vms` for libvirt clusters **once, right after YAML parse**, so all **35** existing `cluster['vms']` consumers are untouched.
- **Per-cluster `provider:`** — already honoured by Phase 1's `provider_type_for_cluster`; now official, validated, and documented. Defaults to the top-level primary provider.

### Compatibility matrix (enforced in `normalize_v2_config`)
| cluster provider | `boxes:` | `vms:` | result |
|---|:---:|:---:|---|
| libvirt | ✓ | – | renamed to `vms:` |
| libvirt | – | ✓ | accepted + deprecation warning |
| libvirt | ✓ | ✓ | `ConfigError` (ambiguous) |
| docker-compose | ✓ | – | kept as-is (Phase 3 consumes it) |
| docker-compose | – | ✓ | `ConfigError` |

A `boxes:` key in a **v1.0** config gets a log-only warning (v1.0 provisioning stays byte-identical).

### Changes
- `manager.py`: `_apply_config_version` + `normalize_v2_config` (+ a v1.0 `boxes:` nudge), called at the end of `load_config`. The `.rendered.yml` dump (raw rendered text) is unchanged.
- `app.py`: `main()` is now a thin wrapper turning `ConfigError` into `log.error` + exit 2 (purely additive — nothing else raises `ConfigError`); body moved verbatim to `_main()`.
- `doc/docker-compose-provider/config-schema.md`: version detection, boxes/vms, per-cluster provider, compat matrix, and the `${VAR}`-safe / bare-`{{ word }}`-unsafe templating caveat for compose values.
- `tests/test_boxman_conf.py`: `TestConfigSchemaV2` (+16).

### Acceptance criteria (#50)
- [x] v1.0 configs: byte-identical behaviour
- [x] v2.0 libvirt-only config behaves exactly like its v1.0 equivalent
- [x] `.rendered.yml` debug dump still written

### Verification
- Full non-integration suite **1145 passed** (1129 + 16 new) on **both** the host and the boxman-provisioned staging VM.
- **Live smoke** against the real staging project: a `boxes:`-keyed v2.0 copy of the staging conf → `snapshot list` resolved the real libvirt domain and `pristine` snapshot via `virsh -c qemu:///system` (proves the normalized v2.0 path drives the identical libvirt resolution as v1.0); `boxman conf` shows the on-disk `boxes:` (fidelity view of the rendered template, by design).

### Known deferral
Structure-aware templating exemption for compose `environment:`/`command:` blocks (bare `{{ word }}` corruption) → **Phase 3**, where those values are actually consumed. Documented in `config-schema.md`; `${VAR}`/`$${VAR}` interpolation is safe today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
