### PR TITLE
feat(docker-compose): Phase 4 networking — macvlan attach to shared bridges (VM↔container L2)

### DIFF
--- a/boxes/docker-compose-standalone/README.md
+++ b/boxes/docker-compose-standalone/README.md
@@ -35,9 +35,9 @@ boxman provision
 # nginx answers on the published port
 curl -sI localhost:8080 | head -1              # HTTP/1.1 200 OK
 
-# inspect the generated, hand-runnable compose file
-docker compose -f .boxman/web/docker-compose.yml ps
-cat .boxman/web/docker-compose.yml
+# inspect the stack — boxman runs it under project 'dc_standalone_web'
+docker compose -p dc_standalone_web ps
+cat .boxman/web/docker-compose.yml     # emits a top-level 'name:', so `-f <file> ps` also works
 
 # redis is healthy behind the frontend
 docker exec dc_standalone_web-cache-1 redis-cli ping   # PONG

--- a/boxes/docker-compose-standalone/README.md
+++ b/boxes/docker-compose-standalone/README.md
@@ -1,0 +1,63 @@
+# docker-compose-standalone
+
+The simplest **docker-compose provider** example — no libvirt, no VMs. Two
+containers on one cluster-internal bridge network:
+
+```
+frontend (nginx, :8080)  --depends_on: service_healthy-->  cache (redis)
+```
+
+On `boxman provision` boxman translates the `boxes:` into a
+`docker-compose.yml` (written to the cluster `workdir`, `./.boxman/web/`) and
+runs `docker compose up -d --wait`. It shows the core docker-compose surface:
+`image`, `ports`, a `healthcheck`, a `depends_on` with a
+`condition: service_healthy` (passed through verbatim), and a cluster-internal
+bridge network with an explicit `subnet:`.
+
+## Prerequisites
+
+- Docker Engine + the **compose v2** plugin (`docker compose version`).
+- boxman on the **`local` runtime** (the default). The docker-compose provider
+  shells out to `docker compose` on the host; it is a config error under the
+  `docker` runtime.
+- Free TCP port **8080** on the host.
+
+## Bring it up
+
+```bash
+cd boxes/docker-compose-standalone
+boxman provision
+```
+
+## Verify
+
+```bash
+# nginx answers on the published port
+curl -sI localhost:8080 | head -1              # HTTP/1.1 200 OK
+
+# inspect the generated, hand-runnable compose file
+docker compose -f .boxman/web/docker-compose.yml ps
+cat .boxman/web/docker-compose.yml
+
+# redis is healthy behind the frontend
+docker exec dc_standalone_web-cache-1 redis-cli ping   # PONG
+```
+
+`boxman up` is idempotent — re-running reconciles (starts anything stopped and
+re-asserts health).
+
+## Tear down
+
+```bash
+boxman down       # docker compose stop (keeps containers/volumes)
+boxman up         # bring them back
+boxman destroy    # docker compose down --volumes + remove the generated file
+```
+
+## Notes
+
+- The generated `docker-compose.yml` lives under `.boxman/` (git-ignored). It
+  is a fidelity artifact — you can run `docker compose -f ... <cmd>` against it
+  directly.
+- Need a compose feature boxman does not model yet? Add it under
+  `compose_extra:` (per-box or per-cluster) and it is deep-merged verbatim.

--- a/boxes/docker-compose-standalone/conf.yml
+++ b/boxes/docker-compose-standalone/conf.yml
@@ -19,7 +19,7 @@
 #   cd boxes/docker-compose-standalone
 #   boxman provision
 #   curl -sI localhost:8080          # nginx is up
-#   docker compose -f .boxman/web/docker-compose.yml ps
+#   docker compose -p dc_standalone_web ps
 #   boxman destroy
 version: '2.0'
 project: dc_standalone

--- a/boxes/docker-compose-standalone/conf.yml
+++ b/boxes/docker-compose-standalone/conf.yml
@@ -1,0 +1,58 @@
+---
+# docker-compose-standalone
+#
+# A pure docker-compose boxman project — no libvirt, no VMs. Two services on
+# one cluster-internal bridge network, brought up with `docker compose up
+# --wait` under the hood:
+#
+#   frontend (nginx, published :8080) --depends_on(healthy)--> cache (redis)
+#
+# Demonstrates the docker-compose provider on its own: `boxes:` -> compose
+# `services:`, a cluster-internal bridge network with a subnet, published
+# ports, a healthcheck, and a `depends_on: {condition: service_healthy}`
+# (passed through verbatim). The generated docker-compose.yml is written to
+# the cluster `workdir` and is inspectable / hand-runnable.
+#
+# Requires the `local` runtime (the default) — the docker-compose provider
+# shells out to `docker compose` on the host.
+#
+#   cd boxes/docker-compose-standalone
+#   boxman provision
+#   curl -sI localhost:8080          # nginx is up
+#   docker compose -f .boxman/web/docker-compose.yml ps
+#   boxman destroy
+version: '2.0'
+project: dc_standalone
+
+provider:
+  docker-compose:
+    project_name: dc_standalone
+
+clusters:
+  web:
+    provider: docker-compose
+    workdir: ./.boxman/web
+
+    networks:
+      appnet:
+        driver: bridge
+        subnet: 172.28.0.0/24
+
+    boxes:
+      cache:
+        image: redis:7-alpine
+        networks: [appnet]
+        healthcheck:
+          test: ["CMD", "redis-cli", "ping"]
+          interval: 5s
+          timeout: 3s
+          retries: 5
+
+      frontend:
+        image: nginx:1.27-alpine
+        ports:
+          - "8080:80"
+        networks: [appnet]
+        depends_on:
+          cache:
+            condition: service_healthy

--- a/boxes/hybrid-libvirt-docker-compose/README.md
+++ b/boxes/hybrid-libvirt-docker-compose/README.md
@@ -41,9 +41,8 @@ host-unreachable `10.10.0.x` address for node01's management IP.
   with `ssh-copy-id` over a password session (`apt install sshpass` /
   `dnf install sshpass`). Without it, key injection is skipped (non-fatal) and
   you fall back to the guest agent for the checks below.
-- The macvlan support this box relies on lands with **Phase 4** — run it from a
-  checkout that has it (the `feat/docker-compose-provider` line, once #62 is
-  merged).
+- The macvlan support this box relies on requires the
+  `feat/docker-compose-provider` line (the docker-compose provider epic).
 - First run downloads the Ubuntu 24.04 cloud image (~0.5 GB, cached under
   `~/.cache/boxman/images`).
 
@@ -109,7 +108,11 @@ shared bridges can be used by multiple projects, so removing them is an explicit
 action:
 
 ```bash
-sudo ip link del bx_app          # only if nothing else uses it
+# remove the two scoped ACCEPT rules ensure() installed for this bridge...
+sudo iptables -D FORWARD -i bx_app -o bx_app -m physdev --physdev-is-bridged -j ACCEPT
+sudo iptables -D DOCKER-USER -i bx_app -o bx_app -m physdev --physdev-is-bridged -j ACCEPT  # if the chain exists
+# ...then the bridge itself (only if nothing else uses it)
+sudo ip link del bx_app
 ```
 
 ## Troubleshooting

--- a/boxes/hybrid-libvirt-docker-compose/README.md
+++ b/boxes/hybrid-libvirt-docker-compose/README.md
@@ -19,10 +19,15 @@ On `boxman up` boxman:
 1. creates the host bridge `bx_app` and installs a **scoped** per-bridge
    netfilter accept rule (decision D8 — `bridge-nf-call-iptables` is left
    untouched host-wide),
-2. clones/boots `node01` with its second NIC on `bx_app` (static `10.10.0.20`
-   via a per-MAC netplan match — the shared bridge has no DHCP),
+2. clones/boots `node01` with its second NIC (`adapter_2`) attached to `bx_app`,
 3. generates the docker-compose file and brings `web` up: a macvlan network on
    `bx_app` (static `10.10.0.10`) plus a cluster-internal `backend` bridge.
+
+`node01`'s management IP is the DHCP address on its mgmt NIC (that is what
+`boxman ssh` uses). The shared bridge is a plain L2 domain with **no DHCP**, so
+`node01`'s address on it (`10.10.0.20`) is assigned as an explicit step in the
+test below — deliberately not at boot, so boxman doesn't mistake that
+host-unreachable `10.10.0.x` address for node01's management IP.
 
 ## Prerequisites
 
@@ -61,32 +66,35 @@ The container is `hybrid_libvirt_dc_services-web-1` (find it with
 `docker ps --filter name=web`). It has `10.10.0.10` on the shared bridge and a
 `backend` address on `172.31.0.0/24`.
 
-**Ping both ways** (VM `10.10.0.20` ⇄ container `10.10.0.10`):
+**Step 1 — give node01 its address on the shared bridge.** It has no DHCP there,
+so assign it once (the app NIC is the second one, `enp7s0` on this box):
 
 ```bash
-# container -> VM
-docker exec hybrid_libvirt_dc_services-web-1 ping -c3 10.10.0.20
-
-# VM -> container
-boxman ssh compute_node01            # or: ssh -F <workspace>/ssh_config compute_node01
-node01$ ping -c3 10.10.0.10
+boxman ssh compute_node01 -- sudo ip addr add 10.10.0.20/24 dev enp7s0
+boxman ssh compute_node01 -- ip -4 -br addr show enp7s0     # -> 10.10.0.20/24
 ```
 
-**ARP resolves across the bridge** (each side learns the other's real MAC —
-proof this is L2, not routed):
+**Step 2 — ping both ways** (VM `10.10.0.20` ⇄ container `10.10.0.10`):
 
 ```bash
-node01$ ip neigh show 10.10.0.10                 # -> lladdr <container mac> REACHABLE
+docker exec hybrid_libvirt_dc_services-web-1 ping -c3 10.10.0.20   # container -> VM
+boxman ssh compute_node01 -- ping -c3 10.10.0.10                   # VM -> container
+```
+
+**Step 3 — ARP resolves across the bridge** (each side learns the other's real
+MAC — proof this is L2, not routed):
+
+```bash
+boxman ssh compute_node01 -- ip neigh show 10.10.0.10       # -> lladdr <container mac>
 docker exec hybrid_libvirt_dc_services-web-1 ip neigh show 10.10.0.20
 ```
 
