### PR TITLE
feat(docker-compose): DockerComposeSession core lifecycle (#51)

### DIFF
--- a/doc/docker-compose-provider/config-schema.md
+++ b/doc/docker-compose-provider/config-schema.md
@@ -75,14 +75,41 @@ A v1.0 config that uses `boxes:` gets a one-line warning (nothing reads
 partial migration that still has a sibling `vms:`) — provisioning behaviour
 is unchanged.
 
-### Not yet runnable: docker-compose / mixed configs
+### Running docker-compose clusters (Phase 3, #51)
 
-A v2.0 config with a docker-compose cluster **parses and normalizes**, but
-is **not runnable until Phase 3** (`DockerComposeSession`). Running
-`boxman provision` / `up` on one exits **2** at session build with the
-friendly "docker-compose provider … lands in Phase 3 (#51)" message (the
-registry has no docker-compose session yet), rather than provisioning
-anything. Pure-libvirt v2.0 configs are fully runnable.
+A v2.0 config with a docker-compose cluster is **runnable**: `boxman
+provision` / `up` generate a `docker-compose.yml` in the cluster `workdir`
+and run `docker compose up -d --wait`, and `down` / `deprovision` / `destroy`
+tear it down. Phase 3 scope is **cluster-internal bridge networks only** —
+`shared_networks` (L2 to VMs) lands in Phase 4, structured `volumes:` in
+Phase 5, ssh/exec/inventory in Phase 6, snapshots in Phase 7. Box features
+outside this scope are warned about and skipped (use `compose_extra:` as the
+escape hatch).
+
+Two hard requirements, both enforced fail-fast (exit 2):
+
+- **`version: '2.0'` is required.** A docker-compose cluster consumes
+  `boxes:`, which v1.0 ignores (see [`_warn_on_v1_boxes`](#) above) — so a
+  v1.0 / versionless config whose primary or per-cluster provider resolves to
+  `docker-compose` is **rejected** (rather than silently provisioning services
+  the v1.0 `boxes:` nudge — see above — says are ignored).
+- **`runtime: local` is required** (see next section).
+
+### Provider vs runtime — two independent axes
+
+`provider:` (per-cluster, this document) selects *what* provisions a cluster
+(`libvirt` vs `docker-compose`). `--runtime` / the app-config `runtime:` key
+selects *where boxman's commands execute*: `local` (directly on the host) or
+`docker` (a.k.a. `docker-compose` — **libvirt inside a container**, used to
+run the libvirt provider without host libvirt). These are unrelated.
+
+The **docker-compose provider requires `runtime: local`**: it shells out to
+`docker compose` on the host directly. Pairing it with the `docker` runtime
+(libvirt-in-a-container) is a configuration error and boxman exits 2 at
+session build. Note this fail-fast fires for **every** subcommand, so a
+project that adds a docker-compose cluster to an existing libvirt-in-docker
+runtime can no longer run *anything* (including `destroy`) until the runtime
+is switched to `local` — an intentional, if blunt, consequence.
 
 ### Why `boxman conf` still shows `boxes:`
 
@@ -111,8 +138,13 @@ Safe / unsafe forms inside a compose `environment:` or `command:` value:
 
 **Rule of thumb:** in docker-compose clusters, use `${VAR}` /
 `$${VAR}` for interpolation and never a bare single-word `{{ word }}`.
-(A structure-aware exemption for compose blocks is deferred to Phase 3,
-where these values are actually consumed.)
+
+**Phase 3 status:** a full structure-aware exemption is still out of scope,
+but the generator now **warns** when a compose `environment:` / `command:`
+value carries the `{word}` corruption signature (a mangled bare
+`{{ word }}`), so the silent-corruption trap surfaces at generate time
+instead of reaching the container. `${VAR}` / `$${VAR}` are unaffected and
+produce no warning.
 
 ## Examples
 

--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -233,6 +233,36 @@ class BoxmanManager:
             return self.provider
         return self.session_for_cluster(cluster_name)
 
+    def _is_compose_cluster(self, cluster_name: str) -> bool:
+        """True if *cluster_name* is provisioned by the docker-compose provider."""
+        return self.provider_type_for_cluster(cluster_name) == 'docker-compose'
+
+    @property
+    def _vm_clusters(self) -> dict[str, Any]:
+        """
+        Clusters handled by a **per-VM** provider (libvirt).
+
+        The manager's per-VM / per-network lifecycle helpers iterate this
+        instead of ``config['clusters']`` so docker-compose clusters (which
+        carry ``boxes:``, not ``vms:``, and are provisioned coarsely via the
+        ``*_compose_clusters`` helpers) are never fed into the per-VM loops.
+        For a libvirt-only project this is exactly ``config['clusters']``, so
+        behaviour is unchanged.
+        """
+        return {
+            name: cluster
+            for name, cluster in (self.config.get('clusters') or {}).items()
+            if not self._is_compose_cluster(name)
+        }
+
+    def _compose_clusters(self) -> dict[str, Any]:
+        """docker-compose clusters, in config order (empty for libvirt-only projects)."""
+        return {
+            name: cluster
+            for name, cluster in (self.config.get('clusters') or {}).items()
+            if self._is_compose_cluster(name)
+        }
+
     def _vm_cluster_map(self) -> dict[str, str]:
         """
         Map every full VM name of this project to its cluster name.
@@ -2370,6 +2400,38 @@ class BoxmanManager:
         netlab.render_topology(source_root=source_root)
         netlab.ensure_up()
 
+    # --- docker-compose clusters: coarse per-cluster lifecycle ------------
+    # docker-compose is cluster-scoped (one `docker compose up --wait` per
+    # cluster, ADR-001/D1). Rather than the per-VM libvirt loops, the manager
+    # dispatches a whole dc cluster to its session's coarse methods. These
+    # helpers are no-ops for libvirt-only projects (``_compose_clusters()``
+    # is empty).
+
+    def provision_compose_clusters(self) -> None:
+        """``docker compose up --wait`` every docker-compose cluster."""
+        for cluster_name, cluster in self._compose_clusters().items():
+            self.session_for_cluster(cluster_name).up_cluster(cluster_name, cluster)
+
+    def stop_compose_clusters(self) -> None:
+        """``docker compose stop`` every docker-compose cluster (boxman down)."""
+        for cluster_name, cluster in self._compose_clusters().items():
+            self.session_for_cluster(cluster_name).stop_cluster(cluster_name, cluster)
+
+    def start_compose_clusters(self) -> None:
+        """``docker compose start`` every docker-compose cluster."""
+        for cluster_name, cluster in self._compose_clusters().items():
+            self.session_for_cluster(cluster_name).start_cluster(cluster_name, cluster)
+
+    def deprovision_compose_clusters(self) -> None:
+        """``docker compose down`` every docker-compose cluster (keep volumes)."""
+        for cluster_name, cluster in self._compose_clusters().items():
+            self.session_for_cluster(cluster_name).down_cluster(cluster_name, cluster)
+
+    def destroy_compose_clusters(self) -> None:
+        """``docker compose down --volumes`` every docker-compose cluster."""
+        for cluster_name, cluster in self._compose_clusters().items():
+            self.session_for_cluster(cluster_name).destroy_cluster(cluster_name, cluster)
+
     def define_networks(self) -> None:
         """
         Define the networks specified in the cluster configuration (sequential).
@@ -2380,7 +2442,7 @@ class BoxmanManager:
         otherwise two concurrent processes can both select the same bridge index
         and the second net-define fails with "bridge name already in use".
         """
-        for cluster_name, cluster in self.config['clusters'].items():
+        for cluster_name, cluster in self._vm_clusters.items():
             for network_name, network_info in cluster.get('networks', {}).items():
                 _network_name = self.full_network_name(
                     project_config=self.config,
@@ -2417,7 +2479,7 @@ class BoxmanManager:
 
         processes = [
             Process(target=_destroy, args=(cluster_name, cluster, network_name, network_info))
-            for cluster_name, cluster in self.config['clusters'].items()
+            for cluster_name, cluster in self._vm_clusters.items()
             for network_name, network_info in cluster.get('networks', {}).items()
         ]
         [p.start() for p in processes]
@@ -2461,7 +2523,7 @@ class BoxmanManager:
         """
         def vm_clone_tasks():
             prj_name = f'bprj__{self.config["project"]}__bprj'
-            for cluster_name, cluster in self.config['clusters'].items():
+            for cluster_name, cluster in self._vm_clusters.items():
                 for vm_name, vm_info in cluster['vms'].items():
                     vm_info = vm_info.copy()
                     new_vm_name = f"{prj_name}_{cluster_name}_{vm_name}"
@@ -2472,7 +2534,7 @@ class BoxmanManager:
         # directory; doing it here sequentially prevents the race condition
         # where N parallel processes all try to define the same pool at once.
         seen_workdirs: set = set()
-        for cluster_name, cluster in self.config['clusters'].items():
+        for cluster_name, cluster in self._vm_clusters.items():
             workdir = os.path.abspath(os.path.expanduser(cluster['workdir']))
             if workdir not in seen_workdirs:
                 seen_workdirs.add(workdir)
@@ -2552,7 +2614,7 @@ class BoxmanManager:
         """
         prj_name = f'bprj__{self.config["project"]}__bprj'
         def vm_destroy_tasks():
-            for cluster_name, cluster in self.config['clusters'].items():
+            for cluster_name, cluster in self._vm_clusters.items():
                 for vm_name in cluster['vms'].keys():
                     full_vm_name = f"{prj_name}_{cluster_name}_{vm_name}"
                     yield full_vm_name, cluster_name, vm_name
@@ -2729,7 +2791,7 @@ class BoxmanManager:
                 target=self._configure_and_start_vm,
                 args=(cluster_name, cluster, vm_name, vm_info)
             )
-            for cluster_name, cluster in self.config['clusters'].items()
+            for cluster_name, cluster in self._vm_clusters.items()
             for vm_name, vm_info in cluster['vms'].items()
         ]
         [p.start() for p in processes]
@@ -2740,7 +2802,7 @@ class BoxmanManager:
     def configure_network_interfaces(self) -> None:
         """Configure network interfaces for all VMs (sequential)."""
         prj_name = f'bprj__{self.config["project"]}__bprj'
-        for cluster_name, cluster in self.config['clusters'].items():
+        for cluster_name, cluster in self._vm_clusters.items():
             for vm_name, vm_info in cluster['vms'].items():
                 full_vm_name = f"{prj_name}_{cluster_name}_{vm_name}"
                 vm_info = vm_info.copy()
@@ -2765,7 +2827,7 @@ class BoxmanManager:
     def configure_disks(self) -> None:
         """Configure disks for all VMs (sequential)."""
         prj_name = f'bprj__{self.config["project"]}__bprj'
-        for cluster_name, cluster in self.config['clusters'].items():
+        for cluster_name, cluster in self._vm_clusters.items():
             workdir = cluster.get('workdir', '.')
             for vm_name, vm_info in cluster['vms'].items():
                 full_vm_name = f"{prj_name}_{cluster_name}_{vm_name}"
@@ -2786,7 +2848,7 @@ class BoxmanManager:
     def configure_cpu_mem(self) -> None:
         """Configure CPU and memory for all VMs (sequential)."""
         prj_name = f'bprj__{self.config["project"]}__bprj'
-        for cluster_name, cluster in self.config['clusters'].items():
+        for cluster_name, cluster in self._vm_clusters.items():
             for vm_name, vm_info in cluster['vms'].items():
                 full_vm_name = f"{prj_name}_{cluster_name}_{vm_name}"
                 self.logger.info(
@@ -2808,7 +2870,7 @@ class BoxmanManager:
     def start_vms(self) -> None:
         """Start all VMs (sequential)."""
         prj_name = f'bprj__{self.config["project"]}__bprj'
-        for cluster_name, cluster in self.config['clusters'].items():
+        for cluster_name, cluster in self._vm_clusters.items():
             for vm_name, vm_info in cluster['vms'].items():
                 full_vm_name = f"{prj_name}_{cluster_name}_{vm_name}"
                 self.logger.info(f"starting vm {full_vm_name}")
@@ -2831,7 +2893,7 @@ class BoxmanManager:
         prj_name = f'bprj__{self.config["project"]}__bprj'
         vm_names = [
             f"{prj_name}_{cluster_name}_{vm_name}"
-            for cluster_name, cluster in self.config['clusters'].items()
+            for cluster_name, cluster in self._vm_clusters.items()
             for vm_name in cluster['vms']
         ]
 
@@ -2865,7 +2927,7 @@ class BoxmanManager:
         ws_path = self.config.get('workspace', {}).get('path', '')
 
         prj_name = f'bprj__{self.config["project"]}__bprj'
-        for cluster_name, cluster in self.config['clusters'].items():
+        for cluster_name, cluster in self._vm_clusters.items():
             self.logger.info(f"cluster: {cluster_name}")
             self.logger.info("-" * 60)
 
@@ -2972,7 +3034,7 @@ class BoxmanManager:
         # blocks — opening 'w' once per cluster would have the later
         # iteration truncate the earlier one's entries.
         groups: dict[str, list[tuple[str, dict, str]]] = {}
-        for cluster_name, cluster in self.config['clusters'].items():
+        for cluster_name, cluster in self._vm_clusters.items():
             base_path = ws_path or cluster.get('workdir', '~')
             ssh_config = os.path.expanduser(os.path.join(
                 base_path,
@@ -3044,7 +3106,7 @@ class BoxmanManager:
         success = True
         ws_path = self.config.get('workspace', {}).get('path', '')
 
-        for _, cluster in self.config['clusters'].items():
+        for _, cluster in self._vm_clusters.items():
             base_path = os.path.expanduser(ws_path or cluster['workdir'])
             admin_key_name = cluster.get('admin_key_name', 'id_ed25519_boxman')
 
@@ -3155,7 +3217,7 @@ class BoxmanManager:
         ws_path = self.config.get('workspace', {}).get('path', '')
 
         prj_name = f'bprj__{self.config["project"]}__bprj'
-        for cluster_name, cluster in self.config['clusters'].items():
+        for cluster_name, cluster in self._vm_clusters.items():
             base_path = os.path.expanduser(ws_path or cluster['workdir'])
             admin_key_name = cluster.get('admin_key_name', 'id_ed25519_boxman')
             admin_pub_key = os.path.join(base_path, f"{admin_key_name}.pub")
@@ -3343,7 +3405,7 @@ class BoxmanManager:
         """
         # write global authorized keys so they can be consumed by container
         # entrypoints or cloud-init scripts
-        for _, cluster in self.config['clusters'].items():
+        for _, cluster in self._vm_clusters.items():
             workdir = os.path.expanduser(cluster['workdir'])
             global_keys_path = os.path.join(workdir, 'global_authorized_keys')
             self.write_global_authorized_keys_file(global_keys_path)
@@ -3631,7 +3693,7 @@ class BoxmanManager:
         # backing chain issues and tray-lock errors on subsequent snapshots.
         cls.logger.info("ejecting cdrom (seed.iso) from all VMs post-provisioning...")
         prj_name = f'bprj__{config["project"]}__bprj'
-        for _cluster_name, _cluster in config['clusters'].items():
+        for _cluster_name, _cluster in cls._vm_clusters.items():
             for _vm_name, _ in _cluster['vms'].items():
                 _full_vm_name = f"{prj_name}_{_cluster_name}_{_vm_name}"
                 cls.session_for_cluster(_cluster_name).eject_cdrom(_full_vm_name)
@@ -3641,6 +3703,10 @@ class BoxmanManager:
 
         # display connection information (after ssh setup so connections are ready)
         cls.connect_info()
+
+        # bring up docker-compose clusters (no-op for libvirt-only projects);
+        # after libvirt VMs, mirroring the netlab hook's "extra infra last" order
+        cls.provision_compose_clusters()
 
         # render and deploy the containerlab topology (no-op if not configured)
         cls.deploy_netlab()
@@ -3664,6 +3730,13 @@ class BoxmanManager:
         expected_vms = cls._get_project_vm_names()
 
         if not expected_vms:
+            # No libvirt VMs. A docker-compose-only project still has work to
+            # do: (idempotently) bring up its compose clusters. `up_cluster`
+            # is `docker compose up -d --wait`, which starts stopped containers
+            # and no-ops when everything is already running.
+            if cls._compose_clusters():
+                cls.provision_compose_clusters()
+                return
             cls.logger.error("no VMs defined in configuration")
             return
 
@@ -3710,6 +3783,9 @@ class BoxmanManager:
             # even though the VMs stayed up.
             cls.ensure_shared_bridges()
             cls.ensure_netlab_up()
+            # Reconcile docker-compose clusters too: a host reboot or manual
+            # `docker compose stop` may have left them down (idempotent).
+            cls.provision_compose_clusters()
             cls.connect_info()
             # Re-write SSH config in case IPs changed (DHCP renewals after
             # a host reboot, manual virsh net cycle, etc.) or in case the
@@ -3793,6 +3869,9 @@ class BoxmanManager:
         # shared bridges have live endpoints on both sides.
         cls.ensure_netlab_up()
 
+        # Bring up docker-compose clusters after the VMs are up (idempotent).
+        cls.provision_compose_clusters()
+
         # Display connection information
         cls.connect_info()
 
@@ -3820,14 +3899,15 @@ class BoxmanManager:
 
         vm_list = cls.process_vm_list(cli_args)
 
-        if not vm_list:
+        if not vm_list and not cls._compose_clusters():
             cls.logger.info("no VMs found in configuration")
             return
 
         use_suspend = getattr(cli_args, 'suspend', False)
 
         if use_suspend:
-            cls.logger.info("suspending all VMs (--suspend)...")
+            if vm_list:
+                cls.logger.info("suspending all VMs (--suspend)...")
 
             def _suspend(vm_name):
                 cls.logger.info(f"suspending VM '{vm_name}'...")
@@ -3839,7 +3919,8 @@ class BoxmanManager:
                 for vm_name, _ in vm_list
             ]
         else:
-            cls.logger.info("saving the state of all VMs to disk...")
+            if vm_list:
+                cls.logger.info("saving the state of all VMs to disk...")
 
             def _save(vm_name, workdir):
                 cls.logger.info(f"saving VM '{vm_name}' state to '{workdir}'...")
@@ -3853,6 +3934,9 @@ class BoxmanManager:
 
         [p.start() for p in processes]
         [p.join() for p in processes]
+
+        # Stop docker-compose clusters (keep containers; reversible via `up`).
+        cls.stop_compose_clusters()
 
         cls.logger.info("infrastructure is down")
 
@@ -3870,12 +3954,16 @@ class BoxmanManager:
         # shared bridges before we touch libvirt state.
         cls.destroy_netlab()
 
+        # Tear down docker-compose clusters (`docker compose down`: remove
+        # containers + networks, keep named volumes) before libvirt state.
+        cls.deprovision_compose_clusters()
+
         processes = [
             Process(
                 target=cls._destroy_vm_and_disks,
                 args=(cluster_name, cluster, vm_name, vm_info)
             )
-            for cluster_name, cluster in cls.config['clusters'].items()
+            for cluster_name, cluster in cls._vm_clusters.items()
             for vm_name, vm_info in cluster['vms'].items()
         ]
         [p.start() for p in processes]
@@ -4124,6 +4212,17 @@ class BoxmanManager:
             except Exception as exc:
                 cls.logger.warning(f"deprovision raised: {exc} — continuing")
 
+        # 2b. fully tear down docker-compose clusters — destroy goes beyond
+        #     deprovision's `docker compose down` (keeps named volumes) to
+        #     `down --volumes` and removes the generated compose file. Runs
+        #     regardless of the libvirt-in-container runtime state: the
+        #     compose provider shells out to the host docker directly.
+        try:
+            cls.destroy_compose_clusters()
+        except Exception as exc:
+            cls.logger.warning(
+                f"destroy_compose_clusters raised: {exc} — continuing")
+
         # 3. tear down the docker runtime (reuses _force_rmtree for the
         #    .boxman dir, no double prompt)
         if is_docker:
@@ -4160,7 +4259,7 @@ class BoxmanManager:
         List snapshots of the VMs in the cluster.
         """
         prj_name = f'bprj__{cls.config["project"]}__bprj'
-        for cluster_name, cluster in cls.config['clusters'].items():
+        for cluster_name, cluster in cls._vm_clusters.items():
             for vm_name, _ in cluster['vms'].items():
                 full_vm_name = f"{prj_name}_{cluster_name}_{vm_name}"
                 cls.session_for_cluster(cluster_name).snapshot_list(full_vm_name)
@@ -4185,7 +4284,7 @@ class BoxmanManager:
 
         # 1. Per-VM data.
         per_vm: dict[str, dict] = {}
-        for cluster_name, cluster in cls.config['clusters'].items():
+        for cluster_name, cluster in cls._vm_clusters.items():
             for vm_name, _ in cluster['vms'].items():
                 full_vm_name = f"{prj_name}_{cluster_name}_{vm_name}"
                 data = cls.session_for_cluster(cluster_name).snapshot_log_data(full_vm_name)
@@ -4608,7 +4707,7 @@ class BoxmanManager:
     def _storage_targets(cls, cli_args=None):
         """Yield ``(full_vm_name, workdir, vm_info)`` for every VM in every cluster."""
         prj_name = f'bprj__{cls.config["project"]}__bprj'
-        for cluster_name, cluster in cls.config['clusters'].items():
+        for cluster_name, cluster in cls._vm_clusters.items():
             workdir = os.path.expanduser(cluster['workdir'])
             for vm_name, vm_info in cluster['vms'].items():
                 full_vm_name = f"{prj_name}_{cluster_name}_{vm_name}"
@@ -4832,7 +4931,7 @@ class BoxmanManager:
         """
         retval = []
         prj_name = f'bprj__{self.config["project"]}__bprj'
-        for cluster_name, cluster in self.config['clusters'].items():
+        for cluster_name, cluster in self._vm_clusters.items():
             workdir = os.path.expanduser(cluster['workdir'])
             for vm_name, _ in cluster['vms'].items():
                 full_vm_name = f"{prj_name}_{cluster_name}_{vm_name}"
@@ -5229,7 +5328,7 @@ class BoxmanManager:
 
         # pre-define storage pools for workdirs of new VMs
         seen_workdirs: set = set()
-        for cluster_name, cluster in self.config['clusters'].items():
+        for cluster_name, cluster in self._vm_clusters.items():
             for vm_name in cluster['vms']:
                 full = f"{prj_name}_{cluster_name}_{vm_name}"
                 if full in new_vm_names:
@@ -5277,7 +5376,7 @@ class BoxmanManager:
         # and the configure/start step below see the resolved values
         self._resolve_iso_config()
         clone_tasks = []
-        for cluster_name, cluster in self.config['clusters'].items():
+        for cluster_name, cluster in self._vm_clusters.items():
             for vm_name, vm_info in cluster['vms'].items():
                 full = f"{prj_name}_{cluster_name}_{vm_name}"
                 if full in new_vm_names:
@@ -5306,7 +5405,7 @@ class BoxmanManager:
 
         # configure and start new VMs (parallel)
         configure_tasks = []
-        for cluster_name, cluster in self.config['clusters'].items():
+        for cluster_name, cluster in self._vm_clusters.items():
             for vm_name, vm_info in cluster['vms'].items():
                 full = f"{prj_name}_{cluster_name}_{vm_name}"
                 if full in new_vm_names:
@@ -5644,7 +5743,7 @@ class BoxmanManager:
             result_queue: Queue = Queue()
 
             update_tasks = []
-            for cluster_name, cluster_cfg in config['clusters'].items():
+            for cluster_name, cluster_cfg in cls._vm_clusters.items():
                 for vm_name, vm_info in cluster_cfg['vms'].items():
                     full = f"{prj_name}_{cluster_name}_{vm_name}"
                     if full in update_vm_names:

--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -255,8 +255,10 @@ class BoxmanManager:
             if not self._is_compose_cluster(name)
         }
 
+    @property
     def _compose_clusters(self) -> dict[str, Any]:
-        """docker-compose clusters, in config order (empty for libvirt-only projects)."""
+        """docker-compose clusters, in config order (empty for libvirt-only
+        projects). A ``@property`` for symmetry with :attr:`_vm_clusters`."""
         return {
             name: cluster
             for name, cluster in (self.config.get('clusters') or {}).items()
@@ -507,6 +509,7 @@ class BoxmanManager:
 
         version = str(conf.get('version', '1.0')).strip()
         if version in ('1', '1.0'):
+            self._reject_v1_docker_compose(conf)
             self._warn_on_v1_boxes(conf)
             return conf
         if version in ('2', '2.0'):
@@ -516,6 +519,35 @@ class BoxmanManager:
             f"unsupported config version: '{version}' "
             f"(supported: '1.0', '2.0')"
         )
+
+    def _reject_v1_docker_compose(self, conf: dict[str, Any]) -> None:
+        """
+        Reject a v1.0 / versionless config that resolves any cluster to the
+        docker-compose provider.
+
+        The docker-compose provider consumes ``boxes:``, which v1.0 ignores
+        (see :meth:`_warn_on_v1_boxes`). Without this guard the cluster would
+        be picked up by ``_compose_clusters`` and provisioned into live
+        services *despite* the v1 nudge telling the user those boxes are
+        ignored — the warning and the behaviour would contradict. The
+        provider is new in this epic, so no legitimate v1 config uses it;
+        failing fast with a clear message is safe.
+
+        Raises:
+            ConfigError: If a cluster's effective provider (per-cluster
+                ``provider:`` or the primary provider) is ``docker-compose``.
+        """
+        for cluster_name, cluster in (conf.get('clusters') or {}).items():
+            if not isinstance(cluster, dict):
+                continue
+            provider = cluster.get('provider') or primary_provider_type(conf)
+            if provider == 'docker-compose':
+                raise ConfigError(
+                    f"cluster '{cluster_name}' uses the docker-compose "
+                    f"provider, which requires version: '2.0' (docker-compose "
+                    f"clusters consume 'boxes:', ignored under v1.0). Add "
+                    f"\"version: '2.0'\" to the config."
+                )
 
     def _warn_on_v1_boxes(self, conf: dict[str, Any]) -> None:
         """
@@ -2409,27 +2441,62 @@ class BoxmanManager:
 
     def provision_compose_clusters(self) -> None:
         """``docker compose up --wait`` every docker-compose cluster."""
-        for cluster_name, cluster in self._compose_clusters().items():
+        self._reject_compose_project_collisions()
+        for cluster_name, cluster in self._compose_clusters.items():
             self.session_for_cluster(cluster_name).up_cluster(cluster_name, cluster)
+
+    def _reject_compose_project_collisions(self) -> None:
+        """
+        Reject two docker-compose clusters whose sanitized ``docker compose``
+        project names collide (e.g. ``web.api`` and ``web_api`` both →
+        ``<base>_web_api``, or case-only differences).
+
+        Colliding clusters would share compose state; teardown runs
+        ``docker compose down --remove-orphans``, so tearing one down could
+        delete the sibling's containers. Fail fast at provision — before any
+        compose state exists — with an actionable message.
+
+        Raises:
+            ConfigError: If any two dc clusters map to the same project name.
+        """
+        seen: dict[str, str] = {}
+        for cluster_name in self._compose_clusters:
+            proj = self.session_for_cluster(cluster_name).compose_project_name(
+                cluster_name)
+            if proj in seen:
+                raise ConfigError(
+                    f"clusters '{seen[proj]}' and '{cluster_name}' both map to "
+                    f"docker compose project '{proj}' — rename one so their "
+                    f"compose state can't collide (teardown uses "
+                    f"--remove-orphans)."
+                )
+            seen[proj] = cluster_name
 
     def stop_compose_clusters(self) -> None:
         """``docker compose stop`` every docker-compose cluster (boxman down)."""
-        for cluster_name, cluster in self._compose_clusters().items():
+        for cluster_name, cluster in self._compose_clusters.items():
             self.session_for_cluster(cluster_name).stop_cluster(cluster_name, cluster)
 
     def start_compose_clusters(self) -> None:
-        """``docker compose start`` every docker-compose cluster."""
-        for cluster_name, cluster in self._compose_clusters().items():
+        """``docker compose start`` every docker-compose cluster.
+
+        Reserved API surface for the later control-verb phase (a cheaper,
+        no-recreate ``start`` after ``stop``). Not wired into a flow yet:
+        ``up``-after-``down`` currently reconciles via
+        :meth:`provision_compose_clusters` (``up -d --wait``), which also
+        starts stopped containers and re-asserts readiness.
+        """
+        for cluster_name, cluster in self._compose_clusters.items():
             self.session_for_cluster(cluster_name).start_cluster(cluster_name, cluster)
 
     def deprovision_compose_clusters(self) -> None:
         """``docker compose down`` every docker-compose cluster (keep volumes)."""
-        for cluster_name, cluster in self._compose_clusters().items():
+        for cluster_name, cluster in self._compose_clusters.items():
             self.session_for_cluster(cluster_name).down_cluster(cluster_name, cluster)
 
     def destroy_compose_clusters(self) -> None:
         """``docker compose down --volumes`` every docker-compose cluster."""
-        for cluster_name, cluster in self._compose_clusters().items():
+        for cluster_name, cluster in self._compose_clusters.items():
             self.session_for_cluster(cluster_name).destroy_cluster(cluster_name, cluster)
 
     def define_networks(self) -> None:
@@ -2487,7 +2554,7 @@ class BoxmanManager:
     ### end networks define / remove / destroy
 
     ### vms define / remove / destroy
-    def _ensure_libvirt_storage_pool(self, workdir: str) -> None:
+    def _ensure_libvirt_storage_pool(self, workdir: str, cluster_name: str) -> None:
         """
         Ensure the libvirt directory storage pool exists for the given workdir.
 
@@ -2496,11 +2563,15 @@ class BoxmanManager:
         the same directory, every process races to define the same pool and all
         but the first fail with "pool already exists". Pre-defining the pool
         here (sequentially, before parallel cloning begins) eliminates the race.
+
+        Uses *cluster_name*'s own libvirt session for the virsh connection so a
+        compose-primary mixed project (where the default ``self.provider`` is
+        the docker-compose session) still targets the configured libvirt
+        URI/runtime instead of silently falling back to local qemu:///system.
         """
         workdir = os.path.abspath(os.path.expanduser(workdir))
         pool_name = os.path.basename(workdir)
-        # Phase 1 (#49): default session — libvirt storage pools by nature.
-        virsh = VirshCommand(self.provider.provider_config)
+        virsh = VirshCommand(self.session_for_cluster(cluster_name).provider_config)
 
         result = virsh.execute("pool-info", pool_name, warn=True)
         if result.ok:
@@ -2538,7 +2609,7 @@ class BoxmanManager:
             workdir = os.path.abspath(os.path.expanduser(cluster['workdir']))
             if workdir not in seen_workdirs:
                 seen_workdirs.add(workdir)
-                self._ensure_libvirt_storage_pool(workdir)
+                self._ensure_libvirt_storage_pool(workdir, cluster_name)
 
         def _clone(cluster, vm_info, new_vm_name):
             max_retries = 5
@@ -3730,12 +3801,23 @@ class BoxmanManager:
         expected_vms = cls._get_project_vm_names()
 
         if not expected_vms:
-            # No libvirt VMs. A docker-compose-only project still has work to
-            # do: (idempotently) bring up its compose clusters. `up_cluster`
-            # is `docker compose up -d --wait`, which starts stopped containers
-            # and no-ops when everything is already running.
-            if cls._compose_clusters():
-                cls.provision_compose_clusters()
+            # No libvirt VMs. A docker-compose-only project still has work to do.
+            if cls._compose_clusters:
+                # A first run (project not yet registered) must go through full
+                # provision() — cache registration, provision_files() (cluster
+                # files: + runtime sentinels) and netlab — exactly like a libvirt
+                # project's first `up` (Case 1 below). provision() ends by calling
+                # provision_compose_clusters(), so the containers come up too. A
+                # subsequent `up` just reconciles the compose clusters (idempotent),
+                # mirroring the libvirt "all running" reconcile path (Case 3).
+                cls.cache.read_projects_cache()
+                project_name = config.get('project')
+                if project_name and project_name in (cls.cache.projects or {}):
+                    cls.provision_compose_clusters()
+                else:
+                    cls.logger.info(
+                        "no existing project state found, running full provision...")
+                    cls.provision(cls, cli_args)
                 return
             cls.logger.error("no VMs defined in configuration")
             return
@@ -3889,6 +3971,12 @@ class BoxmanManager:
         ``boxman control save``). With ``--suspend``, pauses VMs in memory
         instead (same as ``boxman control suspend``).
 
+        docker-compose clusters are always brought down with
+        ``docker compose stop`` (containers kept, reversible via ``up``);
+        ``--suspend`` does not apply to them — compose has no in-memory
+        pause analog wired in this phase, so the flag is a no-op for dc
+        clusters.
+
         Reuses ``process_vm_list()`` and the same provider methods as
         ``boxman control save`` / ``boxman control suspend``.
         """
@@ -3899,7 +3987,7 @@ class BoxmanManager:
 
         vm_list = cls.process_vm_list(cli_args)
 
-        if not vm_list and not cls._compose_clusters():
+        if not vm_list and not cls._compose_clusters:
             cls.logger.info("no VMs found in configuration")
             return
 
@@ -3955,8 +4043,15 @@ class BoxmanManager:
         cls.destroy_netlab()
 
         # Tear down docker-compose clusters (`docker compose down`: remove
-        # containers + networks, keep named volumes) before libvirt state.
-        cls.deprovision_compose_clusters()
+        # containers + networks, keep named volumes). Best-effort, like
+        # destroy's step 2b: a failure here must not abort the libvirt VM /
+        # network / files / cache teardown that follows (deprovision is also
+        # invoked from `provision --force`).
+        try:
+            cls.deprovision_compose_clusters()
+        except Exception as exc:
+            cls.logger.warning(
+                f"deprovision_compose_clusters raised: {exc} — continuing")
 
         processes = [
             Process(
@@ -4132,9 +4227,21 @@ class BoxmanManager:
         templates_present = any(
             os.path.exists(d) for d in template_dirs
         )
+        # docker-compose clusters keep a generated docker-compose.yml in their
+        # workdir until destroy_cluster removes it (only on a successful
+        # teardown). Treat its presence as state to tear down so destroy stays
+        # retryable after the cache entry was lost — the terms above are
+        # otherwise cache-/workspace-/runtime-centric and miss dc state.
+        compose_present = any(
+            os.path.isfile(os.path.join(
+                os.path.expanduser(cluster.get('workdir', '')),
+                'docker-compose.yml'))
+            for cluster in cls._compose_clusters.values()
+            if cluster.get('workdir')
+        )
 
         if not (in_cache or ws_present or boxman_dir_present
-                or container_present or templates_present):
+                or container_present or templates_present or compose_present):
             cls.logger.info(
                 f"nothing to do — project '{project_name or '?'}' "
                 f"is not registered, no workspace dir, no runtime "
@@ -4150,6 +4257,15 @@ class BoxmanManager:
         print(f"  {step}. remove generated provisioning files "
               f"(env.sh, ansible.cfg, inventory, ssh_config, SSH keys)")
         step += 1
+        # Disclose docker-compose named-volume deletion explicitly: destroy runs
+        # `docker compose down --volumes`, which permanently removes named
+        # volumes (declarable via compose_extra) — not obvious from the steps
+        # above, which only mention VMs/networks/files.
+        for _dc_name in cls._compose_clusters:
+            print(f"  {step}. tear down docker-compose cluster '{_dc_name}' "
+                  f"(docker compose down --volumes — removes its containers, "
+                  f"networks AND named volumes)")
+            step += 1
         if is_docker and runtime_plan and runtime_plan["actions"]:
             for action in runtime_plan["actions"]:
                 print(f"  {step}. {action}")
@@ -5335,7 +5451,7 @@ class BoxmanManager:
                     workdir = os.path.abspath(os.path.expanduser(cluster['workdir']))
                     if workdir not in seen_workdirs:
                         seen_workdirs.add(workdir)
-                        self._ensure_libvirt_storage_pool(workdir)
+                        self._ensure_libvirt_storage_pool(workdir, cluster_name)
 
         # clone new VMs (parallel with retry)
         def _clone(cluster, vm_info, new_vm_name):

--- a/src/boxman/providers/__init__.py
+++ b/src/boxman/providers/__init__.py
@@ -29,11 +29,8 @@ def _virtualbox_session(config: dict[str, Any]) -> "ProviderSession":
 
 
 def _docker_compose_session(config: dict[str, Any]) -> "ProviderSession":
-    raise NotImplementedError(
-        "the 'docker-compose' provider is not implemented yet — its core "
-        "lifecycle lands in Phase 3 of the docker-compose provider epic "
-        "(https://github.com/mherkazandjian/boxman/issues/51)"
-    )
+    from boxman.providers.docker_compose.session import DockerComposeSession
+    return DockerComposeSession(config)
 
 
 #: provider-type name -> factory producing a live session for that provider
@@ -58,8 +55,6 @@ def create_session(provider_type: str, config: dict[str, Any]) -> "ProviderSessi
 
     Raises:
         ValueError: If *provider_type* is not a registered provider.
-        NotImplementedError: For providers that are registered but not
-            implemented yet (currently ``docker-compose``).
     """
     try:
         factory = PROVIDERS[provider_type]

--- a/src/boxman/providers/docker_compose/__init__.py
+++ b/src/boxman/providers/docker_compose/__init__.py
@@ -1,0 +1,18 @@
+"""
+The docker-compose provider — provisions container clusters by generating
+a per-cluster ``docker-compose.yml`` and driving ``docker compose``.
+
+Phase 3 of the docker-compose provider epic
+(https://github.com/mherkazandjian/boxman/issues/51). One compose project
+per cluster (ADR-001); the session exposes coarse per-cluster lifecycle
+methods that the manager dispatches to (see ``BoxmanManager`` compose
+helpers), mirroring the ``ContainerlabManager`` integration pattern.
+"""
+
+from __future__ import annotations
+
+from boxman.providers.docker_compose.compose_generator import ComposeGenerator
+from boxman.providers.docker_compose.compose_runner import ComposeRunner
+from boxman.providers.docker_compose.session import DockerComposeSession
+
+__all__ = ["ComposeGenerator", "ComposeRunner", "DockerComposeSession"]

--- a/src/boxman/providers/docker_compose/compose_generator.py
+++ b/src/boxman/providers/docker_compose/compose_generator.py
@@ -1,0 +1,198 @@
+"""
+ComposeGenerator — translate a boxman docker-compose *cluster* into a
+``docker-compose.yml`` dict and write it to the cluster workdir.
+
+Phase 3 scope: services (image / build / command / environment / ports /
+depends_on / restart / healthcheck), cluster-internal bridge networks, and
+the ``compose_extra:`` escape hatch (deep-merged verbatim, per-cluster and
+per-box — design decision D7). Out-of-phase box features are warned about
+and skipped:
+
+- ``volumes:`` (structured named/bind/workdir mounts) → **Phase 5**.
+- a box network that resolves to a ``shared_networks`` bridge (macvlan
+  L2 to VMs) → **Phase 4**; only cluster-internal networks are emitted.
+
+The generated file is a fidelity artifact — inspectable and hand-runnable
+with ``docker compose -f <cluster_workdir>/docker-compose.yml ps`` (D5).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Iterable
+
+import yaml
+
+from boxman import log
+from boxman.exceptions import ConfigError
+
+#: compose service keys copied through verbatim from a box definition
+_PASSTHROUGH_KEYS = (
+    "image",
+    "command",
+    "environment",
+    "ports",
+    "depends_on",
+    "restart",
+    "healthcheck",
+)
+
+
+class ComposeGenerator:
+    """Render a docker-compose cluster to a ``docker-compose.yml`` dict/file."""
+
+    def __init__(self, logger=None) -> None:
+        self.logger = logger or log
+
+    # -- public API --------------------------------------------------------
+
+    def generate(
+        self,
+        cluster_name: str,
+        cluster_cfg: dict[str, Any],
+        conf_dir: str,
+        shared_network_names: Iterable[str] = (),
+    ) -> dict[str, Any]:
+        """
+        Build the compose dict for *cluster_name*.
+
+        Args:
+            cluster_name: The cluster name (for diagnostics).
+            cluster_cfg: The cluster config (``boxes:``, ``networks:``,
+                optional ``compose_extra:``).
+            conf_dir: Directory of the project ``conf.yml`` — ``build.context``
+                is resolved absolute against it (D4).
+            shared_network_names: Names declared under the top-level
+                ``shared_networks:`` — used only to phrase the Phase-4
+                skip warning precisely.
+
+        Returns:
+            The compose dict (no top-level ``version:`` — the compose spec
+            treats it as obsolete).
+        """
+        shared = frozenset(shared_network_names)
+        cluster_networks = cluster_cfg.get("networks") or {}
+
+        services: dict[str, Any] = {}
+        for box_name, box in (cluster_cfg.get("boxes") or {}).items():
+            services[box_name] = self._service(
+                cluster_name, box_name, box or {}, conf_dir, cluster_networks, shared
+            )
+
+        compose: dict[str, Any] = {"services": services}
+        networks = self._networks(cluster_networks)
+        if networks:
+            compose["networks"] = networks
+
+        # D7: per-cluster escape hatch, deep-merged verbatim.
+        return self._deep_merge(compose, cluster_cfg.get("compose_extra") or {})
+
+    def write(self, compose_dict: dict[str, Any], workdir: str) -> str:
+        """Write *compose_dict* to ``<workdir>/docker-compose.yml`` (D5)."""
+        workdir = os.path.expanduser(workdir)
+        os.makedirs(workdir, exist_ok=True)
+        path = os.path.join(workdir, "docker-compose.yml")
+        with open(path, "w") as fobj:
+            yaml.safe_dump(compose_dict, fobj, sort_keys=False, default_flow_style=False)
+        return path
+
+    # -- internals ---------------------------------------------------------
+
+    def _service(
+        self,
+        cluster_name: str,
+        box_name: str,
+        box: dict[str, Any],
+        conf_dir: str,
+        cluster_networks: dict[str, Any],
+        shared: frozenset[str],
+    ) -> dict[str, Any]:
+        svc: dict[str, Any] = {}
+        for key in _PASSTHROUGH_KEYS:
+            if key in box:
+                svc[key] = box[key]
+
+        if "build" in box:
+            svc["build"] = self._build(box["build"], conf_dir)
+
+        nets = self._service_networks(
+            cluster_name, box_name, box.get("networks") or [], cluster_networks, shared
+        )
+        if nets:
+            svc["networks"] = nets
+
+        if box.get("volumes"):
+            self.logger.warning(
+                f"box '{cluster_name}.{box_name}': 'volumes:' is not supported "
+                f"yet (lands in Phase 5) — skipping {len(box['volumes'])} "
+                f"volume(s). Use 'compose_extra:' if you need them now."
+            )
+
+        # D7: per-box escape hatch, deep-merged verbatim (last, so it can
+        # override anything boxman generated).
+        svc = self._deep_merge(svc, box.get("compose_extra") or {})
+
+        if not (svc.get("image") or svc.get("build")):
+            raise ConfigError(
+                f"box '{cluster_name}.{box_name}' must define 'image:' or "
+                f"'build:'."
+            )
+        return svc
+
+    def _build(self, build: Any, conf_dir: str) -> Any:
+        """Resolve ``build.context`` to an absolute path vs *conf_dir* (D4)."""
+        if isinstance(build, str):
+            return os.path.abspath(os.path.join(conf_dir, os.path.expanduser(build)))
+        out = dict(build)
+        ctx = out.get("context", ".")
+        out["context"] = os.path.abspath(
+            os.path.join(conf_dir, os.path.expanduser(str(ctx)))
+        )
+        return out
+
+    def _service_networks(
+        self,
+        cluster_name: str,
+        box_name: str,
+        refs: list[str],
+        cluster_networks: dict[str, Any],
+        shared: frozenset[str],
+    ) -> list[str]:
+        out: list[str] = []
+        for ref in refs:
+            if ref in cluster_networks:
+                out.append(ref)
+            elif ref in shared:
+                self.logger.warning(
+                    f"box '{cluster_name}.{box_name}': network '{ref}' is a "
+                    f"shared_networks bridge — L2 attach to VMs lands in "
+                    f"Phase 4; skipping it for now."
+                )
+            else:
+                self.logger.warning(
+                    f"box '{cluster_name}.{box_name}': network '{ref}' is not a "
+                    f"cluster-internal network — skipping (shared/macvlan "
+                    f"networks land in Phase 4)."
+                )
+        return out
+
+    def _networks(self, cluster_networks: dict[str, Any]) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        for name, net in cluster_networks.items():
+            net = net or {}
+            spec: dict[str, Any] = {"driver": net.get("driver", "bridge")}
+            if net.get("subnet"):
+                spec["ipam"] = {"config": [{"subnet": net["subnet"]}]}
+            out[name] = self._deep_merge(spec, net.get("compose_extra") or {})
+        return out
+
+    @staticmethod
+    def _deep_merge(base: dict[str, Any], extra: dict[str, Any]) -> dict[str, Any]:
+        """Recursively merge *extra* onto *base* (extra wins); returns a copy."""
+        result = dict(base)
+        for key, value in (extra or {}).items():
+            if isinstance(value, dict) and isinstance(result.get(key), dict):
+                result[key] = ComposeGenerator._deep_merge(result[key], value)
+            else:
+                result[key] = value
+        return result

--- a/src/boxman/providers/docker_compose/compose_generator.py
+++ b/src/boxman/providers/docker_compose/compose_generator.py
@@ -19,6 +19,7 @@ with ``docker compose -f <cluster_workdir>/docker-compose.yml ps`` (D5).
 from __future__ import annotations
 
 import os
+import re
 from typing import Any, Iterable
 
 import yaml
@@ -36,6 +37,21 @@ _PASSTHROUGH_KEYS = (
     "restart",
     "healthcheck",
 )
+
+#: the ``{word}`` signature left by config preprocessing when it mangles a
+#: bare Jinja ``{{ word }}`` in a compose value. Excludes ``${word}`` (a `$`
+#: before the brace), which is a safe compose interpolation, not corruption.
+_CORRUPTED_TEMPLATE_RE = re.compile(r"(?<!\$)\{[a-zA-Z_]\w*\}")
+
+#: every box key the Phase-3 generator understands. Anything else is warned
+#: about and dropped (``volumes:`` → Phase 5 is handled separately, but is a
+#: recognised key so it doesn't also trip the unknown-key warning).
+_KNOWN_BOX_KEYS = frozenset(_PASSTHROUGH_KEYS) | {
+    "build",
+    "networks",
+    "volumes",
+    "compose_extra",
+}
 
 
 class ComposeGenerator:
@@ -108,6 +124,18 @@ class ComposeGenerator:
         shared: frozenset[str],
     ) -> dict[str, Any]:
         svc: dict[str, Any] = {}
+
+        self._warn_corrupted_templating(cluster_name, box_name, box)
+
+        unknown = [k for k in box if k not in _KNOWN_BOX_KEYS]
+        if unknown:
+            self.logger.warning(
+                f"box '{cluster_name}.{box_name}': ignoring unknown key(s) "
+                f"{', '.join(repr(k) for k in unknown)} — not part of the "
+                f"Phase-3 docker-compose box schema; use 'compose_extra:' to "
+                f"pass them through to the service."
+            )
+
         for key in _PASSTHROUGH_KEYS:
             if key in box:
                 svc[key] = box[key]
@@ -139,16 +167,65 @@ class ComposeGenerator:
             )
         return svc
 
+    def _warn_corrupted_templating(
+        self, cluster_name: str, box_name: str, box: dict[str, Any]
+    ) -> None:
+        """Warn when a compose ``environment:``/``command:`` value carries the
+        ``{word}`` corruption signature.
+
+        ``load_config`` does a whole-file preprocessing pass that rewrites a
+        bare Jinja ``{{ word }}`` into ``{word}`` (a task placeholder) with no
+        YAML-structure awareness, so it also mangles docker-compose values. The
+        Phase-2 caveat deferred a structure-aware exemption to "Phase 3, where
+        these values are consumed" (config-schema.md); this is that consumer,
+        so at minimum we flag the corruption instead of shipping it silently.
+        ``${VAR}`` / ``$${VAR}`` are unaffected and remain the safe forms.
+        """
+        values: list[str] = []
+        cmd = box.get("command")
+        if isinstance(cmd, str):
+            values.append(cmd)
+        elif isinstance(cmd, (list, tuple)):
+            values.extend(str(x) for x in cmd)
+        env = box.get("environment")
+        if isinstance(env, (list, tuple)):
+            values.extend(str(x) for x in env)
+        elif isinstance(env, dict):
+            values.extend(str(v) for v in env.values())
+
+        for val in values:
+            if _CORRUPTED_TEMPLATE_RE.search(val):
+                self.logger.warning(
+                    f"box '{cluster_name}.{box_name}': value {val!r} contains a "
+                    f"'{{word}}' token — a bare Jinja '{{{{ word }}}}' in a "
+                    f"compose environment:/command: is rewritten to '{{word}}' "
+                    f"by config preprocessing. Use ${{VAR}} or $${{VAR}} for "
+                    f"compose-time interpolation (see "
+                    f"doc/docker-compose-provider/config-schema.md)."
+                )
+                break
+
     def _build(self, build: Any, conf_dir: str) -> Any:
-        """Resolve ``build.context`` to an absolute path vs *conf_dir* (D4)."""
+        """Resolve a **local** ``build.context`` to an absolute path vs
+        *conf_dir* (D4).
+
+        Compose also accepts remote contexts — Git URLs (``https://…​.git#ref``,
+        ``git@…``), scheme URLs, and host shorthands (``github.com/…``). Those
+        are passed through verbatim: joining them onto *conf_dir* would mangle
+        e.g. ``https://github.com/x/y.git#main`` into ``/proj/https:/github…``.
+        """
         if isinstance(build, str):
-            return os.path.abspath(os.path.join(conf_dir, os.path.expanduser(build)))
+            return build if _is_remote_build_context(build) \
+                else self._abs_context(build, conf_dir)
         out = dict(build)
-        ctx = out.get("context", ".")
-        out["context"] = os.path.abspath(
-            os.path.join(conf_dir, os.path.expanduser(str(ctx)))
-        )
+        ctx = str(out.get("context", "."))
+        if not _is_remote_build_context(ctx):
+            out["context"] = self._abs_context(ctx, conf_dir)
         return out
+
+    @staticmethod
+    def _abs_context(ctx: str, conf_dir: str) -> str:
+        return os.path.abspath(os.path.join(conf_dir, os.path.expanduser(ctx)))
 
     def _service_networks(
         self,
@@ -196,3 +273,24 @@ class ComposeGenerator:
             else:
                 result[key] = value
         return result
+
+
+#: git host shorthands compose accepts as a remote build context
+_REMOTE_CONTEXT_HOSTS = ("github.com/", "bitbucket.org/", "gitlab.com/")
+
+
+def _is_remote_build_context(ctx: str) -> bool:
+    """True if *ctx* is a remote build context (Git/URL) rather than a local
+    filesystem path.
+
+    Compose treats these as remote and must **not** have them resolved against
+    the conf.yml dir: scheme URLs (``https://``, ``git://``, ``ssh://``),
+    scp-like Git (``git@host:path``), and the ``github.com/…`` /
+    ``bitbucket.org/…`` / ``gitlab.com/…`` shorthands (with an optional
+    ``#ref`` fragment).
+    """
+    ctx = ctx.strip()
+    if "://" in ctx or ctx.startswith("git@"):
+        return True
+    head = ctx.split("#", 1)[0]
+    return head.startswith(_REMOTE_CONTEXT_HOSTS)

--- a/src/boxman/providers/docker_compose/compose_runner.py
+++ b/src/boxman/providers/docker_compose/compose_runner.py
@@ -25,11 +25,21 @@ DEFAULT_READINESS_TIMEOUT = 120
 
 
 class ComposeRunner:
-    def __init__(self, project: str, compose_file: str, workdir: str, logger=None) -> None:
+    def __init__(
+        self,
+        project: str,
+        compose_file: str | None = None,
+        workdir: str | None = None,
+        logger=None,
+        use_sudo: bool = False,
+    ) -> None:
         self.project = project
         self.compose_file = compose_file
         self.workdir = workdir
         self.logger = logger or log
+        #: ``"sudo "`` prefix when the provider config sets ``use_sudo: true``
+        #: (hosts where docker needs root — no docker group / not rootless).
+        self._sudo = "sudo " if use_sudo else ""
 
     def preflight(self) -> None:
         """Verify ``docker`` and the ``docker compose`` v2 plugin exist."""
@@ -38,7 +48,7 @@ class ComposeRunner:
                 "'docker' is not on PATH — the docker-compose provider needs "
                 "Docker with the Compose v2 plugin installed on this host."
             )
-        if not run("docker compose version", hide=True, warn=True).ok:
+        if not run(f"{self._sudo}docker compose version", hide=True, warn=True).ok:
             raise RuntimeUnavailable(
                 "'docker compose' (Compose v2 plugin) is not available — "
                 "install it or upgrade Docker."
@@ -47,6 +57,11 @@ class ComposeRunner:
     def up(self, timeout: int = DEFAULT_READINESS_TIMEOUT):
         """``docker compose up -d --wait`` — create+start and block on
         readiness. Raises :class:`ProvisionError` on failure/timeout."""
+        if not self.compose_file:
+            raise ProvisionError(
+                f"cannot bring up project '{self.project}' without a compose "
+                f"file (label-only runners are for teardown)."
+            )
         cmd = f"{self._base()} up -d --wait --wait-timeout {int(timeout)}"
         result = run(cmd, warn=True)
         if not result.ok:
@@ -79,8 +94,14 @@ class ComposeRunner:
     # -- internals ---------------------------------------------------------
 
     def _base(self) -> str:
-        return (
-            f"docker compose -p {shlex.quote(self.project)} "
-            f"-f {shlex.quote(self.compose_file)} "
-            f"--project-directory {shlex.quote(self.workdir)}"
-        )
+        # ``-f`` / ``--project-directory`` are included only when set. A
+        # teardown runner with neither operates on the project purely by its
+        # compose labels (``docker compose -p <project> down`` — compose v2
+        # resolves containers/networks from ``com.docker.compose.project``),
+        # so containers can be removed even after the workdir/file is gone.
+        parts = [f"{self._sudo}docker compose -p {shlex.quote(self.project)}"]
+        if self.compose_file:
+            parts.append(f"-f {shlex.quote(self.compose_file)}")
+        if self.workdir:
+            parts.append(f"--project-directory {shlex.quote(self.workdir)}")
+        return " ".join(parts)

--- a/src/boxman/providers/docker_compose/compose_runner.py
+++ b/src/boxman/providers/docker_compose/compose_runner.py
@@ -1,0 +1,86 @@
+"""
+ComposeRunner — drive ``docker compose`` for one cluster's generated
+``docker-compose.yml``.
+
+Stateless and constructed per operation; shells out **directly on the
+host** via ``boxman.utils.shell.run`` (the same pattern
+``ContainerlabManager`` and ``runtime/docker_compose.py`` use for their
+host-side ``docker compose`` calls — the docker-compose *provider* requires
+``runtime: local``, so there is nothing to wrap). Readiness uses
+``docker compose up --wait`` (design decision D1): it blocks until every
+service is ``healthy`` (when a healthcheck exists) or ``running``.
+"""
+
+from __future__ import annotations
+
+import shlex
+import shutil
+
+from boxman import log
+from boxman.exceptions import ProvisionError, RuntimeUnavailable
+from boxman.utils.shell import run
+
+#: default per-cluster readiness timeout, seconds (D1)
+DEFAULT_READINESS_TIMEOUT = 120
+
+
+class ComposeRunner:
+    def __init__(self, project: str, compose_file: str, workdir: str, logger=None) -> None:
+        self.project = project
+        self.compose_file = compose_file
+        self.workdir = workdir
+        self.logger = logger or log
+
+    def preflight(self) -> None:
+        """Verify ``docker`` and the ``docker compose`` v2 plugin exist."""
+        if shutil.which("docker") is None:
+            raise RuntimeUnavailable(
+                "'docker' is not on PATH — the docker-compose provider needs "
+                "Docker with the Compose v2 plugin installed on this host."
+            )
+        if not run("docker compose version", hide=True, warn=True).ok:
+            raise RuntimeUnavailable(
+                "'docker compose' (Compose v2 plugin) is not available — "
+                "install it or upgrade Docker."
+            )
+
+    def up(self, timeout: int = DEFAULT_READINESS_TIMEOUT):
+        """``docker compose up -d --wait`` — create+start and block on
+        readiness. Raises :class:`ProvisionError` on failure/timeout."""
+        cmd = f"{self._base()} up -d --wait --wait-timeout {int(timeout)}"
+        result = run(cmd, warn=True)
+        if not result.ok:
+            raise ProvisionError(
+                f"'docker compose up' failed for project '{self.project}' "
+                f"(timeout {timeout}s): {(result.stderr or result.stdout).strip()}"
+            )
+        return result
+
+    def down(self):
+        """``docker compose down`` — remove containers + networks, keep named volumes."""
+        return run(f"{self._base()} down --remove-orphans", warn=True)
+
+    def down_volumes(self):
+        """``docker compose down --volumes`` — remove everything including named volumes."""
+        return run(f"{self._base()} down --volumes --remove-orphans", warn=True)
+
+    def stop(self):
+        """``docker compose stop`` — stop containers, keep them (reversible by :meth:`start`)."""
+        return run(f"{self._base()} stop", warn=True)
+
+    def start(self):
+        """``docker compose start`` — start previously-stopped containers."""
+        return run(f"{self._base()} start", warn=True)
+
+    def ps(self):
+        """``docker compose ps`` (captured)."""
+        return run(f"{self._base()} ps", hide=True, warn=True)
+
+    # -- internals ---------------------------------------------------------
+
+    def _base(self) -> str:
+        return (
+            f"docker compose -p {shlex.quote(self.project)} "
+            f"-f {shlex.quote(self.compose_file)} "
+            f"--project-directory {shlex.quote(self.workdir)}"
+        )

--- a/src/boxman/providers/docker_compose/session.py
+++ b/src/boxman/providers/docker_compose/session.py
@@ -1,0 +1,218 @@
+"""
+DockerComposeSession — the docker-compose provider session.
+
+One compose project per cluster (ADR-001). Unlike the libvirt session
+(whose per-VM methods the manager calls inside per-box subprocess loops),
+this session exposes **coarse per-cluster** lifecycle methods that the
+manager dispatches a whole cluster to — because docker-compose is
+declarative and cluster-scoped (one ``docker compose up --wait`` per
+cluster, D1/D5). The libvirt-shaped per-VM/network protocol methods exist
+only to satisfy the ``ProviderSession`` protocol; they are never reached
+for a docker-compose cluster and raise a clear error if called.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+
+from boxman import log
+from boxman.exceptions import ConfigError, ProvisionError
+from boxman.providers.docker_compose.compose_generator import ComposeGenerator
+from boxman.providers.docker_compose.compose_runner import (
+    DEFAULT_READINESS_TIMEOUT,
+    ComposeRunner,
+)
+
+
+class DockerComposeSession:
+    """Per-cluster docker-compose provider session."""
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        self.config = config or {}
+        self.logger = log
+        #: set externally by scripts/app.py right after construction
+        self.manager = None
+        self._provider_config = (
+            (self.config.get("provider") or {}).get("docker-compose") or {}
+        )
+        self._generator = ComposeGenerator(logger=self.logger)
+
+    # -- ProviderSession protocol: config surface --------------------------
+
+    @property
+    def provider_config(self) -> dict[str, Any]:
+        return self._provider_config
+
+    @provider_config.setter
+    def provider_config(self, value: dict[str, Any]) -> None:
+        self._provider_config = value or {}
+
+    @property
+    def uri(self) -> str:
+        # docker-compose has no libvirt-style URI; the docker host is implicit.
+        return self._provider_config.get("uri", "")
+
+    @property
+    def use_sudo(self) -> bool:
+        return bool(self._provider_config.get("use_sudo", False))
+
+    def update_provider_config(self, new_config: dict[str, Any]) -> None:
+        self._provider_config = {**self._provider_config, **(new_config or {})}
+
+    def update_provider_config_with_runtime(self) -> None:
+        """No-op: the docker-compose provider requires ``runtime: local``,
+        so there is no runtime enrichment to apply. Present because the
+        manager calls it over every registered session."""
+        return None
+
+    # -- coarse per-cluster lifecycle (the real work) ----------------------
+
+    def up_cluster(self, cluster_name: str, cluster_cfg: dict[str, Any]) -> bool:
+        """boxman provision/up → generate the compose file and
+        ``docker compose up -d --wait`` (idempotent)."""
+        self._require_local_runtime(cluster_name)
+        runner, _workdir, _compose_file = self._compose_context(cluster_name, cluster_cfg)
+        runner.preflight()
+        timeout = int(cluster_cfg.get("readiness_timeout", DEFAULT_READINESS_TIMEOUT))
+        self.logger.info(
+            f"[{cluster_name}] docker compose up (project '{runner.project}', "
+            f"wait ≤{timeout}s)"
+        )
+        runner.up(timeout)
+        return True
+
+    def stop_cluster(self, cluster_name: str, cluster_cfg: dict[str, Any]) -> bool:
+        """boxman down → ``docker compose stop`` (keep containers)."""
+        runner, _wd, _cf = self._compose_context(cluster_name, cluster_cfg)
+        self.logger.info(f"[{cluster_name}] docker compose stop")
+        runner.stop()
+        return True
+
+    def start_cluster(self, cluster_name: str, cluster_cfg: dict[str, Any]) -> bool:
+        """boxman up (after down) → ``docker compose start``."""
+        runner, _wd, _cf = self._compose_context(cluster_name, cluster_cfg)
+        self.logger.info(f"[{cluster_name}] docker compose start")
+        runner.start()
+        return True
+
+    def down_cluster(self, cluster_name: str, cluster_cfg: dict[str, Any]) -> bool:
+        """boxman deprovision → ``docker compose down`` (remove containers +
+        networks, keep named volumes)."""
+        runner, _wd, _cf = self._compose_context(cluster_name, cluster_cfg)
+        self.logger.info(f"[{cluster_name}] docker compose down")
+        runner.down()
+        return True
+
+    def destroy_cluster(self, cluster_name: str, cluster_cfg: dict[str, Any]) -> bool:
+        """boxman destroy → ``docker compose down --volumes`` and remove the
+        generated compose file."""
+        runner, _wd, compose_file = self._compose_context(cluster_name, cluster_cfg)
+        self.logger.info(f"[{cluster_name}] docker compose down --volumes")
+        runner.down_volumes()
+        try:
+            if os.path.isfile(compose_file):
+                os.remove(compose_file)
+        except OSError as exc:
+            self.logger.warning(
+                f"[{cluster_name}] could not remove {compose_file}: {exc}"
+            )
+        return True
+
+    # -- internals ---------------------------------------------------------
+
+    def _compose_context(
+        self, cluster_name: str, cluster_cfg: dict[str, Any]
+    ) -> tuple[ComposeRunner, str, str]:
+        """Regenerate the compose file (idempotent) and build a runner.
+
+        Regenerating on every op keeps ``-f`` valid for down/stop/start
+        even if the workdir was wiped, and keeps the on-disk file in sync
+        with the config.
+        """
+        workdir = os.path.expanduser(cluster_cfg["workdir"])
+        shared = set(self.config.get("shared_networks") or {})
+        compose = self._generator.generate(
+            cluster_name, cluster_cfg, self._conf_dir(), shared
+        )
+        compose_file = self._generator.write(compose, workdir)
+        runner = ComposeRunner(
+            project=self._compose_project(cluster_name),
+            compose_file=compose_file,
+            workdir=workdir,
+            logger=self.logger,
+        )
+        return runner, workdir, compose_file
+
+    def _conf_dir(self) -> str:
+        """Directory of the project ``conf.yml`` (for build-context resolution)."""
+        config_path = getattr(self.manager, "config_path", None)
+        return os.path.dirname(os.path.abspath(config_path)) if config_path else os.getcwd()
+
+    def _compose_project(self, cluster_name: str) -> str:
+        """Derive the ``docker compose -p`` name — one project per cluster
+        (ADR-001), so clusters never share compose state."""
+        base = self._provider_config.get("project_name") or self.config.get("project") or "boxman"
+        return _sanitize_project_name(f"{base}_{cluster_name}")
+
+    def _require_local_runtime(self, cluster_name: str) -> None:
+        """Defense-in-depth: the docker-compose provider requires
+        ``runtime: local`` (the ``docker-compose`` *runtime* is
+        libvirt-in-a-container, a different axis). app.py fails fast at
+        session build; this re-checks in case the session is driven directly."""
+        runtime = getattr(self.manager, "runtime", "local")
+        if runtime != "local":
+            raise ConfigError(
+                f"cluster '{cluster_name}' uses the docker-compose provider, "
+                f"which requires runtime 'local' (got '{runtime}'). The "
+                f"'docker-compose' runtime is libvirt-in-a-container and is a "
+                f"different setting — see doc/docker-compose-provider/config-schema.md."
+            )
+
+    # -- ProviderSession protocol: libvirt-shaped methods (never reached) --
+
+    def _cluster_scoped(self, method: str):
+        raise ProvisionError(
+            f"DockerComposeSession.{method}() is not supported — the "
+            f"docker-compose provider is cluster-scoped; the manager drives "
+            f"it through the per-cluster lifecycle (up_cluster/down_cluster/"
+            f"destroy_cluster), not per-box VM methods."
+        )
+
+    def start_vm(self, vm_name: str) -> bool:
+        self._cluster_scoped("start_vm")
+
+    def destroy_vm(self, name: str, force: bool = False, remove_storage: bool = True, **kwargs) -> bool:
+        self._cluster_scoped("destroy_vm")
+
+    def clone_vm(self, new_vm_name: str, src_vm_name: str, info: dict[str, Any], workdir: str) -> bool:
+        self._cluster_scoped("clone_vm")
+
+    def define_network(self, name=None, info=None, workdir=None) -> bool:
+        self._cluster_scoped("define_network")
+
+    def destroy_network(self, name=None, info=None) -> bool:
+        self._cluster_scoped("destroy_network")
+
+    def remove_network(self, name=None, info=None) -> bool:
+        self._cluster_scoped("remove_network")
+
+    def snapshot_take(self, *args, **kwargs) -> bool:
+        self._cluster_scoped("snapshot_take")
+
+    def snapshot_restore(self, vm_name: str, snapshot_name: str | None = None) -> bool:
+        self._cluster_scoped("snapshot_restore")
+
+    def snapshot_delete(self, vm_name: str, snapshot_name: str) -> bool:
+        self._cluster_scoped("snapshot_delete")
+
+    def snapshot_list(self, vm_name: str | None = None) -> list[dict[str, str]]:
+        self._cluster_scoped("snapshot_list")
+
+
+def _sanitize_project_name(name: str) -> str:
+    """Coerce *name* to a valid compose project name (``[a-z0-9][a-z0-9_-]*``)."""
+    slug = re.sub(r"[^a-z0-9_-]", "_", name.lower())
+    slug = slug.lstrip("_-") or "boxman"
+    return slug

--- a/src/boxman/providers/docker_compose/session.py
+++ b/src/boxman/providers/docker_compose/session.py
@@ -73,9 +73,9 @@ class DockerComposeSession:
         """boxman provision/up → generate the compose file and
         ``docker compose up -d --wait`` (idempotent)."""
         self._require_local_runtime(cluster_name)
+        timeout = self._readiness_timeout(cluster_cfg, cluster_name)
         runner, _workdir, _compose_file = self._compose_context(cluster_name, cluster_cfg)
         runner.preflight()
-        timeout = int(cluster_cfg.get("readiness_timeout", DEFAULT_READINESS_TIMEOUT))
         self.logger.info(
             f"[{cluster_name}] docker compose up (project '{runner.project}', "
             f"wait ≤{timeout}s)"
@@ -85,32 +85,39 @@ class DockerComposeSession:
 
     def stop_cluster(self, cluster_name: str, cluster_cfg: dict[str, Any]) -> bool:
         """boxman down → ``docker compose stop`` (keep containers)."""
-        runner, _wd, _cf = self._compose_context(cluster_name, cluster_cfg)
+        runner, _wd, _cf = self._teardown_runner(cluster_name, cluster_cfg)
         self.logger.info(f"[{cluster_name}] docker compose stop")
-        runner.stop()
-        return True
+        return self._check(cluster_name, "stop", runner.stop())
 
     def start_cluster(self, cluster_name: str, cluster_cfg: dict[str, Any]) -> bool:
-        """boxman up (after down) → ``docker compose start``."""
-        runner, _wd, _cf = self._compose_context(cluster_name, cluster_cfg)
+        """``docker compose start`` — reserved API surface for the later
+        control-verb phase; not driven by a flow yet (``up``-after-``down``
+        reconciles via :meth:`up_cluster`). See
+        ``BoxmanManager.start_compose_clusters``."""
+        runner, _wd, _cf = self._teardown_runner(cluster_name, cluster_cfg)
         self.logger.info(f"[{cluster_name}] docker compose start")
-        runner.start()
-        return True
+        return self._check(cluster_name, "start", runner.start())
 
     def down_cluster(self, cluster_name: str, cluster_cfg: dict[str, Any]) -> bool:
         """boxman deprovision → ``docker compose down`` (remove containers +
         networks, keep named volumes)."""
-        runner, _wd, _cf = self._compose_context(cluster_name, cluster_cfg)
+        runner, _wd, _cf = self._teardown_runner(cluster_name, cluster_cfg)
         self.logger.info(f"[{cluster_name}] docker compose down")
-        runner.down()
-        return True
+        return self._check(cluster_name, "down", runner.down())
 
     def destroy_cluster(self, cluster_name: str, cluster_cfg: dict[str, Any]) -> bool:
         """boxman destroy → ``docker compose down --volumes`` and remove the
-        generated compose file."""
-        runner, _wd, compose_file = self._compose_context(cluster_name, cluster_cfg)
+        generated compose file (only when the teardown actually succeeded)."""
+        runner, _wd, compose_file = self._teardown_runner(cluster_name, cluster_cfg)
         self.logger.info(f"[{cluster_name}] docker compose down --volumes")
-        runner.down_volumes()
+        ok = self._check(cluster_name, "down --volumes", runner.down_volumes())
+        if not ok:
+            # keep the on-disk file so a retry can still resolve the project
+            self.logger.warning(
+                f"[{cluster_name}] keeping {compose_file} for retry "
+                f"(teardown did not report success)."
+            )
+            return False
         try:
             if os.path.isfile(compose_file):
                 os.remove(compose_file)
@@ -120,6 +127,25 @@ class DockerComposeSession:
             )
         return True
 
+    def _check(self, cluster_name: str, op: str, result: Any) -> bool:
+        """Warn (don't raise) when a best-effort teardown op did not succeed.
+
+        The teardown runner methods shell out with ``warn=True`` (no raise);
+        their ``Result.ok`` is inspected here so a failed ``stop``/``down`` is
+        surfaced instead of being silently reported as success. A ``result``
+        without an ``ok`` attribute (e.g. a test double returning ``None``) is
+        treated as success.
+        """
+        if not getattr(result, "ok", True):
+            detail = (
+                getattr(result, "stderr", "") or getattr(result, "stdout", "") or ""
+            ).strip()
+            self.logger.warning(
+                f"[{cluster_name}] 'docker compose {op}' reported failure: {detail}"
+            )
+            return False
+        return True
+
     # -- internals ---------------------------------------------------------
 
     def _compose_context(
@@ -127,11 +153,10 @@ class DockerComposeSession:
     ) -> tuple[ComposeRunner, str, str]:
         """Regenerate the compose file (idempotent) and build a runner.
 
-        Regenerating on every op keeps ``-f`` valid for down/stop/start
-        even if the workdir was wiped, and keeps the on-disk file in sync
-        with the config.
+        Regeneration is for **bring-up only** (``up_cluster``); teardown uses
+        :meth:`_teardown_runner`, which never regenerates.
         """
-        workdir = os.path.expanduser(cluster_cfg["workdir"])
+        workdir = self._workdir(cluster_cfg, cluster_name)
         shared = set(self.config.get("shared_networks") or {})
         compose = self._generator.generate(
             cluster_name, cluster_cfg, self._conf_dir(), shared
@@ -142,13 +167,94 @@ class DockerComposeSession:
             compose_file=compose_file,
             workdir=workdir,
             logger=self.logger,
+            use_sudo=self.use_sudo,
         )
         return runner, workdir, compose_file
+
+    def _teardown_runner(
+        self, cluster_name: str, cluster_cfg: dict[str, Any]
+    ) -> tuple[ComposeRunner, str, str]:
+        """Build a runner for a teardown op **without regenerating** the file.
+
+        Uses the on-disk ``<workdir>/docker-compose.yml`` when present (so a
+        hand-edited file is respected and never overwritten); otherwise falls
+        back to a **label-only** runner (``docker compose -p <project> …``) so
+        containers can still be removed after the workdir/file was wiped.
+
+        This deliberately avoids :meth:`_compose_context`'s ``generate()``:
+        regenerating on teardown would make ``down``/``deprovision``/``destroy``
+        fail on a config that no longer generates cleanly (e.g. a box that lost
+        its ``image:``), and would recreate the workdir + compose file on a
+        ``down`` of a never-provisioned project.
+        """
+        workdir = self._workdir(cluster_cfg, cluster_name)
+        compose_file = os.path.join(workdir, "docker-compose.yml")
+        project = self._compose_project(cluster_name)
+        if os.path.isfile(compose_file):
+            runner = ComposeRunner(
+                project=project,
+                compose_file=compose_file,
+                workdir=workdir,
+                logger=self.logger,
+                use_sudo=self.use_sudo,
+            )
+        else:
+            # label-only: resolve the project from compose labels
+            runner = ComposeRunner(
+                project=project, logger=self.logger, use_sudo=self.use_sudo)
+        return runner, workdir, compose_file
+
+    def _readiness_timeout(self, cluster_cfg: dict[str, Any], cluster_name: str) -> int:
+        """Validate the cluster ``readiness_timeout:`` → positive int seconds.
+
+        Raises a clear :class:`ConfigError` instead of a bare ``ValueError`` /
+        ``TypeError`` traceback for non-integer or non-positive input.
+        """
+        raw = cluster_cfg.get("readiness_timeout", DEFAULT_READINESS_TIMEOUT)
+        try:
+            timeout = int(raw)
+        except (TypeError, ValueError):
+            raise ConfigError(
+                f"docker-compose cluster '{cluster_name}': readiness_timeout "
+                f"must be an integer number of seconds (got {raw!r})."
+            )
+        if timeout <= 0:
+            raise ConfigError(
+                f"docker-compose cluster '{cluster_name}': readiness_timeout "
+                f"must be a positive integer (got {timeout})."
+            )
+        return timeout
+
+    def _workdir(self, cluster_cfg: dict[str, Any], cluster_name: str) -> str:
+        """Resolve the cluster ``workdir:`` (required) to an absolute-ish path.
+
+        Raises a clear :class:`ConfigError` instead of a bare ``KeyError`` when
+        ``workdir:`` is missing — it is the first thing every lifecycle op needs
+        (the generated ``docker-compose.yml`` lives at ``<workdir>/``).
+        """
+        workdir = cluster_cfg.get("workdir")
+        if not workdir:
+            raise ConfigError(
+                f"docker-compose cluster '{cluster_name}' has no 'workdir:' — "
+                f"it is required (the generated docker-compose.yml is written "
+                f"to <workdir>/docker-compose.yml)."
+            )
+        return os.path.expanduser(workdir)
 
     def _conf_dir(self) -> str:
         """Directory of the project ``conf.yml`` (for build-context resolution)."""
         config_path = getattr(self.manager, "config_path", None)
         return os.path.dirname(os.path.abspath(config_path)) if config_path else os.getcwd()
+
+    def compose_project_name(self, cluster_name: str) -> str:
+        """Public accessor for the ``docker compose -p`` name of *cluster_name*.
+
+        The manager uses this to detect cross-cluster project-name collisions
+        (distinct cluster names that sanitize to the same project) before
+        creating any compose state — see
+        ``BoxmanManager._reject_compose_project_collisions``.
+        """
+        return self._compose_project(cluster_name)
 
     def _compose_project(self, cluster_name: str) -> str:
         """Derive the ``docker compose -p`` name — one project per cluster
@@ -160,7 +266,13 @@ class DockerComposeSession:
         """Defense-in-depth: the docker-compose provider requires
         ``runtime: local`` (the ``docker-compose`` *runtime* is
         libvirt-in-a-container, a different axis). app.py fails fast at
-        session build; this re-checks in case the session is driven directly."""
+        session build; this re-checks in case the session is driven directly.
+
+        With no manager attached (a bare direct-drive, e.g. in a unit test)
+        there is no runtime axis to enforce, so the ``getattr`` default of
+        ``"local"`` intentionally passes — the authoritative fail-fast is
+        app.py's session-build guardrail, which always has the manager.
+        """
         runtime = getattr(self.manager, "runtime", "local")
         if runtime != "local":
             raise ConfigError(

--- a/src/boxman/scripts/app.py
+++ b/src/boxman/scripts/app.py
@@ -14,7 +14,7 @@ import yaml
 import boxman
 from boxman import log
 from boxman.abstract.providers import ProviderSession as Session
-from boxman.exceptions import ConfigError
+from boxman.exceptions import BoxmanError
 from boxman.manager import BoxmanManager
 from boxman.providers import create_session, primary_provider_type
 from boxman.providers.libvirt.import_image import ImageImporter
@@ -286,15 +286,19 @@ def main():
     """
     CLI entry point.
 
-    Thin wrapper that translates config-schema errors
-    (:class:`~boxman.exceptions.ConfigError`, e.g. an unsupported
-    ``version:`` or an invalid v2.0 cluster) into a clean ``log.error`` +
-    exit 2, instead of surfacing a traceback. All other flow (including
-    the ``sys.exit()`` calls throughout) lives in :func:`_main`.
+    Thin wrapper that translates any :class:`~boxman.exceptions.BoxmanError`
+    into a clean ``log.error`` + exit 2 instead of surfacing a traceback.
+    This covers config-schema errors (:class:`~boxman.exceptions.ConfigError`,
+    e.g. an unsupported ``version:`` or an invalid v2.0 cluster) as well as
+    operational failures on the docker-compose path — a service that never
+    becomes healthy within ``readiness_timeout``
+    (:class:`~boxman.exceptions.ProvisionError`) or a missing docker/compose
+    plugin (:class:`~boxman.exceptions.RuntimeUnavailable`). All other flow
+    (including the ``sys.exit()`` calls throughout) lives in :func:`_main`.
     """
     try:
         _main()
-    except ConfigError as exc:
+    except BoxmanError as exc:
         # A viewer command (e.g. ``snapshot log``) raises the boxman logger
         # to CRITICAL+1 to silence INFO spam before the config is loaded; if
         # loading then fails, restore a level that lets this error through so

--- a/src/boxman/scripts/app.py
+++ b/src/boxman/scripts/app.py
@@ -544,6 +544,18 @@ def _main():
                     provider_types.append(_cluster_type)
 
         for _ptype in provider_types:
+            # The docker-compose PROVIDER shells out to `docker compose` on
+            # the host; the `docker-compose` RUNTIME is libvirt-in-a-container
+            # (a different axis). Requiring runtime 'local' keeps them from
+            # being confused. Fail fast with a clean message.
+            if _ptype == 'docker-compose' and manager.runtime != 'local':
+                log.error(
+                    f"the docker-compose provider requires runtime 'local' "
+                    f"(got '{manager.runtime}'). The 'docker-compose' runtime "
+                    f"is libvirt-in-a-container — a different setting; see "
+                    f"doc/docker-compose-provider/config-schema.md."
+                )
+                sys.exit(2)
             if _ptype == 'libvirt':
                 # merge runtime metadata into the provider config from boxman.yml
                 provider_conf_with_runtime = manager.get_provider_config_with_runtime(

--- a/tests/test_boxman_conf.py
+++ b/tests/test_boxman_conf.py
@@ -879,6 +879,34 @@ class TestConfigSchemaV2:
         assert self._mgr()._apply_config_version(None) is None
         assert self._mgr()._apply_config_version({}) == {}
 
+    # --- v1.0: docker-compose is rejected (needs v2.0) -------------------
+
+    def test_v1_top_level_docker_compose_is_error(self):
+        """A versionless config whose primary provider is docker-compose is
+        rejected: the provider consumes 'boxes:', which v1.0 ignores, so
+        provisioning would contradict the v1 'boxes ignored' nudge."""
+        cfg = self._cfg(top_provider='docker-compose',
+                        cluster={'boxes': {'web': {'image': 'nginx'}}})
+        with pytest.raises(ConfigError, match=r"docker-compose.*requires version: '2.0'"):
+            self._mgr()._apply_config_version(cfg)
+
+    def test_v1_per_cluster_docker_compose_is_error(self):
+        """A v1.0 config with a per-cluster docker-compose provider is also
+        rejected (the predicate reads the same per-cluster override)."""
+        cfg = self._cfg(version='1.0', top_provider='libvirt',
+                        cluster={'provider': 'docker-compose',
+                                 'boxes': {'web': {'image': 'nginx'}}})
+        with pytest.raises(ConfigError, match=r"docker-compose.*requires version: '2.0'"):
+            self._mgr()._apply_config_version(cfg)
+
+    def test_v1_libvirt_with_boxes_still_only_warns(self):
+        """The rejection is docker-compose-specific: a v1 libvirt cluster
+        using 'boxes:' still merely warns (regression guard for the nudge)."""
+        cfg = self._cfg(version='1.0', top_provider='libvirt',
+                        cluster={'boxes': {'b1': {}}})
+        out = self._mgr()._apply_config_version(cfg)  # no raise
+        assert out is cfg
+
     # --- v2.0 libvirt: boxes -> vms --------------------------------------
 
     def test_v2_libvirt_boxes_renamed_to_vms(self):
@@ -1174,3 +1202,20 @@ class TestMainConfigErrorExit:
             assert any('shown-anyway' in r.message for r in captured_logs.records)
         finally:
             boxman_logger.setLevel(previous)
+
+    def test_provision_error_also_exits_2(self, captured_logs, monkeypatch):
+        """Phase 3: the wrapper now catches the whole BoxmanError family, so an
+        operational failure on the docker-compose path (an unhealthy service →
+        ProvisionError) exits 2 cleanly instead of dumping a traceback."""
+        from boxman.scripts import app
+        from boxman.exceptions import ProvisionError
+
+        def _raise():
+            raise ProvisionError('service never became healthy')
+
+        monkeypatch.setattr(app, '_main', _raise)
+        with captured_logs.at_level(logging.ERROR, logger='boxman'):
+            with pytest.raises(SystemExit) as excinfo:
+                app.main()
+        assert excinfo.value.code == 2
+        assert any('never became healthy' in r.message for r in captured_logs.records)

--- a/tests/test_docker_compose_provider.py
+++ b/tests/test_docker_compose_provider.py
@@ -1,0 +1,544 @@
+"""
+Unit tests for the docker-compose provider (Phase 3, epic #42 / issue #51).
+
+Everything here is mocked — no live ``docker`` and no libvirt. Per the
+host-vs-VM testing policy, live container behaviour is exercised only inside
+the staging VM (nested docker-compose e2e), never on the host. These tests
+cover four seams:
+
+- :class:`ComposeGenerator` — ``boxes:`` → compose ``services:`` translation,
+  cluster-internal bridge networks, absolute ``build.context`` (D4),
+  ``compose_extra:`` deep-merge (D7), and the warn+skip of out-of-phase box
+  features (``volumes:`` → Phase 5, shared/macvlan networks → Phase 4).
+- :class:`ComposeRunner` — the exact ``docker compose`` command strings and
+  the preflight / failure error paths (``boxman.utils.shell.run`` mocked).
+- :class:`DockerComposeSession` — satisfies the ``ProviderSession`` protocol,
+  the coarse per-cluster methods drive the runner correctly, the per-VM
+  protocol methods raise, and the ``runtime: local`` guardrail fires.
+- Manager dispatch — ``_vm_clusters`` / ``_compose_clusters`` partition a
+  mixed config and the coarse ``*_compose_clusters`` helpers route each dc
+  cluster to its session (libvirt clusters untouched).
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+import yaml
+
+from boxman.abstract.providers import ProviderSession
+from boxman.exceptions import ConfigError, ProvisionError, RuntimeUnavailable
+from boxman.manager import BoxmanManager
+from boxman.providers import create_session
+from boxman.providers.docker_compose.compose_generator import ComposeGenerator
+from boxman.providers.docker_compose.compose_runner import (
+    DEFAULT_READINESS_TIMEOUT,
+    ComposeRunner,
+)
+from boxman.providers.docker_compose.session import (
+    DockerComposeSession,
+    _sanitize_project_name,
+)
+
+
+# --------------------------------------------------------------------------
+# ComposeGenerator
+# --------------------------------------------------------------------------
+class TestComposeGenerator:
+
+    def test_translates_boxes_to_services_passthrough(self):
+        gen = ComposeGenerator()
+        cluster = {
+            "boxes": {
+                "web": {
+                    "image": "nginx:latest",
+                    "command": "nginx -g 'daemon off;'",
+                    "environment": ["FOO=bar"],
+                    "ports": ["8080:80"],
+                    "depends_on": ["api"],
+                    "restart": "unless-stopped",
+                    "healthcheck": {"test": ["CMD", "true"]},
+                },
+            },
+        }
+        compose = gen.generate("stack", cluster, conf_dir="/proj")
+        web = compose["services"]["web"]
+        assert web["image"] == "nginx:latest"
+        assert web["command"] == "nginx -g 'daemon off;'"
+        assert web["environment"] == ["FOO=bar"]
+        assert web["ports"] == ["8080:80"]
+        assert web["depends_on"] == ["api"]
+        assert web["restart"] == "unless-stopped"
+        assert web["healthcheck"] == {"test": ["CMD", "true"]}
+        # the obsolete top-level `version:` key must not be emitted
+        assert "version" not in compose
+
+    def test_unknown_box_keys_are_dropped(self):
+        """Only the passthrough keys and build/networks land in a service;
+        boxman-specific keys (e.g. base_image) are not leaked into compose."""
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"db": {"image": "postgres:16", "base_image": "x"}}}
+        svc = gen.generate("s", cluster, conf_dir="/proj")["services"]["db"]
+        assert svc == {"image": "postgres:16"}
+
+    def test_build_context_dict_resolved_absolute(self):
+        gen = ComposeGenerator()
+        cluster = {
+            "boxes": {
+                "api": {"build": {"context": "./api", "dockerfile": "Dockerfile"}},
+            },
+        }
+        svc = gen.generate("s", cluster, conf_dir="/proj/conf")["services"]["api"]
+        assert svc["build"]["context"] == "/proj/conf/api"
+        assert svc["build"]["dockerfile"] == "Dockerfile"
+
+    def test_build_context_string_resolved_absolute(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"api": {"build": "api"}}}
+        svc = gen.generate("s", cluster, conf_dir="/proj")["services"]["api"]
+        assert svc["build"] == "/proj/api"
+
+    def test_cluster_internal_networks_become_top_level(self):
+        gen = ComposeGenerator()
+        cluster = {
+            "networks": {"backend": {"subnet": "172.30.0.0/24"}},
+            "boxes": {
+                "web": {"image": "nginx", "networks": ["backend"]},
+            },
+        }
+        compose = gen.generate("s", cluster, conf_dir="/proj")
+        assert compose["networks"]["backend"] == {
+            "driver": "bridge",
+            "ipam": {"config": [{"subnet": "172.30.0.0/24"}]},
+        }
+        assert compose["services"]["web"]["networks"] == ["backend"]
+
+    def test_network_without_subnet_defaults_to_bridge(self):
+        gen = ComposeGenerator()
+        cluster = {"networks": {"backend": {}}, "boxes": {"w": {"image": "x"}}}
+        compose = gen.generate("s", cluster, conf_dir="/proj")
+        assert compose["networks"]["backend"] == {"driver": "bridge"}
+
+    def test_compose_extra_deep_merge_cluster_and_box(self):
+        gen = ComposeGenerator()
+        cluster = {
+            "compose_extra": {"services": {"web": {"labels": {"team": "infra"}}}},
+            "boxes": {
+                "web": {
+                    "image": "nginx",
+                    "compose_extra": {"labels": {"role": "frontend"}},
+                },
+            },
+        }
+        svc = gen.generate("s", cluster, conf_dir="/proj")["services"]["web"]
+        # per-box escape hatch merges onto the service
+        assert svc["labels"]["role"] == "frontend"
+        # per-cluster escape hatch merges onto the whole compose dict
+        assert svc["labels"]["team"] == "infra"
+
+    def test_box_compose_extra_overrides_generated_key(self):
+        gen = ComposeGenerator()
+        cluster = {
+            "boxes": {
+                "web": {"image": "nginx", "compose_extra": {"image": "nginx:pinned"}},
+            },
+        }
+        svc = gen.generate("s", cluster, conf_dir="/proj")["services"]["web"]
+        assert svc["image"] == "nginx:pinned"
+
+    def test_network_compose_extra_merges_onto_spec(self):
+        gen = ComposeGenerator()
+        cluster = {
+            "networks": {
+                "backend": {"subnet": "10.0.0.0/24", "compose_extra": {"internal": True}},
+            },
+            "boxes": {"w": {"image": "x", "networks": ["backend"]}},
+        }
+        net = gen.generate("s", cluster, conf_dir="/proj")["networks"]["backend"]
+        assert net["internal"] is True
+        assert net["driver"] == "bridge"
+
+    def test_volumes_warn_and_skip(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"db": {"image": "postgres", "volumes": ["data:/var/lib"]}}}
+        with mock.patch.object(gen.logger, "warning") as warn:
+            svc = gen.generate("s", cluster, conf_dir="/proj")["services"]["db"]
+        assert "volumes" not in svc
+        assert warn.called
+        assert "Phase 5" in warn.call_args[0][0]
+
+    def test_shared_network_ref_warned_and_skipped(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"w": {"image": "x", "networks": ["labnet"]}}}
+        with mock.patch.object(gen.logger, "warning") as warn:
+            svc = gen.generate(
+                "s", cluster, conf_dir="/proj", shared_network_names=["labnet"]
+            )["services"]["w"]
+        assert "networks" not in svc
+        assert warn.called
+        assert "Phase 4" in warn.call_args[0][0]
+
+    def test_unknown_network_ref_warned_and_skipped(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"w": {"image": "x", "networks": ["ghost"]}}}
+        with mock.patch.object(gen.logger, "warning") as warn:
+            svc = gen.generate("s", cluster, conf_dir="/proj")["services"]["w"]
+        assert "networks" not in svc
+        assert warn.called
+
+    def test_box_without_image_or_build_raises(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"broken": {"environment": ["X=1"]}}}
+        with pytest.raises(ConfigError, match=r"must define 'image:' or 'build:'"):
+            gen.generate("s", cluster, conf_dir="/proj")
+
+    def test_write_produces_valid_yaml_file(self, tmp_path):
+        gen = ComposeGenerator()
+        compose = gen.generate(
+            "s", {"boxes": {"w": {"image": "nginx"}}}, conf_dir="/proj"
+        )
+        path = gen.write(compose, str(tmp_path))
+        assert path == os.path.join(str(tmp_path), "docker-compose.yml")
+        with open(path) as fobj:
+            loaded = yaml.safe_load(fobj)
+        assert loaded["services"]["w"]["image"] == "nginx"
+        assert "version" not in loaded
+
+
+# --------------------------------------------------------------------------
+# ComposeRunner
+# --------------------------------------------------------------------------
+def _ok(stdout="", stderr=""):
+    return SimpleNamespace(ok=True, stdout=stdout, stderr=stderr)
+
+
+def _fail(stdout="", stderr="boom"):
+    return SimpleNamespace(ok=False, stdout=stdout, stderr=stderr)
+
+
+class TestComposeRunner:
+
+    def _runner(self):
+        return ComposeRunner(
+            project="proj_stack",
+            compose_file="/wd/docker-compose.yml",
+            workdir="/wd",
+        )
+
+    def test_base_command_shape(self):
+        base = self._runner()._base()
+        assert base == (
+            "docker compose -p proj_stack "
+            "-f /wd/docker-compose.yml "
+            "--project-directory /wd"
+        )
+
+    def test_up_command_and_wait_timeout(self):
+        runner = self._runner()
+        with mock.patch(
+            "boxman.providers.docker_compose.compose_runner.run",
+            return_value=_ok(),
+        ) as run:
+            runner.up(45)
+        cmd = run.call_args[0][0]
+        assert "up -d --wait --wait-timeout 45" in cmd
+        assert cmd.startswith("docker compose -p proj_stack")
+
+    def test_up_default_timeout(self):
+        runner = self._runner()
+        with mock.patch(
+            "boxman.providers.docker_compose.compose_runner.run",
+            return_value=_ok(),
+        ) as run:
+            runner.up()
+        assert f"--wait-timeout {DEFAULT_READINESS_TIMEOUT}" in run.call_args[0][0]
+
+    def test_up_raises_provision_error_on_failure(self):
+        runner = self._runner()
+        with mock.patch(
+            "boxman.providers.docker_compose.compose_runner.run",
+            return_value=_fail(stderr="service unhealthy"),
+        ):
+            with pytest.raises(ProvisionError, match=r"service unhealthy"):
+                runner.up(10)
+
+    def test_down_stop_start_commands(self):
+        runner = self._runner()
+        with mock.patch(
+            "boxman.providers.docker_compose.compose_runner.run",
+            return_value=_ok(),
+        ) as run:
+            runner.down()
+            runner.down_volumes()
+            runner.stop()
+            runner.start()
+        cmds = [c.args[0] for c in run.call_args_list]
+        assert any(c.endswith("down --remove-orphans") for c in cmds)
+        assert any("down --volumes --remove-orphans" in c for c in cmds)
+        assert any(c.endswith(" stop") for c in cmds)
+        assert any(c.endswith(" start") for c in cmds)
+
+    def test_project_and_file_are_shell_quoted(self):
+        runner = ComposeRunner(
+            project="pr oj",
+            compose_file="/w d/docker-compose.yml",
+            workdir="/w d",
+        )
+        base = runner._base()
+        assert "'pr oj'" in base
+        assert "'/w d/docker-compose.yml'" in base
+
+    def test_preflight_missing_docker_raises(self):
+        runner = self._runner()
+        with mock.patch(
+            "boxman.providers.docker_compose.compose_runner.shutil.which",
+            return_value=None,
+        ):
+            with pytest.raises(RuntimeUnavailable, match=r"'docker' is not on PATH"):
+                runner.preflight()
+
+    def test_preflight_missing_compose_plugin_raises(self):
+        runner = self._runner()
+        with mock.patch(
+            "boxman.providers.docker_compose.compose_runner.shutil.which",
+            return_value="/usr/bin/docker",
+        ), mock.patch(
+            "boxman.providers.docker_compose.compose_runner.run",
+            return_value=_fail(),
+        ):
+            with pytest.raises(RuntimeUnavailable, match=r"Compose v2 plugin"):
+                runner.preflight()
+
+    def test_preflight_ok(self):
+        runner = self._runner()
+        with mock.patch(
+            "boxman.providers.docker_compose.compose_runner.shutil.which",
+            return_value="/usr/bin/docker",
+        ), mock.patch(
+            "boxman.providers.docker_compose.compose_runner.run",
+            return_value=_ok(),
+        ):
+            runner.preflight()  # no raise
+
+
+# --------------------------------------------------------------------------
+# DockerComposeSession
+# --------------------------------------------------------------------------
+class _FakeRunner:
+    """Records coarse-method calls without touching docker."""
+
+    def __init__(self):
+        self.project = "proj_stack"
+        self.calls: list = []
+
+    def preflight(self):
+        self.calls.append(("preflight",))
+
+    def up(self, timeout):
+        self.calls.append(("up", timeout))
+
+    def down(self):
+        self.calls.append(("down",))
+
+    def down_volumes(self):
+        self.calls.append(("down_volumes",))
+
+    def stop(self):
+        self.calls.append(("stop",))
+
+    def start(self):
+        self.calls.append(("start",))
+
+
+class TestDockerComposeSession:
+
+    def _session(self, runtime="local"):
+        session = DockerComposeSession({"provider": {"docker-compose": {}}})
+        session.manager = SimpleNamespace(runtime=runtime, config_path="/proj/conf.yml")
+        return session
+
+    def _patch_context(self, session, runner, compose_file="/wd/docker-compose.yml"):
+        return mock.patch.object(
+            session, "_compose_context",
+            return_value=(runner, "/wd", compose_file),
+        )
+
+    def test_satisfies_provider_protocol(self):
+        assert isinstance(self._session(), ProviderSession)
+
+    def test_registry_builds_the_session(self):
+        session = create_session(
+            "docker-compose", {"provider": {"docker-compose": {}}})
+        assert isinstance(session, DockerComposeSession)
+
+    def test_up_cluster_preflights_and_ups_with_timeout(self):
+        session = self._session()
+        runner = _FakeRunner()
+        with self._patch_context(session, runner):
+            session.up_cluster("stack", {"readiness_timeout": 30})
+        assert ("preflight",) in runner.calls
+        assert ("up", 30) in runner.calls
+
+    def test_up_cluster_default_timeout(self):
+        session = self._session()
+        runner = _FakeRunner()
+        with self._patch_context(session, runner):
+            session.up_cluster("stack", {})
+        assert ("up", DEFAULT_READINESS_TIMEOUT) in runner.calls
+
+    def test_stop_cluster_calls_stop(self):
+        session = self._session()
+        runner = _FakeRunner()
+        with self._patch_context(session, runner):
+            session.stop_cluster("stack", {})
+        assert runner.calls == [("stop",)]
+
+    def test_start_cluster_calls_start(self):
+        session = self._session()
+        runner = _FakeRunner()
+        with self._patch_context(session, runner):
+            session.start_cluster("stack", {})
+        assert runner.calls == [("start",)]
+
+    def test_down_cluster_calls_down(self):
+        session = self._session()
+        runner = _FakeRunner()
+        with self._patch_context(session, runner):
+            session.down_cluster("stack", {})
+        assert runner.calls == [("down",)]
+
+    def test_destroy_cluster_downs_volumes_and_removes_file(self, tmp_path):
+        session = self._session()
+        runner = _FakeRunner()
+        compose_file = tmp_path / "docker-compose.yml"
+        compose_file.write_text("services: {}\n")
+        with self._patch_context(session, runner, str(compose_file)):
+            session.destroy_cluster("stack", {})
+        assert runner.calls == [("down_volumes",)]
+        assert not compose_file.exists()
+
+    def test_require_local_runtime_guardrail(self):
+        session = self._session(runtime="docker-compose")
+        with pytest.raises(ConfigError, match=r"requires runtime 'local'"):
+            session.up_cluster("stack", {"workdir": "/wd"})
+
+    @pytest.mark.parametrize("method,args", [
+        ("start_vm", ("vm",)),
+        ("destroy_vm", ("vm",)),
+        ("clone_vm", ("new", "src", {}, "/wd")),
+        ("define_network", ()),
+        ("destroy_network", ()),
+        ("remove_network", ()),
+        ("snapshot_take", ()),
+        ("snapshot_restore", ("vm",)),
+        ("snapshot_delete", ("vm", "snap")),
+        ("snapshot_list", ()),
+    ])
+    def test_per_vm_protocol_methods_raise(self, method, args):
+        session = self._session()
+        with pytest.raises(ProvisionError, match=r"cluster-scoped"):
+            getattr(session, method)(*args)
+
+    def test_compose_project_name_is_sanitized_and_scoped(self):
+        session = DockerComposeSession(
+            {"project": "My Proj", "provider": {"docker-compose": {}}})
+        assert session._compose_project("stack-1") == "my_proj_stack-1"
+
+    def test_sanitize_project_name(self):
+        assert _sanitize_project_name("A/B C") == "a_b_c"
+        assert _sanitize_project_name("__weird") == "weird"
+        assert _sanitize_project_name("---") == "boxman"
+
+
+# --------------------------------------------------------------------------
+# Manager dispatch (coarse per-cluster seam)
+# --------------------------------------------------------------------------
+class _RecordingSession:
+    def __init__(self):
+        self.calls: list = []
+
+    def up_cluster(self, name, cfg):
+        self.calls.append(("up", name))
+
+    def stop_cluster(self, name, cfg):
+        self.calls.append(("stop", name))
+
+    def start_cluster(self, name, cfg):
+        self.calls.append(("start", name))
+
+    def down_cluster(self, name, cfg):
+        self.calls.append(("down", name))
+
+    def destroy_cluster(self, name, cfg):
+        self.calls.append(("destroy", name))
+
+
+class TestManagerDispatch:
+
+    def _mixed_manager(self):
+        manager = BoxmanManager()
+        manager.config = {
+            "project": "proj",
+            "provider": {"libvirt": {}},
+            "clusters": {
+                "vms": {"vms": {"vm1": {}}},
+                "svc": {"provider": "docker-compose", "boxes": {"web": {"image": "x"}}},
+            },
+        }
+        dc = _RecordingSession()
+        manager.register_session("docker-compose", dc)
+        return manager, dc
+
+    def test_partition_vm_vs_compose_clusters(self):
+        manager, _ = self._mixed_manager()
+        assert set(manager._vm_clusters) == {"vms"}
+        assert set(manager._compose_clusters()) == {"svc"}
+        assert manager._is_compose_cluster("svc") is True
+        assert manager._is_compose_cluster("vms") is False
+
+    def test_provision_compose_routes_only_dc_clusters(self):
+        manager, dc = self._mixed_manager()
+        manager.provision_compose_clusters()
+        assert dc.calls == [("up", "svc")]
+
+    def test_all_lifecycle_helpers_route_to_session(self):
+        manager, dc = self._mixed_manager()
+        manager.stop_compose_clusters()
+        manager.start_compose_clusters()
+        manager.deprovision_compose_clusters()
+        manager.destroy_compose_clusters()
+        assert dc.calls == [
+            ("stop", "svc"),
+            ("start", "svc"),
+            ("down", "svc"),
+            ("destroy", "svc"),
+        ]
+
+    def test_libvirt_only_project_has_no_compose_work(self):
+        manager = BoxmanManager()
+        manager.config = {
+            "project": "proj",
+            "provider": {"libvirt": {}},
+            "clusters": {"a": {"vms": {"vm1": {}}}},
+        }
+        assert manager._compose_clusters() == {}
+        # coarse helpers are safe no-ops (no dc session registered)
+        manager.provision_compose_clusters()
+        manager.destroy_compose_clusters()
+
+    def test_dc_only_project_partitions_all_clusters_as_compose(self):
+        manager = BoxmanManager()
+        manager.config = {
+            "project": "proj",
+            "provider": {"docker-compose": {}},
+            "clusters": {"svc": {"boxes": {"web": {"image": "x"}}}},
+        }
+        dc = _RecordingSession()
+        manager.register_session("docker-compose", dc)
+        assert manager._vm_clusters == {}
+        assert set(manager._compose_clusters()) == {"svc"}
+        manager.provision_compose_clusters()
+        assert dc.calls == [("up", "svc")]

--- a/tests/test_docker_compose_provider.py
+++ b/tests/test_docker_compose_provider.py
@@ -76,13 +76,30 @@ class TestComposeGenerator:
         # the obsolete top-level `version:` key must not be emitted
         assert "version" not in compose
 
-    def test_unknown_box_keys_are_dropped(self):
-        """Only the passthrough keys and build/networks land in a service;
-        boxman-specific keys (e.g. base_image) are not leaked into compose."""
+    def test_unknown_box_keys_dropped_with_warning(self):
+        """Keys outside the Phase-3 box schema (e.g. a carried-over libvirt
+        'base_image', or a typo) are dropped from the service AND warned about
+        — not silently swallowed."""
         gen = ComposeGenerator()
-        cluster = {"boxes": {"db": {"image": "postgres:16", "base_image": "x"}}}
-        svc = gen.generate("s", cluster, conf_dir="/proj")["services"]["db"]
+        cluster = {"boxes": {"db": {"image": "postgres:16", "base_image": "x",
+                                    "enviroment": ["TYPO=1"]}}}
+        with mock.patch.object(gen.logger, "warning") as warn:
+            svc = gen.generate("s", cluster, conf_dir="/proj")["services"]["db"]
         assert svc == {"image": "postgres:16"}
+        assert warn.called
+        msg = warn.call_args[0][0]
+        assert "base_image" in msg and "enviroment" in msg
+
+    def test_known_box_keys_do_not_warn(self):
+        """A well-formed box (only recognised keys, incl. volumes/compose_extra)
+        raises no unknown-key warning."""
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"web": {"image": "nginx", "networks": [],
+                                     "compose_extra": {"labels": {"a": "b"}}}}}
+        with mock.patch.object(gen.logger, "warning") as warn:
+            gen.generate("s", cluster, conf_dir="/proj")
+        assert not any(
+            "unknown key" in str(c.args[0]) for c in warn.call_args_list)
 
     def test_build_context_dict_resolved_absolute(self):
         gen = ComposeGenerator()
@@ -100,6 +117,26 @@ class TestComposeGenerator:
         cluster = {"boxes": {"api": {"build": "api"}}}
         svc = gen.generate("s", cluster, conf_dir="/proj")["services"]["api"]
         assert svc["build"] == "/proj/api"
+
+    @pytest.mark.parametrize("ctx", [
+        "https://github.com/docker/awesome-compose.git#main",
+        "git@github.com:docker/awesome-compose.git",
+        "github.com/docker/awesome-compose",
+        "git://example.com/repo.git",
+    ])
+    def test_remote_build_context_string_preserved(self, ctx):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"api": {"build": ctx}}}
+        svc = gen.generate("s", cluster, conf_dir="/proj")["services"]["api"]
+        assert svc["build"] == ctx  # not resolved onto conf_dir
+
+    def test_remote_build_context_mapping_preserved(self):
+        gen = ComposeGenerator()
+        ctx = "https://github.com/docker/awesome-compose.git#main"
+        cluster = {"boxes": {"api": {"build": {"context": ctx, "dockerfile": "Dockerfile"}}}}
+        svc = gen.generate("s", cluster, conf_dir="/proj")["services"]["api"]
+        assert svc["build"]["context"] == ctx
+        assert svc["build"]["dockerfile"] == "Dockerfile"
 
     def test_cluster_internal_networks_become_top_level(self):
         gen = ComposeGenerator()
@@ -189,6 +226,25 @@ class TestComposeGenerator:
         assert "networks" not in svc
         assert warn.called
 
+    def test_corrupted_templating_warns(self):
+        """A '{word}' token (the signature of a mangled bare '{{ word }}') in a
+        compose command:/environment: value is flagged."""
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"web": {"image": "nginx",
+                                     "command": "echo {hostname}"}}}
+        with mock.patch.object(gen.logger, "warning") as warn:
+            gen.generate("s", cluster, conf_dir="/proj")
+        assert any("token" in str(c.args[0]) for c in warn.call_args_list)
+
+    def test_dollar_var_interpolation_does_not_warn(self):
+        """'${VAR}' is a safe compose interpolation — not corruption."""
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"web": {"image": "nginx",
+                                     "environment": ["HOST=${HOSTVAR}"]}}}
+        with mock.patch.object(gen.logger, "warning") as warn:
+            gen.generate("s", cluster, conf_dir="/proj")
+        assert not any("token" in str(c.args[0]) for c in warn.call_args_list)
+
     def test_box_without_image_or_build_raises(self):
         gen = ComposeGenerator()
         cluster = {"boxes": {"broken": {"environment": ["X=1"]}}}
@@ -235,6 +291,22 @@ class TestComposeRunner:
             "-f /wd/docker-compose.yml "
             "--project-directory /wd"
         )
+
+    def test_base_command_label_only(self):
+        """A teardown runner with no file/workdir operates by project label."""
+        runner = ComposeRunner(project="proj_stack")
+        assert runner._base() == "docker compose -p proj_stack"
+
+    def test_use_sudo_prefixes_command(self):
+        runner = ComposeRunner(
+            project="proj_stack", compose_file="/wd/docker-compose.yml",
+            workdir="/wd", use_sudo=True)
+        assert runner._base().startswith("sudo docker compose -p proj_stack")
+
+    def test_up_without_compose_file_raises(self):
+        runner = ComposeRunner(project="proj_stack")  # label-only
+        with pytest.raises(ProvisionError, match=r"without a compose file"):
+            runner.up(10)
 
     def test_up_command_and_wait_timeout(self):
         runner = self._runner()
@@ -366,6 +438,12 @@ class TestDockerComposeSession:
             return_value=(runner, "/wd", compose_file),
         )
 
+    def _patch_teardown(self, session, runner, compose_file="/wd/docker-compose.yml"):
+        return mock.patch.object(
+            session, "_teardown_runner",
+            return_value=(runner, "/wd", compose_file),
+        )
+
     def test_satisfies_provider_protocol(self):
         assert isinstance(self._session(), ProviderSession)
 
@@ -389,24 +467,34 @@ class TestDockerComposeSession:
             session.up_cluster("stack", {})
         assert ("up", DEFAULT_READINESS_TIMEOUT) in runner.calls
 
+    def test_readiness_timeout_non_integer_raises(self):
+        session = self._session()
+        with pytest.raises(ConfigError, match=r"readiness_timeout must be an integer"):
+            session.up_cluster("stack", {"readiness_timeout": "soon"})
+
+    def test_readiness_timeout_non_positive_raises(self):
+        session = self._session()
+        with pytest.raises(ConfigError, match=r"must be a positive integer"):
+            session.up_cluster("stack", {"readiness_timeout": 0})
+
     def test_stop_cluster_calls_stop(self):
         session = self._session()
         runner = _FakeRunner()
-        with self._patch_context(session, runner):
+        with self._patch_teardown(session, runner):
             session.stop_cluster("stack", {})
         assert runner.calls == [("stop",)]
 
     def test_start_cluster_calls_start(self):
         session = self._session()
         runner = _FakeRunner()
-        with self._patch_context(session, runner):
+        with self._patch_teardown(session, runner):
             session.start_cluster("stack", {})
         assert runner.calls == [("start",)]
 
     def test_down_cluster_calls_down(self):
         session = self._session()
         runner = _FakeRunner()
-        with self._patch_context(session, runner):
+        with self._patch_teardown(session, runner):
             session.down_cluster("stack", {})
         assert runner.calls == [("down",)]
 
@@ -415,10 +503,59 @@ class TestDockerComposeSession:
         runner = _FakeRunner()
         compose_file = tmp_path / "docker-compose.yml"
         compose_file.write_text("services: {}\n")
-        with self._patch_context(session, runner, str(compose_file)):
+        with self._patch_teardown(session, runner, str(compose_file)):
             session.destroy_cluster("stack", {})
         assert runner.calls == [("down_volumes",)]
         assert not compose_file.exists()
+
+    # -- teardown is best-effort but not silent (Finding 7) ----------------
+
+    def test_teardown_warns_and_returns_false_on_failure(self):
+        session = self._session()
+
+        class _FailRunner:
+            def stop(self):
+                return SimpleNamespace(ok=False, stdout="", stderr="daemon down")
+
+        with self._patch_teardown(session, _FailRunner()):
+            assert session.stop_cluster("stack", {}) is False
+
+    def test_destroy_keeps_file_when_teardown_fails(self, tmp_path):
+        session = self._session()
+        compose_file = tmp_path / "docker-compose.yml"
+        compose_file.write_text("services: {}\n")
+
+        class _FailRunner:
+            def down_volumes(self):
+                return SimpleNamespace(ok=False, stdout="", stderr="boom")
+
+        with self._patch_teardown(session, _FailRunner(), str(compose_file)):
+            assert session.destroy_cluster("stack", {}) is False
+        assert compose_file.exists()  # kept for retry
+
+    # -- teardown never regenerates (Finding 5) ----------------------------
+
+    def test_teardown_runner_uses_ondisk_file_without_regenerating(self, tmp_path):
+        session = self._session()
+        (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+        with mock.patch.object(session._generator, "generate") as gen:
+            runner, wd, cf = session._teardown_runner("app", {"workdir": str(tmp_path)})
+        gen.assert_not_called()
+        assert runner.compose_file == str(tmp_path / "docker-compose.yml")
+        assert "-f " in runner._base()
+
+    def test_teardown_runner_label_only_when_file_absent(self, tmp_path):
+        session = self._session()
+        runner, wd, cf = session._teardown_runner("app", {"workdir": str(tmp_path)})
+        assert runner.compose_file is None
+        base = runner._base()
+        assert "-f " not in base
+        assert base.startswith("docker compose -p ")
+
+    def test_teardown_missing_workdir_raises_configerror(self):
+        session = self._session()
+        with pytest.raises(ConfigError, match=r"no 'workdir:'"):
+            session._teardown_runner("app", {})
 
     def test_require_local_runtime_guardrail(self):
         session = self._session(runtime="docker-compose")
@@ -460,6 +597,10 @@ class _RecordingSession:
     def __init__(self):
         self.calls: list = []
 
+    def compose_project_name(self, name):
+        # unique per cluster → no spurious collision in dispatch tests
+        return f"proj_{name}"
+
     def up_cluster(self, name, cfg):
         self.calls.append(("up", name))
 
@@ -495,7 +636,7 @@ class TestManagerDispatch:
     def test_partition_vm_vs_compose_clusters(self):
         manager, _ = self._mixed_manager()
         assert set(manager._vm_clusters) == {"vms"}
-        assert set(manager._compose_clusters()) == {"svc"}
+        assert set(manager._compose_clusters) == {"svc"}
         assert manager._is_compose_cluster("svc") is True
         assert manager._is_compose_cluster("vms") is False
 
@@ -524,10 +665,65 @@ class TestManagerDispatch:
             "provider": {"libvirt": {}},
             "clusters": {"a": {"vms": {"vm1": {}}}},
         }
-        assert manager._compose_clusters() == {}
+        assert manager._compose_clusters == {}
         # coarse helpers are safe no-ops (no dc session registered)
         manager.provision_compose_clusters()
         manager.destroy_compose_clusters()
+
+    def test_provision_rejects_compose_project_name_collision(self):
+        """Two dc clusters whose names sanitize to the same compose project
+        (web.api vs web_api) are rejected before any compose state is created
+        — teardown's --remove-orphans would otherwise cross-delete."""
+        manager = BoxmanManager()
+        manager.config = {
+            "project": "proj",
+            "provider": {"docker-compose": {}},
+            "clusters": {
+                "web.api": {"provider": "docker-compose",
+                            "boxes": {"a": {"image": "x"}}},
+                "web_api": {"provider": "docker-compose",
+                            "boxes": {"b": {"image": "y"}}},
+            },
+        }
+        session = DockerComposeSession(manager.config)
+        session.manager = manager
+        manager.register_session("docker-compose", session)
+        with pytest.raises(ConfigError, match=r"both map to docker compose project"):
+            manager.provision_compose_clusters()
+
+    def test_storage_pool_uses_cluster_libvirt_session_not_dc_default(self, monkeypatch):
+        """Finding 2: in a compose-primary mixed project, self.provider is the
+        dc session; _ensure_libvirt_storage_pool must build VirshCommand from
+        the libvirt cluster's own session config (its URI), not the dc default."""
+        from boxman import manager as mgr_mod
+
+        m = BoxmanManager()
+        m.config = {
+            "project": "proj",
+            "provider": {"docker-compose": {}, "libvirt": {"uri": "qemu+ssh://remote/system"}},
+            "clusters": {
+                "svc": {"provider": "docker-compose", "workdir": "/tmp/dc",
+                        "boxes": {"w": {"image": "x"}}},
+                "vms": {"provider": "libvirt", "workdir": "/tmp/vm", "vms": {"n": {}}},
+            },
+        }
+        # dc session registered first → becomes the legacy default self.provider
+        m.register_session("docker-compose", DockerComposeSession(m.config))
+        m.register_session(
+            "libvirt", SimpleNamespace(provider_config={"uri": "qemu+ssh://remote/system"}))
+
+        captured = {}
+
+        class _FakeVirsh:
+            def __init__(self, provider_config):
+                captured["cfg"] = provider_config
+
+            def execute(self, *a, **k):
+                return SimpleNamespace(ok=True, stdout="", stderr="")
+
+        monkeypatch.setattr(mgr_mod, "VirshCommand", _FakeVirsh)
+        m._ensure_libvirt_storage_pool("/tmp/vm", "vms")
+        assert captured["cfg"] == {"uri": "qemu+ssh://remote/system"}
 
     def test_dc_only_project_partitions_all_clusters_as_compose(self):
         manager = BoxmanManager()
@@ -539,6 +735,116 @@ class TestManagerDispatch:
         dc = _RecordingSession()
         manager.register_session("docker-compose", dc)
         assert manager._vm_clusters == {}
-        assert set(manager._compose_clusters()) == {"svc"}
+        assert set(manager._compose_clusters) == {"svc"}
         manager.provision_compose_clusters()
         assert dc.calls == [("up", "svc")]
+
+
+# --------------------------------------------------------------------------
+# Flow wiring — pin the compose hooks inside provision/up/down/deprovision/
+# destroy (and their ordering vs libvirt/netlab). Without these, deleting a
+# hook keeps the rest of the suite green (Finding 18). The compose helpers and
+# the libvirt/cache/netlab collaborators are replaced with recorders/no-ops so
+# no real docker or libvirt is touched.
+# --------------------------------------------------------------------------
+class TestFlowWiring:
+
+    def _mgr(self):
+        m = BoxmanManager()
+        m.config = {
+            "project": "proj",
+            "provider": {"docker-compose": {}},
+            "clusters": {
+                "app": {"provider": "docker-compose", "workdir": "/tmp/dc",
+                        "boxes": {"w": {"image": "nginx"}}},
+            },
+        }
+        return m
+
+    def _neutralize(self, m, monkeypatch, order):
+        """Stub the resource-touching collaborators; record the ordering hooks."""
+        m.cache.projects = {}
+        monkeypatch.setattr(m.cache, "read_projects_cache", lambda: None)
+        # no-op the libvirt/cache/ssh/files collaborators
+        for name in [
+            "register_project_in_cache", "unregister_from_cache",
+            "_expand_oci_base_images", "ensure_templates_exist",
+            "validate_base_images", "provision_files", "deprovision_files",
+            "ensure_shared_bridges", "setup_ssh_access", "connect_info",
+            "write_ssh_config", "define_networks", "destroy_networks",
+        ]:
+            monkeypatch.setattr(m, name, lambda *a, **k: None)
+        monkeypatch.setattr(m, "_find_existing_project_vms", lambda *a, **k: [])
+        monkeypatch.setattr(m, "_get_vm_states", lambda *a, **k: {})
+        monkeypatch.setattr(m, "get_connect_info", lambda *a, **k: True)
+        # record the ordering-relevant hooks
+        monkeypatch.setattr(m, "configure_and_start_vms", lambda: order.append("vms"))
+        monkeypatch.setattr(m, "deploy_netlab", lambda: order.append("netlab"))
+        monkeypatch.setattr(m, "ensure_netlab_up", lambda: order.append("netlab_up"))
+        monkeypatch.setattr(m, "destroy_netlab", lambda: order.append("netlab_down"))
+        for hook in ["provision_compose_clusters", "stop_compose_clusters",
+                     "start_compose_clusters", "deprovision_compose_clusters",
+                     "destroy_compose_clusters"]:
+            monkeypatch.setattr(m, hook, (lambda h: lambda: order.append(h))(hook))
+
+    def test_provision_brings_compose_up_after_vms_before_netlab(self, monkeypatch):
+        m = self._mgr()
+        order = []
+        self._neutralize(m, monkeypatch, order)
+        BoxmanManager.provision(m, SimpleNamespace(force=False, rebuild_templates=False))
+        assert "provision_compose_clusters" in order
+        assert order.index("vms") < order.index("provision_compose_clusters") < order.index("netlab")
+
+    def test_down_stops_compose_clusters(self, monkeypatch):
+        m = self._mgr()
+        order = []
+        self._neutralize(m, monkeypatch, order)
+        BoxmanManager.down(m, SimpleNamespace(suspend=False))
+        assert "stop_compose_clusters" in order
+
+    def test_deprovision_tears_down_compose_after_netlab(self, monkeypatch):
+        m = self._mgr()
+        order = []
+        self._neutralize(m, monkeypatch, order)
+        BoxmanManager.deprovision(m, SimpleNamespace(cleanup=False))
+        assert "deprovision_compose_clusters" in order
+        assert order.index("netlab_down") < order.index("deprovision_compose_clusters")
+
+    def test_destroy_destroys_compose_clusters(self, monkeypatch):
+        m = self._mgr()
+        order = []
+        self._neutralize(m, monkeypatch, order)
+        m.cache.projects = {"proj": {"conf": "x", "runtime": "local"}}
+        monkeypatch.setattr(m, "_force_rmtree", lambda *a, **k: None)
+        BoxmanManager.destroy(m, SimpleNamespace(auto_accept=True, templates=False))
+        assert "destroy_compose_clusters" in order
+
+    def test_up_dc_only_first_run_routes_through_provision(self, monkeypatch):
+        m = self._mgr()
+        order = []
+        self._neutralize(m, monkeypatch, order)
+        monkeypatch.setattr(m, "_get_project_vm_names", lambda *a, **k: [])
+        # project not in cache → first run → full provision()
+        monkeypatch.setattr(m, "provision", lambda *a, **k: order.append("provision"))
+        BoxmanManager.up(m, SimpleNamespace(force=False))
+        assert order == ["provision"]
+
+    def test_up_dc_only_reconcile_calls_compose_up(self, monkeypatch):
+        m = self._mgr()
+        order = []
+        self._neutralize(m, monkeypatch, order)
+        monkeypatch.setattr(m, "_get_project_vm_names", lambda *a, **k: [])
+        m.cache.projects = {"proj": {"conf": "x", "runtime": "local"}}  # already provisioned
+        BoxmanManager.up(m, SimpleNamespace(force=False))
+        assert order == ["provision_compose_clusters"]
+
+    def test_up_all_vms_running_reconciles_compose(self, monkeypatch):
+        m = self._mgr()
+        order = []
+        self._neutralize(m, monkeypatch, order)
+        # simulate a mixed project whose libvirt VMs are all already running
+        monkeypatch.setattr(m, "_get_project_vm_names", lambda *a, **k: ["vm1"])
+        monkeypatch.setattr(m, "_get_vm_states", lambda *a, **k: {"vm1": "running"})
+        BoxmanManager.up(m, SimpleNamespace(force=False))
+        assert "provision_compose_clusters" in order
+        assert order.index("netlab_up") < order.index("provision_compose_clusters")

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -53,9 +53,14 @@ class TestCreateSession:
         assert isinstance(session, FakeVirtualbox)
         assert created_with == [conf]
 
-    def test_docker_compose_is_a_friendly_not_implemented(self):
-        with pytest.raises(NotImplementedError, match=r"Phase 3"):
-            create_session('docker-compose', {})
+    def test_docker_compose_builds_a_session(self):
+        """Phase 3 (#51): the docker-compose provider is now implemented, so
+        the registry constructs a real ``DockerComposeSession`` (it no longer
+        raises the Phase-1 ``NotImplementedError`` stub)."""
+        from boxman.providers.docker_compose.session import DockerComposeSession
+        session = create_session(
+            'docker-compose', {"provider": {"docker-compose": {}}})
+        assert isinstance(session, DockerComposeSession)
 
     def test_unknown_provider_lists_supported_types(self):
         with pytest.raises(ValueError) as excinfo:


### PR DESCRIPTION
## Phase 3 — DockerComposeSession core lifecycle (#51)

Part of the docker-compose provider epic (#42). Phases 0–2 (design, provider
registry, config schema v2.0) are already on `feat/docker-compose-provider`.
Before this PR, a v2.0 config could *declare* a `provider: docker-compose`
cluster but running it exited 2 (no session existed). **Phase 3 makes
`boxman provision / up / down / deprovision / destroy` actually work for a
docker-compose cluster** — default docker **bridge** networks only.

Out of scope (later phases): macvlan/shared-bridge L2 to VMs (#52, Phase 4),
structured volumes (Phase 5), ssh/exec/inventory (Phase 6), snapshots via
`docker commit` (Phase 7).

### Architecture — coarse per-cluster seam
boxman's lifecycle flows are VM-centric (per-VM loops over `cluster['vms']`,
each in its own `multiprocessing.Process`). docker-compose is cluster-centric
(one file + one `docker compose up --wait` per cluster, ADR-001/D1/D5). Rather
than reshape the libvirt flows, the manager **dispatches a whole dc cluster to
session-level coarse methods**, and the existing per-VM/network helpers **skip**
dc clusters. Libvirt flows stay byte-identical.

### New package `src/boxman/providers/docker_compose/`
- **`ComposeGenerator`** — translate `boxes:` → compose `services:`
  (`image`/`command`/`environment`/`ports`/`depends_on`/`restart`/`healthcheck`);
  resolve `build.context` absolute vs the conf.yml dir (D4); cluster-internal
  `networks:` → top-level compose networks (`driver: bridge` + ipam subnet);
  deep-merge per-cluster & per-box `compose_extra:` verbatim (D7); **warn+skip**
  out-of-phase box features (`volumes:` → Phase 5; shared/macvlan network refs →
  Phase 4). Writes `<workdir>/docker-compose.yml` (D5), an inspectable,
  hand-runnable fidelity artifact.
- **`ComposeRunner`** — stateless; shells out to host `docker compose` (mirrors
  `ContainerlabManager` / the docker-compose *runtime*'s host-side calls).
  `preflight()`, `up -d --wait --wait-timeout <readiness_timeout|120>` (D1) →
  `ProvisionError` on failure, `down` / `down --volumes` / `stop` / `start` / `ps`.
- **`DockerComposeSession`** — satisfies the `ProviderSession` protocol
  (`provider_config`/`uri`/`use_sudo`/`update_provider_config*`); coarse
  `up_cluster` / `stop_cluster` / `start_cluster` / `down_cluster` /
  `destroy_cluster`. The per-VM/libvirt-shaped protocol methods
  (`clone_vm`, `start_vm`, `define_network`, `snapshot_*`, …) raise a clear
  "docker-compose is cluster-scoped; use the cluster lifecycle" error — they are
  never reached because the manager takes the coarse path.

### Registry + guardrail
- Registry now returns a real `DockerComposeSession` (Phase-1 stub removed).
- **`runtime: local` guardrail** in `app.py`: a dc-provider cluster with a
  non-local runtime fails fast (exit 2). The `docker-compose` *runtime*
  (libvirt-in-a-container) is a different axis — see `config-schema.md`.
  Defense-in-depth: `up_cluster` re-checks via `self.manager.runtime`.

### Manager integration (libvirt byte-identical)
- New `_vm_clusters` view + `_compose_clusters()` / `_is_compose_cluster()`.
  All per-VM/network/ssh helpers iterate `_vm_clusters` (dc clusters carry
  `boxes:`, not `vms:`, so they're skipped structurally — no `KeyError`).
- Coarse `provision_/stop_/start_/deprovision_/destroy_compose_clusters()`
  helpers wired into provision/up/down/deprovision/destroy (ordering mirrors
  the netlab hooks — dc up after libvirt VMs, torn down before). Cache
  registration is provider-agnostic (unchanged).
- Cosmetic: dc-only `down` no longer logs the libvirt "saving all VMs to disk"
  line when there are no VMs.

### Verification
- **Host unit suite: 1209 passed** (+49 new in `tests/test_docker_compose_provider.py`:
  generator translation, runner command strings, session protocol + coarse
  dispatch, the guardrail, and manager partitioning — all mocked, no live
  docker/libvirt). Stale Phase-1 registry stub test updated.
- **Live nested dc-only e2e inside stage01** (first live-container phase; never
  on the host hypervisor): `boxman provision` a 2-service bridge-network cluster
  (redis + nginx, both healthchecked) → `docker compose up -d --wait` to
  **both healthy**; `up` idempotent (no recreate); `down`→`stop` then `up`→healthy;
  `destroy` removes containers + network + the generated compose file. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