-**Cluster-internal isolation** — the container's `backend` address is *not*
-reachable from the VM (only the shared bridge is L2-adjacent):
+**Step 4 — cluster-internal isolation.** The container's `backend` address is
+*not* reachable from the VM (only the shared bridge is L2-adjacent):
 
 ```bash
-# find the container's backend IP
-docker exec hybrid_libvirt_dc_services-web-1 ip -4 addr show eth0
-node01$ ping -c2 -W2 172.31.0.<that ip>          # -> 100% loss (isolated)
+docker exec hybrid_libvirt_dc_services-web-1 ip -4 -br addr   # note the 172.31.0.x
+boxman ssh compute_node01 -- ping -c2 -W2 172.31.0.2          # -> 100% loss (isolated)
 ```
 
 ## Tear down
@@ -110,6 +118,10 @@ sudo ip link del bx_app          # only if nothing else uses it
   as a non-root user: the agent check uses a bare `virsh` (no `-c` URI), which
   defaults to `qemu:///session`. Export `LIBVIRT_DEFAULT_URI=qemu:///system`
   before `boxman up`.
+- **`ssh-copy-id`/`boxman ssh` gets "Permission denied"** right after a
+  `destroy` + `up`: the fresh `node01` reuses the same mgmt IP but has a new
+  host key, so the client refuses password auth against the stale
+  `known_hosts` entry. Clear it: `ssh-keygen -R <node01 mgmt ip>`.
 - **`web` has no internet** (e.g. an in-container package install fails): the
   L2 test does not need it, but if you want it, keep the container's default
   route on `backend` (don't add a `gateway:` to `app_bridge`, as this box does).

--- a/boxes/hybrid-libvirt-docker-compose/README.md
+++ b/boxes/hybrid-libvirt-docker-compose/README.md
@@ -1,0 +1,115 @@
+# hybrid-libvirt-docker-compose
+
+A **libvirt VM and a docker-compose container sharing an L2 domain** — the
+Phase 4 (#52) capability, end to end. Both endpoints attach to the same host
+Linux bridge `bx_app`; the container attaches through a docker **macvlan**
+network whose `parent` is that bridge, so the VM and the container are directly
+L2-adjacent (same broadcast domain, ARP resolves across, no router in between).
+
+```
+node01 (libvirt)                            web (docker-compose)
+  adapter_1  dhcp   -> mgmt NAT               eth0 -> backend 172.31.0.0/24 (cluster-internal)
+  adapter_2  10.10.0.20/24 --\                eth1 -> 10.10.0.10 (macvlan) --\
+                              \                                               \
+                               `----- bx_app  (shared bridge, 10.10.0.0/24) --'
+```
+
+On `boxman up` boxman:
+
+1. creates the host bridge `bx_app` and installs a **scoped** per-bridge
+   netfilter accept rule (decision D8 — `bridge-nf-call-iptables` is left
+   untouched host-wide),
+2. clones/boots `node01` with its second NIC on `bx_app` (static `10.10.0.20`
+   via a per-MAC netplan match — the shared bridge has no DHCP),
+3. generates the docker-compose file and brings `web` up: a macvlan network on
+   `bx_app` (static `10.10.0.10`) plus a cluster-internal `backend` bridge.
+
+## Prerequisites
+
+- **libvirt / qemu-kvm** working under `qemu:///system`, and **Docker + the
+  compose v2 plugin**, both on the same host.
+- boxman on the **`local` runtime** (the default) — the docker-compose provider
+  shells out to `docker compose` on the host.
+- **`sudo`** — the shared bridge is created with `ip link ...` via sudo, and the
+  libvirt provider uses `use_sudo: true`.
+- **`sshpass`** on `PATH` — boxman injects the generated SSH key into the VM
+  with `ssh-copy-id` over a password session (`apt install sshpass` /
+  `dnf install sshpass`). Without it, key injection is skipped (non-fatal) and
+  you fall back to the guest agent for the checks below.
+- The macvlan support this box relies on lands with **Phase 4** — run it from a
+  checkout that has it (the `feat/docker-compose-provider` line, once #62 is
+  merged).
+- First run downloads the Ubuntu 24.04 cloud image (~0.5 GB, cached under
+  `~/.cache/boxman/images`).
+
+> **qemu file access:** under `qemu:///system` the VM runs as `libvirt-qemu`,
+> which must be able to traverse to the VM disks. If your `$HOME` (or the
+> `workspace:`/template dirs) is mode `0700`, grant a search bit, e.g.
+> `sudo setfacl -m u:libvirt-qemu:x $HOME`. virt-install prints the exact
+> directories if this is missing.
+
+## Bring it up
+
+```bash
+cd boxes/hybrid-libvirt-docker-compose
+boxman up
+```
+
+## Verify the shared L2 (ping + ARP + isolation)
+
+The container is `hybrid_libvirt_dc_services-web-1` (find it with
+`docker ps --filter name=web`). It has `10.10.0.10` on the shared bridge and a
+`backend` address on `172.31.0.0/24`.
+
+**Ping both ways** (VM `10.10.0.20` ⇄ container `10.10.0.10`):
+
+```bash
+# container -> VM
+docker exec hybrid_libvirt_dc_services-web-1 ping -c3 10.10.0.20
+
+# VM -> container
+boxman ssh compute_node01            # or: ssh -F <workspace>/ssh_config compute_node01
+node01$ ping -c3 10.10.0.10
+```
+
+**ARP resolves across the bridge** (each side learns the other's real MAC —
+proof this is L2, not routed):
+
+```bash
+node01$ ip neigh show 10.10.0.10                 # -> lladdr <container mac> REACHABLE
+docker exec hybrid_libvirt_dc_services-web-1 ip neigh show 10.10.0.20
+```
+
+**Cluster-internal isolation** — the container's `backend` address is *not*
+reachable from the VM (only the shared bridge is L2-adjacent):
+
+```bash
+# find the container's backend IP
+docker exec hybrid_libvirt_dc_services-web-1 ip -4 addr show eth0
+node01$ ping -c2 -W2 172.31.0.<that ip>          # -> 100% loss (isolated)
+```
+
+## Tear down
+
+```bash
+boxman destroy
+```
+
+This removes `node01`, the mgmt network, and the docker-compose cluster
+(`down --volumes`). The shared bridge `bx_app` is **left in place by design** —
+shared bridges can be used by multiple projects, so removing them is an explicit
+action:
+
+```bash
+sudo ip link del bx_app          # only if nothing else uses it
+```
+
+## Troubleshooting
+
+- **Template bake hangs on "waiting for QEMU guest agent"** when running boxman
+  as a non-root user: the agent check uses a bare `virsh` (no `-c` URI), which
+  defaults to `qemu:///session`. Export `LIBVIRT_DEFAULT_URI=qemu:///system`
+  before `boxman up`.
+- **`web` has no internet** (e.g. an in-container package install fails): the
+  L2 test does not need it, but if you want it, keep the container's default
+  route on `backend` (don't add a `gateway:` to `app_bridge`, as this box does).

--- a/boxes/hybrid-libvirt-docker-compose/conf.yml
+++ b/boxes/hybrid-libvirt-docker-compose/conf.yml
@@ -1,0 +1,167 @@
+---
+# hybrid-libvirt-docker-compose
+#
+# A libvirt VM and a docker-compose container sharing an L2 domain (Phase 4,
+# issue #52). Both attach to the same host Linux bridge `bx_app`; the
+# container attaches via a docker **macvlan** network whose parent is that
+# bridge, so VM and container are directly L2-adjacent.
+#
+#   node01 (libvirt)                          web (docker-compose)
+#     adapter_1 -- dhcp --- mgmt NAT            eth0 -- backend (172.31.0.0/24)
+#     adapter_2 -- 10.10.0.20/24 --\            eth1 -- 10.10.0.10 (macvlan) --\
+#                                   \                                          \
+#                                    `------ bx_app (shared bridge, 10.10.0.0/24) -'
+#
+# boxman creates bx_app (+ a scoped netfilter accept rule — decision D8),
+# attaches node01's second NIC to it, and brings the macvlan container up on
+# it. The VM's shared-bridge address is assigned by a per-MAC netplan match
+# in cloud-init (the shared bridge is a plain L2 domain with no DHCP). The
+# container's macvlan address is pinned statically at 10.10.0.10.
+#
+#   cd boxes/hybrid-libvirt-docker-compose
+#   boxman up
+#   # then follow README.md to ping/ARP between node01 and web
+#   boxman destroy
+version: '2.0'
+project: hybrid_libvirt_dc
+
+provider:
+  libvirt:
+    uri: qemu:///system
+    use_sudo: True
+    virt_install_cmd: '/usr/bin/virt-install'
+    virt_clone_cmd: '/usr/bin/virt-clone'
+    virsh_cmd: '/usr/bin/virsh'
+    verbose: True
+  docker-compose:
+    project_name: hybrid_libvirt_dc
+
+# Host Linux bridge shared by the VM (bridge port) and the container (macvlan).
+shared_networks:
+  app_bridge:
+    bridge: bx_app
+    subnet: 10.10.0.0/24     # required: docker macvlan IPAM pool for the container
+    stp: false
+    # disable_netfilter defaults to false (decision D8): boxman installs a
+    # scoped per-bridge physdev accept rule rather than disabling netfilter
+    # host-wide. Set it to true only if you specifically need the global
+    # disable (discouraged; logged loudly).
+
+templates:
+  template1:
+    name: ubuntu-24.04-minimal-base-template-cloudinit
+    image:
+      uri: http://cloud-images-archive.ubuntu.com/releases/noble/release-20240423/ubuntu-24.04-server-cloudimg-amd64.img
+      checksum: sha256:32a9d30d18803da72f5936cf2b7b9efcb4d0bb63c67933f17e3bdfd1751de3f3
+    disk_size: 20G
+    os_variant: ubuntu24.04
+    memory: 2048
+    vcpus: 2
+    cloudinit_done_marker: /var/log/hybrid-cloudinit.log
+    cloudinit: |
+      #cloud-config
+      hostname: node01
+      manage_etc_hosts: true
+
+      # Per-MAC netplan: adapter_1 (mgmt NAT) takes DHCP; adapter_2 gets a
+      # static address on the shared bridge, which has no DHCP — it is a
+      # plain L2 domain, so the address is assigned here by MAC match.
+      network:
+        version: 2
+        ethernets:
+          mgmt-nic:
+            match: { macaddress: "52:54:00:aa:00:01" }
+            dhcp4: true
+            dhcp6: false
+            optional: true
+          app-nic:
+            match: { macaddress: "52:54:00:aa:00:02" }
+            addresses: [10.10.0.20/24]
+
+      users:
+        - name: ubuntu
+          lock_passwd: false
+          groups: [sudo]
+          sudo: "ALL=(ALL) NOPASSWD:ALL"
+          shell: /bin/bash
+
+      chpasswd:
+        expire: false
+        list: |
+          ubuntu:ubuntu
+
+      ssh_pwauth: true
+      package_update: false
+      packages:
+        - qemu-guest-agent
+        - iputils-ping
+
+      runcmd:
+        - [ systemctl, enable, --now, qemu-guest-agent ]
+        - [ sh, -c, "id admin >/dev/null 2>&1 || useradd -m -d /admin -s /bin/bash -G sudo admin" ]
+        - [ sh, -c, "echo 'admin ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/admin && chmod 0440 /etc/sudoers.d/admin" ]
+        - [ sh, -c, "echo 'admin:{{ env('BOXMAN_ADMIN_PASS', default='boxman') }}' | chpasswd" ]
+        - [ sh, -c, "echo done at $(date -Is) >> /var/log/hybrid-cloudinit.log" ]
+
+workspace:
+  path: ~/workspaces/boxmandev/hybrid-libvirt-docker-compose
+
+clusters:
+  compute:
+    provider: libvirt
+    base_image: ubuntu-24.04-minimal-base-template-cloudinit
+    proxy_host: localhost
+    admin_user: admin
+    admin_pass: {{ env("BOXMAN_ADMIN_PASS", default="boxman") }}
+    admin_key_name: id_ed25519_boxman
+    ssh_config: ssh_config
+
+    networks:
+      mgmt:
+        mode: nat
+        bridge:
+          stp: 'on'
+          delay: '0'
+        mac: '52:54:00:aa:ff:01'
+        ip:
+          address: '192.168.90.1'
+          netmask: '255.255.255.0'
+          dhcp:
+            range:
+              start: '192.168.90.2'
+              end: '192.168.90.254'
+        enable: True
+        autostart: True
+
+    boxes:
+      node01:
+        hostname: node01
+        cpus: { sockets: 1, cores: 2 }
+        memory: 2048
+        network_adapters:
+          - name: adapter_1
+            link_state: 'up'
+            network_source: 'mgmt'
+            mac: '52:54:00:aa:00:01'
+          - name: adapter_2
+            link_state: 'up'
+            network_source: 'app_bridge'
+            mac: '52:54:00:aa:00:02'
+
+  services:
+    provider: docker-compose
+    workdir: ./.boxman/services
+
+    networks:
+      backend:
+        driver: bridge
+        subnet: 172.31.0.0/24
+
+    boxes:
+      web:
+        image: nicolaka/netshoot
+        command: ["/bin/sleep", "infinity"]
+        networks:
+          backend: null                 # cluster-internal (isolated from the VM)
+          app_bridge:
+            ipv4_address: 10.10.0.10     # static macvlan address on the shared bridge

--- a/boxes/hybrid-libvirt-docker-compose/conf.yml
+++ b/boxes/hybrid-libvirt-docker-compose/conf.yml
@@ -14,9 +14,11 @@
 #
 # boxman creates bx_app (+ a scoped netfilter accept rule — decision D8),
 # attaches node01's second NIC to it, and brings the macvlan container up on
-# it. The VM's shared-bridge address is assigned by a per-MAC netplan match
-# in cloud-init (the shared bridge is a plain L2 domain with no DHCP). The
-# container's macvlan address is pinned statically at 10.10.0.10.
+# it. The VM's shared-bridge address (10.10.0.20) is assigned as an explicit
+# step in the README — the shared bridge is a plain L2 domain with no DHCP, and
+# addressing it at boot would make boxman mistake that host-unreachable address
+# for node01's management IP. The container's macvlan address is pinned
+# statically at 10.10.0.10.
 #
 #   cd boxes/hybrid-libvirt-docker-compose
 #   boxman up

--- a/boxes/hybrid-libvirt-docker-compose/conf.yml
+++ b/boxes/hybrid-libvirt-docker-compose/conf.yml
@@ -63,21 +63,12 @@ templates:
       hostname: node01
       manage_etc_hosts: true
 
-      # Per-MAC netplan: adapter_1 (mgmt NAT) takes DHCP; adapter_2 gets a
-      # static address on the shared bridge, which has no DHCP — it is a
-      # plain L2 domain, so the address is assigned here by MAC match.
-      network:
-        version: 2
-        ethernets:
-          mgmt-nic:
-            match: { macaddress: "52:54:00:aa:00:01" }
-            dhcp4: true
-            dhcp6: false
-            optional: true
-          app-nic:
-            match: { macaddress: "52:54:00:aa:00:02" }
-            addresses: [10.10.0.20/24]
-
+      # node01's mgmt NIC (adapter_1) gets a DHCP address from the libvirt NAT
+      # and that is node01's routable/management IP (boxman uses it for ssh).
+      # The shared bridge (adapter_2) is a plain L2 domain with NO DHCP, so its
+      # address is assigned as an explicit step in the README before the L2
+      # test — deliberately NOT here, so boxman does not mistake the
+      # unreachable 10.10.0.x address for node01's management IP.
       users:
         - name: ubuntu
           lock_passwd: false
@@ -87,20 +78,18 @@ templates:
 
       chpasswd:
         expire: false
-        list: |
-          ubuntu:ubuntu
+        users:
+          - name: ubuntu
+            password: {{ env("BOXMAN_ADMIN_PASS", default="boxman") }}
+            type: text
 
       ssh_pwauth: true
       package_update: false
       packages:
         - qemu-guest-agent
-        - iputils-ping
 
       runcmd:
         - [ systemctl, enable, --now, qemu-guest-agent ]
-        - [ sh, -c, "id admin >/dev/null 2>&1 || useradd -m -d /admin -s /bin/bash -G sudo admin" ]
-        - [ sh, -c, "echo 'admin ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/admin && chmod 0440 /etc/sudoers.d/admin" ]
-        - [ sh, -c, "echo 'admin:{{ env('BOXMAN_ADMIN_PASS', default='boxman') }}' | chpasswd" ]
         - [ sh, -c, "echo done at $(date -Is) >> /var/log/hybrid-cloudinit.log" ]
 
 workspace:
@@ -111,7 +100,7 @@ clusters:
     provider: libvirt
     base_image: ubuntu-24.04-minimal-base-template-cloudinit
     proxy_host: localhost
-    admin_user: admin
+    admin_user: ubuntu
     admin_pass: {{ env("BOXMAN_ADMIN_PASS", default="boxman") }}
     admin_key_name: id_ed25519_boxman
     ssh_config: ssh_config

--- a/doc/docker-compose-provider/config-schema.md
+++ b/doc/docker-compose-provider/config-schema.md
@@ -175,10 +175,14 @@ Notes and requirements:
   `compose_extra:` if you need a static IP on a cluster-internal network.
 - **Netfilter (decision D8):** by default (`disable_netfilter: false`) boxman
   leaves the host-global `bridge-nf-call-iptables` untouched and installs an
-  idempotent per-bridge scoped `iptables` accept rule so bridged lab frames
-  aren't dropped by a docker `FORWARD`/`DOCKER-USER` DROP policy. Setting
-  `disable_netfilter: true` instead disables netfilter on bridges **host-wide**
-  (a discouraged opt-in, logged loudly, reverted by any reboot).
+  idempotent per-bridge scoped `iptables` accept rule (on `FORWARD`, and
+  `DOCKER-USER` when that chain exists) so bridged lab frames aren't dropped by
+  a docker `FORWARD`/`DOCKER-USER` DROP policy. Like the shared bridges
+  themselves, these rules are **never removed by boxman** (they can be shared
+  across projects) — tearing them down is an explicit user action (see the
+  hybrid box's teardown note). Setting `disable_netfilter: true` instead
+  disables netfilter on bridges **host-wide** (a discouraged opt-in, logged
+  loudly, reverted by any reboot).
 
 ## Templating caveat for compose values (`environment:`, `command:`)
 

--- a/doc/docker-compose-provider/config-schema.md
+++ b/doc/docker-compose-provider/config-schema.md
@@ -80,11 +80,12 @@ is unchanged.
 A v2.0 config with a docker-compose cluster is **runnable**: `boxman
 provision` / `up` generate a `docker-compose.yml` in the cluster `workdir`
 and run `docker compose up -d --wait`, and `down` / `deprovision` / `destroy`
-tear it down. Phase 3 scope is **cluster-internal bridge networks only** —
-`shared_networks` (L2 to VMs) lands in Phase 4, structured `volumes:` in
-Phase 5, ssh/exec/inventory in Phase 6, snapshots in Phase 7. Box features
-outside this scope are warned about and skipped (use `compose_extra:` as the
-escape hatch).
+tear it down. Scope covers cluster-internal bridge networks and
+`shared_networks` **macvlan L2 to libvirt VMs** (Phase 4, #52 — see
+[Shared networks (macvlan L2 to VMs)](#shared-networks-macvlan-l2-to-vms)
+below). Still out of scope: structured `volumes:` (Phase 5),
+ssh/exec/inventory (Phase 6), snapshots (Phase 7). Box features outside this
+scope are warned about and skipped (use `compose_extra:` as the escape hatch).
 
 Two hard requirements, both enforced fail-fast (exit 2):
 
@@ -119,6 +120,65 @@ therefore intentionally show the **pre-normalization** shape — a fidelity
 view of what you wrote (`boxes:`), not boxman's internal `vms:` form. This
 is by design; the internal normalization is what the provisioning flows act
 on.
+
+## Shared networks (macvlan L2 to VMs)
+
+A top-level `shared_networks:` block declares host Linux bridges that both a
+docker-compose container **and** a libvirt VM can attach to, putting them on
+the same L2 domain. boxman creates each bridge on the host
+(`shared_bridges.ensure`, idempotent, never torn down — bridges can be shared
+across projects); the docker-compose generator attaches a referencing
+container via a docker **macvlan** network whose `parent` is that bridge.
+
+```yaml
+version: '2.0'
+project: hybrid_lab
+shared_networks:
+  app_bridge:
+    bridge: br-app            # required: the host Linux bridge name
+    subnet: 10.10.0.0/24      # required when a box attaches (macvlan IPAM pool)
+    gateway: 10.10.0.1        # optional
+    ip_range: 10.10.0.128/25  # optional — restrict docker's auto-assign pool
+    stp: false                # optional (default false)
+    # disable_netfilter: false  # default; see the Netfilter note below
+    # compose_extra: {...}      # optional, deep-merged onto the macvlan net
+clusters:
+  services:
+    provider: docker-compose
+    workdir: ./.boxman/services
+    boxes:
+      web:
+        image: nginx
+        networks: [app_bridge]          # list form → auto-assigned address
+      api:
+        image: myapi
+        networks:
+          app_bridge:
+            ipv4_address: 10.10.0.20     # mapping form → static address
+```
+
+A box's `networks:` accepts two forms:
+
+| Form | Example | Effect |
+|---|---|---|
+| **list** | `networks: [app_bridge, backend]` | attach to each; docker auto-assigns an address |
+| **mapping** | `networks: {app_bridge: {ipv4_address: 10.10.0.20}}` | pin a static address on that network |
+
+Notes and requirements:
+
+- A shared network a box attaches to **must** declare `bridge:` and `subnet:`
+  — otherwise `provision` fails with a `ConfigError` (docker's macvlan IPAM
+  needs an address pool). A `shared_networks` entry that no box references is
+  fine and simply isn't emitted into the compose file.
+- `ipv4_address` is **only** wired for `shared_networks` (macvlan) attachments.
+  On a cluster-internal network it is warned about and dropped — use
+  `compose_extra:` if you need a static IP on a cluster-internal network.
+- **Netfilter (decision D8):** by default (`disable_netfilter: false`) boxman
+  leaves the host-global `bridge-nf-call-iptables` untouched and installs an
+  idempotent per-bridge scoped `iptables` accept rule so bridged lab frames
+  aren't dropped by a docker `FORWARD`/`DOCKER-USER` DROP policy. Setting
+  `disable_netfilter: true` instead disables netfilter on bridges **host-wide**
+  (a discouraged opt-in, logged loudly, reverted by any reboot).
 
 ## Templating caveat for compose values (`environment:`, `command:`)
 

--- a/doc/docker-compose-provider/design.md
+++ b/doc/docker-compose-provider/design.md
@@ -230,6 +230,8 @@ provider:
 shared_networks:
   app_bridge:
     bridge: br-app
+    subnet: 10.10.0.0/24       # required when a docker-compose box attaches (macvlan IPAM)
+    gateway: 10.10.0.1         # optional
     stp: false
     disable_netfilter: false   # default — scoped per-bridge rules instead (decision D8)
 
@@ -349,7 +351,7 @@ graph LR
     D --> E[Generate macvlan network]
     E --> F[docker-compose.yml]
     
-    F --> G["networks:<br/>  app_bridge:<br/>    driver: macvlan<br/>    driver_opts:<br/>      parent: br-app"]
+    F --> G["networks:<br/>  app_bridge:<br/>    driver: macvlan<br/>    driver_opts:<br/>      parent: br-app<br/>    ipam:<br/>      config:<br/>        - subnet: 10.10.0.0/24"]
     
     C --> H[Host bridge ready]
     G --> I[Containers attach via macvlan]

--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -3813,6 +3813,12 @@ class BoxmanManager:
                 cls.cache.read_projects_cache()
                 project_name = config.get('project')
                 if project_name and project_name in (cls.cache.projects or {}):
+                    # Shared bridges must exist before macvlan-attached
+                    # containers come up: a host reboot drops the
+                    # (non-persistent) Linux bridge, so recreate it on this
+                    # dc-only reconcile path too — mirroring the hybrid
+                    # "all VMs running" path (ensure_shared_bridges → up).
+                    cls.ensure_shared_bridges()
                     cls.provision_compose_clusters()
                 else:
                     cls.logger.info(

--- a/src/boxman/netlab/shared_bridges.py
+++ b/src/boxman/netlab/shared_bridges.py
@@ -42,6 +42,50 @@ def _set_sysfs(path: str, value: str) -> None:
     run(f"echo {value} | sudo tee {path}", hide=True)
 
 
+def _scoped_rule_body(bridge: str) -> str:
+    """The physdev accept rule body shared by ``-C`` (check) and ``-I`` (insert).
+
+    Accepts frames both entering and leaving *bridge* that are bridged
+    (``--physdev-is-bridged``) — i.e. L2 lab traffic between a bridge-attached
+    VM and a macvlan-attached container on the same bridge — so it isn't
+    dropped by a docker-style ``FORWARD``/``DOCKER-USER`` DROP policy while the
+    host keeps ``bridge-nf-call-iptables=1`` (decision D8).
+    """
+    return (f"-i {bridge} -o {bridge} "
+            f"-m physdev --physdev-is-bridged -j ACCEPT")
+
+
+def _iptables_chain_exists(chain: str) -> bool:
+    return run(f"sudo iptables -t filter -n -L {chain}",
+               warn=True, hide=True).ok
+
+
+def _ensure_iptables_rule(chain: str, body: str) -> None:
+    """Idempotently insert ``body`` at the top of filter table *chain*.
+
+    Uses ``-C`` (check) before ``-I`` (insert at position 1) so repeated
+    ``ensure()`` calls don't stack duplicate rules (spike scenario 7).
+    """
+    if run(f"sudo iptables -t filter -C {chain} {body}",
+           warn=True, hide=True).ok:
+        return  # already present
+    _run_sudo(f"iptables -t filter -I {chain} 1 {body}")
+
+
+def _ensure_scoped_accept(bridge: str) -> None:
+    """Allow bridged lab frames on *bridge* via scoped per-bridge rules (D8).
+
+    Inserts into ``FORWARD`` (works without docker) and, when the
+    ``DOCKER-USER`` chain exists (docker host), there too — that copy survives
+    a docker daemon restart (docker recreates but does not flush DOCKER-USER),
+    which the spike confirmed.
+    """
+    body = _scoped_rule_body(bridge)
+    _ensure_iptables_rule("FORWARD", body)
+    if _iptables_chain_exists("DOCKER-USER"):
+        _ensure_iptables_rule("DOCKER-USER", body)
+
+
 def ensure(shared_networks: dict[str, dict[str, Any]] | None) -> None:
     """Ensure every bridge declared in *shared_networks* exists and is up.
 
@@ -51,15 +95,21 @@ def ensure(shared_networks: dict[str, dict[str, Any]] | None) -> None:
 
     - ``bridge`` (str, required): the Linux bridge name on the host.
     - ``stp`` (bool, default False): enable STP on the bridge.
-    - ``disable_netfilter`` (bool, default True): set
-      ``/proc/sys/net/bridge/bridge-nf-call-iptables=0`` so lab frames
-      aren't dropped by host iptables rules. System-wide setting;
-      we flip it once per ``ensure()`` call if any entry asks for it.
+    - ``disable_netfilter`` (bool, default **False**): when False (the
+      default, decision D8), lab frames are allowed by an idempotent
+      per-bridge scoped ``iptables`` accept rule and the host-global
+      ``bridge-nf-call-iptables`` is left untouched. When True (an explicit,
+      discouraged opt-in), the host-global ``bridge-nf-call-iptables=0`` is
+      set instead, with a loud warning — it weakens docker/k8s bridge
+      filtering host-wide and is reverted by any reboot / kubelet.
+
+    ``subnet``/``gateway``/``ip_range`` may also be present; those are
+    consumed by the docker-compose generator (macvlan IPAM), not here.
     """
     if not shared_networks:
         return
 
-    want_nf_disabled = False
+    globally_disabled: list[str] = []
     for entry_name, entry in shared_networks.items():
         bridge = entry.get("bridge")
         if not bridge:
@@ -79,10 +129,24 @@ def ensure(shared_networks: dict[str, dict[str, Any]] | None) -> None:
         _run_sudo(f"ip link set dev {bridge} type bridge stp_state "
                   f"{1 if stp == 'on' else 0}")
 
-        if entry.get("disable_netfilter", True):
-            want_nf_disabled = True
+        # Decision D8: default to scoped per-bridge accept rules; the
+        # host-global sysctl disable is an explicit opt-in.
+        if entry.get("disable_netfilter", False):
+            globally_disabled.append(bridge)
+        else:
+            _ensure_scoped_accept(bridge)
 
-    if want_nf_disabled:
+    if globally_disabled:
+        log.warning(
+            f"disable_netfilter: true set for shared bridge(s) "
+            f"{', '.join(repr(b) for b in globally_disabled)} — setting the "
+            f"host-global bridge-nf-call-iptables=0. This weakens docker/k8s "
+            f"bridge filtering HOST-WIDE, is reverted by any reboot "
+            f"(br_netfilter defaults the sysctl to 1 on load) and by kubelet "
+            f"on kubernetes hosts. Prefer the default (scoped per-bridge accept "
+            f"rules) — drop 'disable_netfilter: true' unless you specifically "
+            f"need the global disable."
+        )
         nf_path = Path("/proc/sys/net/bridge/bridge-nf-call-iptables")
         if nf_path.exists():
             _set_sysfs(str(nf_path), "0")

--- a/src/boxman/netlab/shared_bridges.py
+++ b/src/boxman/netlab/shared_bridges.py
@@ -45,11 +45,16 @@ def _set_sysfs(path: str, value: str) -> None:
 def _scoped_rule_body(bridge: str) -> str:
     """The physdev accept rule body shared by ``-C`` (check) and ``-I`` (insert).
 
-    Accepts frames both entering and leaving *bridge* that are bridged
-    (``--physdev-is-bridged``) — i.e. L2 lab traffic between a bridge-attached
-    VM and a macvlan-attached container on the same bridge — so it isn't
-    dropped by a docker-style ``FORWARD``/``DOCKER-USER`` DROP policy while the
-    host keeps ``bridge-nf-call-iptables=1`` (decision D8).
+    ``-i <br> -o <br> -m physdev --physdev-is-bridged`` matches frames the
+    bridge **forwards between two of its ports** (br_netfilter's FORWARD
+    traversal) — e.g. VM↔VM or VM↔containerlab-veth L2 lab traffic on the
+    shared bridge — so it isn't dropped by a docker-style
+    ``FORWARD``/``DOCKER-USER`` DROP policy while the host keeps
+    ``bridge-nf-call-iptables=1`` (decision D8). It is also installed as
+    belt-and-braces for macvlan-attached containers, though a macvlan endpoint
+    is a child of the bridge *device* rather than a bridge port, so on mainline
+    kernels VM↔container frames use the bridge local pass-up / ``br_dev_xmit``
+    paths and likely do not traverse filter ``FORWARD`` at all.
     """
     return (f"-i {bridge} -o {bridge} "
             f"-m physdev --physdev-is-bridged -j ACCEPT")

--- a/src/boxman/providers/docker_compose/compose_generator.py
+++ b/src/boxman/providers/docker_compose/compose_generator.py
@@ -2,15 +2,21 @@
 ComposeGenerator — translate a boxman docker-compose *cluster* into a
 ``docker-compose.yml`` dict and write it to the cluster workdir.
 
-Phase 3 scope: services (image / build / command / environment / ports /
-depends_on / restart / healthcheck), cluster-internal bridge networks, and
-the ``compose_extra:`` escape hatch (deep-merged verbatim, per-cluster and
-per-box — design decision D7). Out-of-phase box features are warned about
-and skipped:
+Scope: services (image / build / command / environment / ports /
+depends_on / restart / healthcheck), cluster-internal bridge networks,
+``shared_networks`` bridges attached as docker **macvlan** networks (Phase 4
+— L2 to libvirt VMs on the same host bridge), and the ``compose_extra:``
+escape hatch (deep-merged verbatim, per-cluster and per-box — design
+decision D7). Out-of-phase box features are warned about and skipped:
 
 - ``volumes:`` (structured named/bind/workdir mounts) → **Phase 5**.
-- a box network that resolves to a ``shared_networks`` bridge (macvlan
-  L2 to VMs) → **Phase 4**; only cluster-internal networks are emitted.
+
+A box's ``networks:`` may be a plain list (``[app_bridge, backend]`` — the
+container gets an auto-assigned address on each) or a mapping that pins a
+static address on a shared bridge
+(``{app_bridge: {ipv4_address: 10.10.0.5}}``). A shared bridge referenced by
+a box must declare a ``subnet:`` under ``shared_networks:`` so docker's
+macvlan IPAM has an address pool.
 
 The generated file is a fidelity artifact — inspectable and hand-runnable
 with ``docker compose -f <cluster_workdir>/docker-compose.yml ps`` (D5).
@@ -20,7 +26,7 @@ from __future__ import annotations
 
 import os
 import re
-from typing import Any, Iterable
+from typing import Any
 
 import yaml
 
@@ -67,7 +73,7 @@ class ComposeGenerator:
         cluster_name: str,
         cluster_cfg: dict[str, Any],
         conf_dir: str,
-        shared_network_names: Iterable[str] = (),
+        shared_networks: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """
         Build the compose dict for *cluster_name*.
@@ -78,25 +84,34 @@ class ComposeGenerator:
                 optional ``compose_extra:``).
             conf_dir: Directory of the project ``conf.yml`` — ``build.context``
                 is resolved absolute against it (D4).
-            shared_network_names: Names declared under the top-level
-                ``shared_networks:`` — used only to phrase the Phase-4
-                skip warning precisely.
+            shared_networks: The top-level ``shared_networks:`` block (name →
+                ``{bridge, subnet, gateway?, ip_range?, ...}``). A box network
+                ref that matches a key here is emitted as a docker **macvlan**
+                network over that host bridge (Phase 4).
 
         Returns:
             The compose dict (no top-level ``version:`` — the compose spec
             treats it as obsolete).
         """
-        shared = frozenset(shared_network_names)
+        shared_networks = shared_networks or {}
         cluster_networks = cluster_cfg.get("networks") or {}
+        #: shared_networks keys actually attached by a box in this cluster —
+        #: only these become top-level macvlan networks (insertion order via
+        #: shared_networks below keeps the output deterministic).
+        referenced_shared: set[str] = set()
 
         services: dict[str, Any] = {}
         for box_name, box in (cluster_cfg.get("boxes") or {}).items():
             services[box_name] = self._service(
-                cluster_name, box_name, box or {}, conf_dir, cluster_networks, shared
+                cluster_name, box_name, box or {}, conf_dir,
+                cluster_networks, shared_networks, referenced_shared,
             )
 
         compose: dict[str, Any] = {"services": services}
         networks = self._networks(cluster_networks)
+        networks.update(
+            self._shared_macvlan_networks(referenced_shared, shared_networks)
+        )
         if networks:
             compose["networks"] = networks
 
@@ -121,7 +136,8 @@ class ComposeGenerator:
         box: dict[str, Any],
         conf_dir: str,
         cluster_networks: dict[str, Any],
-        shared: frozenset[str],
+        shared_networks: dict[str, Any],
+        referenced_shared: set[str],
     ) -> dict[str, Any]:
         svc: dict[str, Any] = {}
 
@@ -144,7 +160,8 @@ class ComposeGenerator:
             svc["build"] = self._build(box["build"], conf_dir)
 
         nets = self._service_networks(
-            cluster_name, box_name, box.get("networks") or [], cluster_networks, shared
+            cluster_name, box_name, box.get("networks"),
+            cluster_networks, shared_networks, referenced_shared,
         )
         if nets:
             svc["networks"] = nets
@@ -231,27 +248,91 @@ class ComposeGenerator:
         self,
         cluster_name: str,
         box_name: str,
-        refs: list[str],
+        networks: Any,
         cluster_networks: dict[str, Any],
-        shared: frozenset[str],
-    ) -> list[str]:
-        out: list[str] = []
-        for ref in refs:
+        shared_networks: dict[str, Any],
+        referenced_shared: set[str],
+    ) -> list[str] | dict[str, Any]:
+        """Resolve a box's ``networks:`` to the service's compose ``networks``.
+
+        *networks* is either a list of names (auto address on each) or a
+        mapping ``name -> {ipv4_address: …}`` pinning a static address (only
+        meaningful on a shared/macvlan bridge). Cluster-internal and shared
+        refs are attached; a shared ref is recorded in *referenced_shared* so
+        :meth:`_shared_macvlan_networks` emits the top-level macvlan network.
+        Unknown refs are warned about and dropped.
+
+        Returns the mapping form (``{name: {ipv4_address: …}}``) when any ref
+        carries per-network options, else the plain list form.
+        """
+        entries = self._normalize_box_networks(cluster_name, box_name, networks)
+        attached: dict[str, dict[str, Any]] = {}
+        any_opts = False
+        for ref, opts in entries:
             if ref in cluster_networks:
-                out.append(ref)
-            elif ref in shared:
-                self.logger.warning(
-                    f"box '{cluster_name}.{box_name}': network '{ref}' is a "
-                    f"shared_networks bridge — L2 attach to VMs lands in "
-                    f"Phase 4; skipping it for now."
-                )
+                if opts.get("ipv4_address"):
+                    self.logger.warning(
+                        f"box '{cluster_name}.{box_name}': ignoring "
+                        f"'ipv4_address' on cluster-internal network '{ref}' — "
+                        f"static addresses are only wired for shared_networks "
+                        f"(macvlan) bridges; use 'compose_extra:' for a static "
+                        f"IP on a cluster-internal network."
+                    )
+                    opts = {k: v for k, v in opts.items() if k != "ipv4_address"}
+            elif ref in shared_networks:
+                self._require_macvlan_ipam(cluster_name, box_name, ref,
+                                           shared_networks[ref] or {})
+                referenced_shared.add(ref)
             else:
                 self.logger.warning(
-                    f"box '{cluster_name}.{box_name}': network '{ref}' is not a "
-                    f"cluster-internal network — skipping (shared/macvlan "
-                    f"networks land in Phase 4)."
+                    f"box '{cluster_name}.{box_name}': network '{ref}' is "
+                    f"neither a cluster-internal network nor a shared_networks "
+                    f"bridge — skipping."
                 )
-        return out
+                continue
+            svc_opts = {"ipv4_address": opts["ipv4_address"]} \
+                if opts.get("ipv4_address") else {}
+            if svc_opts:
+                any_opts = True
+            attached[ref] = svc_opts
+
+        if not attached:
+            return []
+        return attached if any_opts else list(attached)
+
+    @staticmethod
+    def _normalize_box_networks(
+        cluster_name: str, box_name: str, networks: Any
+    ) -> list[tuple[str, dict[str, Any]]]:
+        """Normalise a box ``networks:`` (list or mapping) to ``[(ref, opts)]``.
+
+        List form yields empty opts per ref; mapping form carries each ref's
+        option dict (``{ipv4_address: …}``, or ``None`` → empty).
+        """
+        if not networks:
+            return []
+        if isinstance(networks, dict):
+            return [(ref, dict(opts or {})) for ref, opts in networks.items()]
+        if isinstance(networks, (list, tuple)):
+            return [(ref, {}) for ref in networks]
+        return []
+
+    def _require_macvlan_ipam(
+        self, cluster_name: str, box_name: str, ref: str, entry: dict[str, Any]
+    ) -> None:
+        """A shared bridge attached by a box needs a ``subnet`` (macvlan IPAM)
+        and an underlying ``bridge`` — raise ``ConfigError`` otherwise."""
+        if not entry.get("bridge"):
+            raise ConfigError(
+                f"box '{cluster_name}.{box_name}': shared network '{ref}' has "
+                f"no 'bridge:' — add it under shared_networks['{ref}']."
+            )
+        if not entry.get("subnet"):
+            raise ConfigError(
+                f"box '{cluster_name}.{box_name}': shared network '{ref}' needs "
+                f"a 'subnet:' for the docker macvlan IPAM pool — add it under "
+                f"shared_networks['{ref}']."
+            )
 
     def _networks(self, cluster_networks: dict[str, Any]) -> dict[str, Any]:
         out: dict[str, Any] = {}
@@ -261,6 +342,38 @@ class ComposeGenerator:
             if net.get("subnet"):
                 spec["ipam"] = {"config": [{"subnet": net["subnet"]}]}
             out[name] = self._deep_merge(spec, net.get("compose_extra") or {})
+        return out
+
+    def _shared_macvlan_networks(
+        self, referenced: set[str], shared_networks: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Emit a top-level docker **macvlan** network for each referenced
+        shared bridge, so containers land on the same L2 as libvirt VMs
+        cabled into that host bridge (Phase 4, design D8).
+
+        Each becomes ``driver: macvlan`` + ``driver_opts.parent: <bridge>`` +
+        an ``ipam`` config carrying the bridge's ``subnet`` (required) and
+        optional ``gateway`` / ``ip_range``. Iterated in *shared_networks*
+        declaration order (filtered by *referenced*) for deterministic output.
+        Presence of ``bridge``/``subnet`` is already enforced upstream in
+        :meth:`_require_macvlan_ipam`.
+        """
+        out: dict[str, Any] = {}
+        for name, entry in shared_networks.items():
+            if name not in referenced:
+                continue
+            entry = entry or {}
+            ipam_cfg: dict[str, Any] = {"subnet": entry["subnet"]}
+            if entry.get("gateway"):
+                ipam_cfg["gateway"] = entry["gateway"]
+            if entry.get("ip_range"):
+                ipam_cfg["ip_range"] = entry["ip_range"]
+            spec: dict[str, Any] = {
+                "driver": "macvlan",
+                "driver_opts": {"parent": entry["bridge"]},
+                "ipam": {"config": [ipam_cfg]},
+            }
+            out[name] = self._deep_merge(spec, entry.get("compose_extra") or {})
         return out
 
     @staticmethod

--- a/src/boxman/providers/docker_compose/compose_generator.py
+++ b/src/boxman/providers/docker_compose/compose_generator.py
@@ -74,6 +74,7 @@ class ComposeGenerator:
         cluster_cfg: dict[str, Any],
         conf_dir: str,
         shared_networks: dict[str, Any] | None = None,
+        project_name: str | None = None,
     ) -> dict[str, Any]:
         """
         Build the compose dict for *cluster_name*.
@@ -88,6 +89,12 @@ class ComposeGenerator:
                 ``{bridge, subnet, gateway?, ip_range?, ...}``). A box network
                 ref that matches a key here is emitted as a docker **macvlan**
                 network over that host bridge (Phase 4).
+            project_name: The compose project name boxman runs the stack under.
+                When given, it is emitted as a top-level ``name:`` so the file
+                is hand-runnable (``docker compose -f <file> ps``) under the
+                same project boxman uses — the D5 fidelity claim. The runner
+                still passes ``-p`` explicitly, which overrides ``name:``, so
+                its behaviour is unchanged.
 
         Returns:
             The compose dict (no top-level ``version:`` — the compose spec
@@ -107,7 +114,10 @@ class ComposeGenerator:
                 cluster_networks, shared_networks, referenced_shared,
             )
 
-        compose: dict[str, Any] = {"services": services}
+        compose: dict[str, Any] = {}
+        if project_name:
+            compose["name"] = project_name
+        compose["services"] = services
         networks = self._networks(cluster_networks)
         networks.update(
             self._shared_macvlan_networks(referenced_shared, shared_networks)
@@ -307,15 +317,34 @@ class ComposeGenerator:
         """Normalise a box ``networks:`` (list or mapping) to ``[(ref, opts)]``.
 
         List form yields empty opts per ref; mapping form carries each ref's
-        option dict (``{ipv4_address: …}``, or ``None`` → empty).
+        option dict (``{ipv4_address: …}``, or ``None`` → empty). Malformed
+        input fails fast with a ``ConfigError`` rather than silently dropping
+        the attachment — a bare string (``networks: app_bridge``, a forgotten
+        ``[…]``) would otherwise emit a service with no ``networks:`` key at
+        all, so compose attaches it to the project-default bridge and the
+        macvlan L2 attach silently never happens.
         """
         if not networks:
             return []
+        if isinstance(networks, str):
+            # A forgotten list: treat the single name as a one-element list
+            # rather than dropping it silently.
+            return [(networks, {})]
         if isinstance(networks, dict):
+            for ref, opts in networks.items():
+                if opts is not None and not isinstance(opts, dict):
+                    raise ConfigError(
+                        f"box '{cluster_name}.{box_name}': networks['{ref}'] "
+                        f"must be a mapping like {{ipv4_address: …}} or null "
+                        f"(got {opts!r})."
+                    )
             return [(ref, dict(opts or {})) for ref, opts in networks.items()]
         if isinstance(networks, (list, tuple)):
-            return [(ref, {}) for ref in networks]
-        return []
+            return [(str(ref), {}) for ref in networks]
+        raise ConfigError(
+            f"box '{cluster_name}.{box_name}': 'networks:' must be a list or "
+            f"mapping (got {type(networks).__name__})."
+        )
 
     def _require_macvlan_ipam(
         self, cluster_name: str, box_name: str, ref: str, entry: dict[str, Any]

--- a/src/boxman/providers/docker_compose/session.py
+++ b/src/boxman/providers/docker_compose/session.py
@@ -157,9 +157,9 @@ class DockerComposeSession:
         :meth:`_teardown_runner`, which never regenerates.
         """
         workdir = self._workdir(cluster_cfg, cluster_name)
-        shared = set(self.config.get("shared_networks") or {})
+        shared_networks = self.config.get("shared_networks") or {}
         compose = self._generator.generate(
-            cluster_name, cluster_cfg, self._conf_dir(), shared
+            cluster_name, cluster_cfg, self._conf_dir(), shared_networks
         )
         compose_file = self._generator.write(compose, workdir)
         runner = ComposeRunner(

--- a/src/boxman/providers/docker_compose/session.py
+++ b/src/boxman/providers/docker_compose/session.py
@@ -158,12 +158,14 @@ class DockerComposeSession:
         """
         workdir = self._workdir(cluster_cfg, cluster_name)
         shared_networks = self.config.get("shared_networks") or {}
+        project = self._compose_project(cluster_name)
         compose = self._generator.generate(
-            cluster_name, cluster_cfg, self._conf_dir(), shared_networks
+            cluster_name, cluster_cfg, self._conf_dir(), shared_networks,
+            project_name=project,
         )
         compose_file = self._generator.write(compose, workdir)
         runner = ComposeRunner(
-            project=self._compose_project(cluster_name),
+            project=project,
             compose_file=compose_file,
             workdir=workdir,
             logger=self.logger,

--- a/tests/test_docker_compose_provider.py
+++ b/tests/test_docker_compose_provider.py
@@ -1,5 +1,6 @@
 """
-Unit tests for the docker-compose provider (Phase 3, epic #42 / issue #51).
+Unit tests for the docker-compose provider (epic #42 / issues #51 Phase 3,
+#52 Phase 4).
 
 Everything here is mocked — no live ``docker`` and no libvirt. Per the
 host-vs-VM testing policy, live container behaviour is exercised only inside
@@ -7,9 +8,10 @@ the staging VM (nested docker-compose e2e), never on the host. These tests
 cover four seams:
 
 - :class:`ComposeGenerator` — ``boxes:`` → compose ``services:`` translation,
-  cluster-internal bridge networks, absolute ``build.context`` (D4),
-  ``compose_extra:`` deep-merge (D7), and the warn+skip of out-of-phase box
-  features (``volumes:`` → Phase 5, shared/macvlan networks → Phase 4).
+  cluster-internal bridge networks, ``shared_networks`` → macvlan attach
+  (Phase 4: static/auto IPs, IPAM, reference-gating), absolute
+  ``build.context`` (D4), ``compose_extra:`` deep-merge (D7), and the warn+skip
+  of still-out-of-phase box features (``volumes:`` → Phase 5).
 - :class:`ComposeRunner` — the exact ``docker compose`` command strings and
   the preflight / failure error paths (``boxman.utils.shell.run`` mocked).
 - :class:`DockerComposeSession` — satisfies the ``ProviderSession`` protocol,
@@ -207,16 +209,120 @@ class TestComposeGenerator:
         assert warn.called
         assert "Phase 5" in warn.call_args[0][0]
 
-    def test_shared_network_ref_warned_and_skipped(self):
+    # -- Phase 4: shared_networks → macvlan ------------------------------
+    def _shared(self, **over):
+        base = {"bridge": "br-lab", "subnet": "10.10.0.0/24"}
+        base.update(over)
+        return {"labnet": base}
+
+    def test_shared_network_emits_macvlan_and_attaches(self):
+        """A box ref to a shared_networks bridge → a top-level macvlan network
+        (driver + parent + ipam subnet) and a plain-list service attachment."""
         gen = ComposeGenerator()
         cluster = {"boxes": {"w": {"image": "x", "networks": ["labnet"]}}}
+        compose = gen.generate(
+            "s", cluster, conf_dir="/proj", shared_networks=self._shared()
+        )
+        assert compose["networks"]["labnet"] == {
+            "driver": "macvlan",
+            "driver_opts": {"parent": "br-lab"},
+            "ipam": {"config": [{"subnet": "10.10.0.0/24"}]},
+        }
+        assert compose["services"]["w"]["networks"] == ["labnet"]
+
+    def test_shared_network_static_ipv4_address_mapping_form(self):
+        """A mapping ``{net: {ipv4_address: …}}`` pins a static address and
+        forces the service ``networks`` into mapping form."""
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"w": {"image": "x",
+                                   "networks": {"labnet": {"ipv4_address": "10.10.0.5"}}}}}
+        compose = gen.generate(
+            "s", cluster, conf_dir="/proj", shared_networks=self._shared()
+        )
+        assert compose["services"]["w"]["networks"] == {
+            "labnet": {"ipv4_address": "10.10.0.5"}
+        }
+        assert compose["networks"]["labnet"]["driver"] == "macvlan"
+
+    def test_shared_network_gateway_and_ip_range_in_ipam(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"w": {"image": "x", "networks": ["labnet"]}}}
+        shared = self._shared(gateway="10.10.0.1", ip_range="10.10.0.128/25")
+        net = gen.generate(
+            "s", cluster, conf_dir="/proj", shared_networks=shared
+        )["networks"]["labnet"]
+        assert net["ipam"]["config"][0] == {
+            "subnet": "10.10.0.0/24",
+            "gateway": "10.10.0.1",
+            "ip_range": "10.10.0.128/25",
+        }
+
+    def test_shared_network_only_emitted_when_referenced(self):
+        """A shared network declared but attached by no box is not emitted."""
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"w": {"image": "x"}}}
+        compose = gen.generate(
+            "s", cluster, conf_dir="/proj", shared_networks=self._shared()
+        )
+        assert "networks" not in compose
+
+    def test_shared_network_without_subnet_raises(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"w": {"image": "x", "networks": ["labnet"]}}}
+        shared = {"labnet": {"bridge": "br-lab"}}  # no subnet
+        with pytest.raises(ConfigError, match=r"needs a 'subnet:'"):
+            gen.generate("s", cluster, conf_dir="/proj", shared_networks=shared)
+
+    def test_shared_network_without_bridge_raises(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"w": {"image": "x", "networks": ["labnet"]}}}
+        shared = {"labnet": {"subnet": "10.10.0.0/24"}}  # no bridge
+        with pytest.raises(ConfigError, match=r"no 'bridge:'"):
+            gen.generate("s", cluster, conf_dir="/proj", shared_networks=shared)
+
+    def test_shared_and_cluster_networks_mixed_mapping_form(self):
+        """A box on both a cluster-internal net and a static-IP shared net →
+        mapping form with an empty opts dict for the internal one."""
+        gen = ComposeGenerator()
+        cluster = {
+            "networks": {"backend": {"subnet": "172.30.0.0/24"}},
+            "boxes": {"w": {"image": "x", "networks": {
+                "backend": None,
+                "labnet": {"ipv4_address": "10.10.0.9"},
+            }}},
+        }
+        compose = gen.generate(
+            "s", cluster, conf_dir="/proj", shared_networks=self._shared()
+        )
+        assert compose["services"]["w"]["networks"] == {
+            "backend": {},
+            "labnet": {"ipv4_address": "10.10.0.9"},
+        }
+        assert compose["networks"]["backend"]["driver"] == "bridge"
+        assert compose["networks"]["labnet"]["driver"] == "macvlan"
+
+    def test_ipv4_address_on_cluster_internal_net_warns_and_drops(self):
+        gen = ComposeGenerator()
+        cluster = {
+            "networks": {"backend": {"subnet": "172.30.0.0/24"}},
+            "boxes": {"w": {"image": "x",
+                            "networks": {"backend": {"ipv4_address": "172.30.0.5"}}}},
+        }
         with mock.patch.object(gen.logger, "warning") as warn:
-            svc = gen.generate(
-                "s", cluster, conf_dir="/proj", shared_network_names=["labnet"]
-            )["services"]["w"]
-        assert "networks" not in svc
-        assert warn.called
-        assert "Phase 4" in warn.call_args[0][0]
+            svc = gen.generate("s", cluster, conf_dir="/proj")["services"]["w"]
+        # dropped → plain list attach, no static IP wired
+        assert svc["networks"] == ["backend"]
+        assert any("only wired for shared_networks" in str(c.args[0])
+                   for c in warn.call_args_list)
+
+    def test_shared_network_compose_extra_merges_onto_macvlan(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"w": {"image": "x", "networks": ["labnet"]}}}
+        shared = self._shared(compose_extra={"driver_opts": {"macvlan_mode": "bridge"}})
+        net = gen.generate(
+            "s", cluster, conf_dir="/proj", shared_networks=shared
+        )["networks"]["labnet"]
+        assert net["driver_opts"] == {"parent": "br-lab", "macvlan_mode": "bridge"}
 
     def test_unknown_network_ref_warned_and_skipped(self):
         gen = ComposeGenerator()
@@ -770,7 +876,7 @@ class TestFlowWiring:
             "register_project_in_cache", "unregister_from_cache",
             "_expand_oci_base_images", "ensure_templates_exist",
             "validate_base_images", "provision_files", "deprovision_files",
-            "ensure_shared_bridges", "setup_ssh_access", "connect_info",
+            "setup_ssh_access", "connect_info",
             "write_ssh_config", "define_networks", "destroy_networks",
         ]:
             monkeypatch.setattr(m, name, lambda *a, **k: None)
@@ -779,6 +885,7 @@ class TestFlowWiring:
         monkeypatch.setattr(m, "get_connect_info", lambda *a, **k: True)
         # record the ordering-relevant hooks
         monkeypatch.setattr(m, "configure_and_start_vms", lambda: order.append("vms"))
+        monkeypatch.setattr(m, "ensure_shared_bridges", lambda: order.append("bridges"))
         monkeypatch.setattr(m, "deploy_netlab", lambda: order.append("netlab"))
         monkeypatch.setattr(m, "ensure_netlab_up", lambda: order.append("netlab_up"))
         monkeypatch.setattr(m, "destroy_netlab", lambda: order.append("netlab_down"))
@@ -794,6 +901,8 @@ class TestFlowWiring:
         BoxmanManager.provision(m, SimpleNamespace(force=False, rebuild_templates=False))
         assert "provision_compose_clusters" in order
         assert order.index("vms") < order.index("provision_compose_clusters") < order.index("netlab")
+        # shared bridges (macvlan parents) must exist before compose comes up
+        assert order.index("bridges") < order.index("provision_compose_clusters")
 
     def test_down_stops_compose_clusters(self, monkeypatch):
         m = self._mgr()
@@ -829,14 +938,16 @@ class TestFlowWiring:
         BoxmanManager.up(m, SimpleNamespace(force=False))
         assert order == ["provision"]
 
-    def test_up_dc_only_reconcile_calls_compose_up(self, monkeypatch):
+    def test_up_dc_only_reconcile_ensures_bridges_before_compose_up(self, monkeypatch):
         m = self._mgr()
         order = []
         self._neutralize(m, monkeypatch, order)
         monkeypatch.setattr(m, "_get_project_vm_names", lambda *a, **k: [])
         m.cache.projects = {"proj": {"conf": "x", "runtime": "local"}}  # already provisioned
         BoxmanManager.up(m, SimpleNamespace(force=False))
-        assert order == ["provision_compose_clusters"]
+        # a host reboot drops the non-persistent bridge; recreate it before
+        # the macvlan-attached containers reconcile.
+        assert order == ["bridges", "provision_compose_clusters"]
 
     def test_up_all_vms_running_reconciles_compose(self, monkeypatch):
         m = self._mgr()
@@ -848,3 +959,5 @@ class TestFlowWiring:
         BoxmanManager.up(m, SimpleNamespace(force=False))
         assert "provision_compose_clusters" in order
         assert order.index("netlab_up") < order.index("provision_compose_clusters")
+        # bridges reconciled before compose on the hybrid all-running path too
+        assert order.index("bridges") < order.index("provision_compose_clusters")

--- a/tests/test_docker_compose_provider.py
+++ b/tests/test_docker_compose_provider.py
@@ -332,6 +332,51 @@ class TestComposeGenerator:
         assert "networks" not in svc
         assert warn.called
 
+    # -- malformed networks: fail fast, never silently drop -----------------
+    def test_bare_string_networks_is_attached_not_silently_dropped(self):
+        """A forgotten list (`networks: labnet`) must still attach — not vanish
+        (which would land the service on the default bridge, no macvlan)."""
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"w": {"image": "x", "networks": "labnet"}}}
+        svc = gen.generate(
+            "s", cluster, conf_dir="/proj", shared_networks=self._shared()
+        )["services"]["w"]
+        assert svc["networks"] == ["labnet"]
+
+    def test_scalar_network_opts_raises_configerror(self):
+        """`networks: {labnet: 10.10.0.5}` (a scalar where a mapping/null is
+        required) is a ConfigError, not a raw ValueError."""
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"w": {"image": "x",
+                                   "networks": {"labnet": "10.10.0.5"}}}}
+        with pytest.raises(ConfigError, match=r"must be a mapping"):
+            gen.generate("s", cluster, conf_dir="/proj",
+                         shared_networks=self._shared())
+
+    def test_non_list_non_mapping_networks_raises_configerror(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"w": {"image": "x", "networks": 123}}}
+        with pytest.raises(ConfigError, match=r"must be a list or mapping"):
+            gen.generate("s", cluster, conf_dir="/proj")
+
+    def test_generate_emits_top_level_name_when_project_given(self):
+        """With project_name, a top-level `name:` is emitted so the file is
+        hand-runnable under the same project boxman uses (D5)."""
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"w": {"image": "nginx"}}}
+        compose = gen.generate("web", cluster, conf_dir="/proj",
+                               project_name="dc_standalone_web")
+        assert compose["name"] == "dc_standalone_web"
+        # name comes first, services still present
+        assert list(compose)[0] == "name"
+        assert "w" in compose["services"]
+
+    def test_generate_omits_name_without_project(self):
+        gen = ComposeGenerator()
+        compose = gen.generate("web", {"boxes": {"w": {"image": "x"}}},
+                               conf_dir="/proj")
+        assert "name" not in compose
+
     def test_corrupted_templating_warns(self):
         """A '{word}' token (the signature of a mangled bare '{{ word }}') in a
         compose command:/environment: value is flagged."""

--- a/tests/test_netlab_shared_bridges.py
+++ b/tests/test_netlab_shared_bridges.py
@@ -145,7 +145,7 @@ class TestEnsure:
         all_cmds = " | ".join(c.args[0] for c in run.call_args_list)
         assert "-I DOCKER-USER" not in all_cmds
 
-    def test_disable_netfilter_opt_in_sets_global_and_warns(self, caplog):
+    def test_disable_netfilter_opt_in_sets_global_and_warns(self, captured_logs):
         """Explicit disable_netfilter: true → host-global sysctl=0, a loud
         warning, and NO scoped FORWARD rule."""
         import logging as _logging
@@ -153,12 +153,12 @@ class TestEnsure:
         with patch("boxman.netlab.shared_bridges.run",
                    side_effect=self._fake_run()) as run:
             with patch("pathlib.Path.exists", return_value=True):
-                with caplog.at_level(_logging.WARNING, logger="boxman"):
+                with captured_logs.at_level(_logging.WARNING, logger="boxman"):
                     shared_bridges.ensure(cfg)
         all_cmds = " | ".join(c.args[0] for c in run.call_args_list)
         assert "bridge-nf-call-iptables" in all_cmds and "echo 0" in all_cmds
         assert "-I FORWARD" not in all_cmds  # global disable, no scoped rule
-        assert any("HOST-WIDE" in r.message for r in caplog.records)
+        assert any("HOST-WIDE" in r.message for r in captured_logs.records)
 
     def test_missing_bridge_key_raises(self):
         cfg = {"lab_mgmt": {"stp": False}}  # no 'bridge'

--- a/tests/test_netlab_shared_bridges.py
+++ b/tests/test_netlab_shared_bridges.py
@@ -148,13 +148,11 @@ class TestEnsure:
     def test_disable_netfilter_opt_in_sets_global_and_warns(self, captured_logs):
         """Explicit disable_netfilter: true → host-global sysctl=0, a loud
         warning, and NO scoped FORWARD rule."""
-        import logging as _logging
         cfg = {"lab_mgmt": {"bridge": "br1", "disable_netfilter": True}}
         with patch("boxman.netlab.shared_bridges.run",
                    side_effect=self._fake_run()) as run:
             with patch("pathlib.Path.exists", return_value=True):
-                with captured_logs.at_level(_logging.WARNING, logger="boxman"):
-                    shared_bridges.ensure(cfg)
+                shared_bridges.ensure(cfg)
         all_cmds = " | ".join(c.args[0] for c in run.call_args_list)
         assert "bridge-nf-call-iptables" in all_cmds and "echo 0" in all_cmds
         assert "-I FORWARD" not in all_cmds  # global disable, no scoped rule

--- a/tests/test_netlab_shared_bridges.py
+++ b/tests/test_netlab_shared_bridges.py
@@ -83,34 +83,82 @@ class TestEnsure:
 
         assert any("stp_state 1" in c.args[0] for c in run.call_args_list)
 
-    def test_disables_bridge_netfilter_when_proc_exists(self):
-        def fake_run(cmd, **kwargs):
+    @staticmethod
+    def _fake_run(rule_present=False, docker_user=False):
+        """A run() double for the netfilter path.
+
+        ``rule_present`` → the ``iptables -C`` check reports the scoped rule
+        already exists (so no ``-I`` insert). ``docker_user`` → the
+        ``DOCKER-USER`` chain exists.
+        """
+        def fake(cmd, **kwargs):
             if cmd.startswith("ip link show dev"):
                 return _result(ok=True)
+            if "-C FORWARD" in cmd or "-C DOCKER-USER" in cmd:
+                return _result(ok=rule_present)
+            if "-n -L DOCKER-USER" in cmd:
+                return _result(ok=docker_user)
             return _result(ok=True)
+        return fake
 
-        cfg = {"lab_mgmt": {"bridge": "br1"}}  # disable_netfilter defaults True
-        with patch("boxman.netlab.shared_bridges.run", side_effect=fake_run) as run:
+    def test_default_applies_scoped_forward_rule_not_global_disable(self):
+        """D8 default (disable_netfilter unset → False): a scoped physdev
+        ACCEPT rule is inserted into FORWARD, and the host-global sysctl is
+        left untouched."""
+        cfg = {"lab_mgmt": {"bridge": "br1"}}  # default disable_netfilter=False
+        with patch("boxman.netlab.shared_bridges.run",
+                   side_effect=self._fake_run()) as run:
             with patch("pathlib.Path.exists", return_value=True):
                 shared_bridges.ensure(cfg)
-
         all_cmds = " | ".join(c.args[0] for c in run.call_args_list)
-        assert "bridge-nf-call-iptables" in all_cmds
-        assert "echo 0" in all_cmds
-
-    def test_skips_netfilter_when_opted_out(self):
-        def fake_run(cmd, **kwargs):
-            if cmd.startswith("ip link show dev"):
-                return _result(ok=True)
-            return _result(ok=True)
-
-        cfg = {"lab_mgmt": {"bridge": "br1", "disable_netfilter": False}}
-        with patch("boxman.netlab.shared_bridges.run", side_effect=fake_run) as run:
-            with patch("pathlib.Path.exists", return_value=True):
-                shared_bridges.ensure(cfg)
-
-        all_cmds = " | ".join(c.args[0] for c in run.call_args_list)
+        assert ("iptables -t filter -I FORWARD 1 -i br1 -o br1 "
+                "-m physdev --physdev-is-bridged -j ACCEPT") in all_cmds
         assert "bridge-nf-call-iptables" not in all_cmds
+        assert "echo 0" not in all_cmds
+
+    def test_scoped_rule_idempotent_when_already_present(self):
+        """When ``iptables -C`` reports the rule exists, no ``-I`` insert runs."""
+        cfg = {"lab_mgmt": {"bridge": "br1"}}
+        with patch("boxman.netlab.shared_bridges.run",
+                   side_effect=self._fake_run(rule_present=True)) as run:
+            with patch("pathlib.Path.exists", return_value=True):
+                shared_bridges.ensure(cfg)
+        all_cmds = " | ".join(c.args[0] for c in run.call_args_list)
+        assert "-C FORWARD" in all_cmds       # checked
+        assert "-I FORWARD" not in all_cmds   # but not re-inserted
+
+    def test_scoped_rule_added_to_docker_user_when_chain_exists(self):
+        cfg = {"lab_mgmt": {"bridge": "br1"}}
+        with patch("boxman.netlab.shared_bridges.run",
+                   side_effect=self._fake_run(docker_user=True)) as run:
+            with patch("pathlib.Path.exists", return_value=True):
+                shared_bridges.ensure(cfg)
+        all_cmds = " | ".join(c.args[0] for c in run.call_args_list)
+        assert "-I DOCKER-USER 1 -i br1 -o br1" in all_cmds
+
+    def test_scoped_rule_skips_docker_user_when_chain_absent(self):
+        cfg = {"lab_mgmt": {"bridge": "br1"}}
+        with patch("boxman.netlab.shared_bridges.run",
+                   side_effect=self._fake_run(docker_user=False)) as run:
+            with patch("pathlib.Path.exists", return_value=True):
+                shared_bridges.ensure(cfg)
+        all_cmds = " | ".join(c.args[0] for c in run.call_args_list)
+        assert "-I DOCKER-USER" not in all_cmds
+
+    def test_disable_netfilter_opt_in_sets_global_and_warns(self, caplog):
+        """Explicit disable_netfilter: true → host-global sysctl=0, a loud
+        warning, and NO scoped FORWARD rule."""
+        import logging as _logging
+        cfg = {"lab_mgmt": {"bridge": "br1", "disable_netfilter": True}}
+        with patch("boxman.netlab.shared_bridges.run",
+                   side_effect=self._fake_run()) as run:
+            with patch("pathlib.Path.exists", return_value=True):
+                with caplog.at_level(_logging.WARNING, logger="boxman"):
+                    shared_bridges.ensure(cfg)
+        all_cmds = " | ".join(c.args[0] for c in run.call_args_list)
+        assert "bridge-nf-call-iptables" in all_cmds and "echo 0" in all_cmds
+        assert "-I FORWARD" not in all_cmds  # global disable, no scoped rule
+        assert any("HOST-WIDE" in r.message for r in caplog.records)
 
     def test_missing_bridge_key_raises(self):
         cfg = {"lab_mgmt": {"stp": False}}  # no 'bridge'


### PR DESCRIPTION
Phase 4 of the docker-compose provider epic (#42). Closes #52.
Base: `feat/docker-compose-provider`.

## What this does
Lets a docker-compose container and a libvirt VM share an L2 domain by
attaching the container to the same host Linux bridge as the VM, via a
docker **macvlan** network whose `parent` is that bridge.

## Changes
- **Generator** — `shared_networks` refs become top-level macvlan networks
  (`driver: macvlan` + `driver_opts.parent` + `ipam` from
  `subnet`/`gateway`/`ip_range`). Box `networks:` supports the list form
  (auto address) and the mapping form (`{net: {ipv4_address: …}}`, static).
  Missing `bridge`/`subnet` on an attached shared net → `ConfigError`;
  `ipv4_address` on a cluster-internal net → warn + drop.
- **Netfilter (D8)** — default `disable_netfilter: false`: keep the
  host-global `bridge-nf-call-iptables` untouched and install idempotent
  per-bridge scoped physdev accept rules on `FORWARD` (+ `DOCKER-USER` when
  present). Global disable is an explicit, loudly-warned opt-in.
- **Manager** — dc-only reconcile `up` ensures shared bridges before the
  macvlan containers reconcile (survives a host reboot dropping the bridge).
- **Docs** — `config-schema.md` shared_networks + static-IP syntax;
  `design.md` D8 marked implemented, macvlan example corrected.

## Testing
- **Host unit suite:** 1251 passed (net +8 over Phase 3), integration deselected.
- **Live hybrid e2e in stage01** (nested, per the host-vs-VM policy — never the
  host hypervisor). One conf.yml: a libvirt VM (`node01`, eth1 → `br-p4app`) +
  a docker-compose container (`web`, macvlan on `br-p4app` static 10.10.0.10 +
  cluster-internal `backend`). `boxman provision` → `destroy`:
  - **AC10** VM↔container ping both ways — 3/3 each direction
  - **AC11** ARP both ways — MACs cross-verified (real L2, not routing)
  - **AC12** cluster-internal `backend` isolated from the VM — 100% loss
  - D8 rules present on `FORWARD` + `DOCKER-USER`; `bridge-nf-call-iptables=1`
    left untouched
  - `destroy` tears down both clusters; shared bridge left in place by design

## Notes
- The dc-only **reconcile** bridge-ensure path is pinned by unit test, not
  live-exercised (consistent with Phase 3's precedent).
- Live dogfooding re-confirmed two known prereq issues (guest-agent check
  bypasses the `-c` URI; `sshpass` missing breaks key injection) — already on
  the epic's candidate-issues list, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
