### PR TITLE
feat(docker-compose): Phase 5 volumes — named/bind/workdir mounts (#53)

### DIFF
--- a/doc/docker-compose-provider/config-schema.md
+++ b/doc/docker-compose-provider/config-schema.md
@@ -80,12 +80,13 @@ is unchanged.
 A v2.0 config with a docker-compose cluster is **runnable**: `boxman
 provision` / `up` generate a `docker-compose.yml` in the cluster `workdir`
 and run `docker compose up -d --wait`, and `down` / `deprovision` / `destroy`
-tear it down. Scope covers cluster-internal bridge networks and
+tear it down. Scope covers cluster-internal bridge networks,
 `shared_networks` **macvlan L2 to libvirt VMs** (Phase 4, #52 — see
 [Shared networks (macvlan L2 to VMs)](#shared-networks-macvlan-l2-to-vms)
-below). Still out of scope: structured `volumes:` (Phase 5),
-ssh/exec/inventory (Phase 6), snapshots (Phase 7). Box features outside this
-scope are warned about and skipped (use `compose_extra:` as the escape hatch).
+below), and structured **`volumes:`** (Phase 5, #53 — see
+[Volumes](#volumes) below). Still out of scope: ssh/exec/inventory (Phase 6),
+snapshots (Phase 7). Box features outside this scope are warned about and
+skipped (use `compose_extra:` as the escape hatch).
 
 Two hard requirements, both enforced fail-fast (exit 2):
 
@@ -215,17 +216,25 @@ clusters:
 | **bind** | has `host_path` | `<abs host_path>:<container_path>[:ro]` | — |
 | **workdir** | a bind with `host_path: .` | `<conf dir>:<container_path>[:ro]` | — |
 
-- `readonly: true` appends `:ro`.
+- `container_path` must be an **absolute** path; `readonly: true` appends `:ro`.
 - A relative `host_path` is resolved absolute against the `conf.yml` directory
   (same rule as `build.context`). boxman `mkdir -p`s a bind host dir before
   `up` (so docker doesn't create it as `root`); an existing path is left as-is.
+  A **missing bind path is always created as a directory** — a single-file bind
+  mount must already exist on the host (boxman, like docker, can't tell a file
+  from a dir from the schema).
 - **`size:` is advisory** — docker's `local` volume driver does not enforce
   quotas, so boxman emits the volume and logs a warning rather than pretending
   to cap it. On a bind mount `size:` is meaningless and warned/ignored.
+- `name:` and `compose_extra:` apply to **named volumes only** — on a bind mount
+  (`host_path:` present) they are warned and ignored. `compose_extra:` on a
+  named entry is deep-merged onto its top-level `{driver: local}` spec (e.g.
+  custom `driver_opts`); when two boxes share a `name:`, the first-seen spec
+  wins and a later box's differing options are warned + ignored.
 - Malformed entries fail fast with a `ConfigError` (non-mapping entry, missing
-  `container_path`, or a named entry missing `name`) rather than silently
-  dropping a mount. `compose_extra:` on a named entry is deep-merged onto its
-  top-level `{driver: local}` spec (e.g. custom `driver_opts`).
+  or non-absolute `container_path`, a named entry missing `name`, or a `:` in a
+  path/name that would re-split the emitted mount) rather than silently
+  dropping a mount.
 
 **Lifecycle:** `boxman down` keeps volumes (`docker compose down`); `boxman
 destroy` removes **named** volumes (`down --volumes`) and the generated compose

--- a/doc/docker-compose-provider/config-schema.md
+++ b/doc/docker-compose-provider/config-schema.md
@@ -184,6 +184,54 @@ Notes and requirements:
   disables netfilter on bridges **host-wide** (a discouraged opt-in, logged
   loudly, reverted by any reboot).
 
+## Volumes
+
+A box's `volumes:` is a list of **structured** mounts (not raw compose
+strings — use `compose_extra:` for those). Each entry needs a `container_path`;
+whether it has a `host_path` decides its kind:
+
+```yaml
+clusters:
+  data:
+    provider: docker-compose
+    workdir: ./.boxman/data
+    boxes:
+      db:
+        image: postgres:16
+        volumes:
+          - name: pg_data                 # named volume (docker-managed)
+            container_path: /var/lib/postgresql/data
+            size: 10G                      # advisory only — see below
+          - host_path: ./initdb           # bind mount (relative → resolved vs conf.yml dir)
+            container_path: /docker-entrypoint-initdb.d
+            readonly: true
+          - host_path: .                   # "workdir" mount — a bind at the project dir
+            container_path: /workspace
+```
+
+| Kind | Trigger | Emitted | Top-level `volumes:` |
+|---|---|---|---|
+| **named** | has `name`, no `host_path` | `<name>:<container_path>[:ro]` | `{<name>: {driver: local}}` |
+| **bind** | has `host_path` | `<abs host_path>:<container_path>[:ro]` | — |
+| **workdir** | a bind with `host_path: .` | `<conf dir>:<container_path>[:ro]` | — |
+
+- `readonly: true` appends `:ro`.
+- A relative `host_path` is resolved absolute against the `conf.yml` directory
+  (same rule as `build.context`). boxman `mkdir -p`s a bind host dir before
+  `up` (so docker doesn't create it as `root`); an existing path is left as-is.
+- **`size:` is advisory** — docker's `local` volume driver does not enforce
+  quotas, so boxman emits the volume and logs a warning rather than pretending
+  to cap it. On a bind mount `size:` is meaningless and warned/ignored.
+- Malformed entries fail fast with a `ConfigError` (non-mapping entry, missing
+  `container_path`, or a named entry missing `name`) rather than silently
+  dropping a mount. `compose_extra:` on a named entry is deep-merged onto its
+  top-level `{driver: local}` spec (e.g. custom `driver_opts`).
+
+**Lifecycle:** `boxman down` keeps volumes (`docker compose down`); `boxman
+destroy` removes **named** volumes (`down --volumes`) and the generated compose
+file. Bind-mount host directories are **never** removed — they are your paths
+(`./initdb`, `.`), so cleaning them up is your call.
+
 ## Templating caveat for compose values (`environment:`, `command:`)
 
 `load_config` pre-processes bare `{{ name }}` tokens into `{name}` task

--- a/doc/docker-compose-provider/design.md
+++ b/doc/docker-compose-provider/design.md
@@ -413,6 +413,16 @@ with a loud warning. Evidence: [spike/findings.md](spike/findings.md)
 
 ## Volume Management
 
+> **Implemented in Phase 5 ([#53](https://github.com/mherkazandjian/boxman/issues/53)).**
+> Structured `volumes:` (named / bind / workdir, `readonly:`) translate to
+> compose mounts + a top-level `volumes:` block for named volumes.
+> `size:` is **advisory** — docker's `local` driver can't enforce quotas, so
+> boxman emits the volume and warns rather than pretending to cap it (it stays
+> available via `compose_extra: {driver_opts: …}` for setups that can).
+> Lifecycle: `down` keeps volumes, `destroy` runs `down --volumes`; bind-mount
+> host dirs are never auto-removed. See
+> [config-schema.md](./config-schema.md#volumes).
+
 ### Volume Types
 
 ```mermaid

--- a/src/boxman/providers/docker_compose/compose_generator.py
+++ b/src/boxman/providers/docker_compose/compose_generator.py
@@ -5,11 +5,20 @@ ComposeGenerator — translate a boxman docker-compose *cluster* into a
 Scope: services (image / build / command / environment / ports /
 depends_on / restart / healthcheck), cluster-internal bridge networks,
 ``shared_networks`` bridges attached as docker **macvlan** networks (Phase 4
-— L2 to libvirt VMs on the same host bridge), and the ``compose_extra:``
-escape hatch (deep-merged verbatim, per-cluster and per-box — design
-decision D7). Out-of-phase box features are warned about and skipped:
+— L2 to libvirt VMs on the same host bridge), structured ``volumes:`` (Phase
+5 — named / bind / workdir mounts), and the ``compose_extra:`` escape hatch
+(deep-merged verbatim, per-cluster and per-box — design decision D7).
 
-- ``volumes:`` (structured named/bind/workdir mounts) → **Phase 5**.
+A box's ``volumes:`` is a list of structured mounts:
+
+- **named** (``{name: pg_data, container_path: /var/lib/postgresql/data}``) —
+  emitted as ``pg_data:/var/lib/postgresql/data`` plus a top-level
+  ``volumes: {pg_data: {driver: local}}``. An optional ``size:`` is
+  **advisory** (warned) — docker's local driver does not enforce quotas.
+- **bind** (``{host_path: ./configs, container_path: /etc/app,
+  readonly: true}``) — emitted as ``<abs host>:/etc/app:ro``; a relative
+  ``host_path`` is resolved against the project ``conf.yml`` dir (D4). A
+  "workdir mount" is just a bind mount with ``host_path: .``.
 
 A box's ``networks:`` may be a plain list (``[app_bridge, backend]`` — the
 container gets an auto-assigned address on each) or a mapping that pins a
@@ -49,15 +58,24 @@ _PASSTHROUGH_KEYS = (
 #: before the brace), which is a safe compose interpolation, not corruption.
 _CORRUPTED_TEMPLATE_RE = re.compile(r"(?<!\$)\{[a-zA-Z_]\w*\}")
 
-#: every box key the Phase-3 generator understands. Anything else is warned
-#: about and dropped (``volumes:`` → Phase 5 is handled separately, but is a
-#: recognised key so it doesn't also trip the unknown-key warning).
+#: every box key the generator understands. Anything else is warned about and
+#: dropped.
 _KNOWN_BOX_KEYS = frozenset(_PASSTHROUGH_KEYS) | {
     "build",
     "networks",
     "volumes",
     "compose_extra",
 }
+
+#: keys understood inside a structured ``volumes:`` entry. Others warn.
+_KNOWN_VOLUME_KEYS = frozenset({
+    "name",
+    "container_path",
+    "host_path",
+    "readonly",
+    "size",
+    "compose_extra",
+})
 
 
 class ComposeGenerator:
@@ -106,12 +124,16 @@ class ComposeGenerator:
         #: only these become top-level macvlan networks (insertion order via
         #: shared_networks below keeps the output deterministic).
         referenced_shared: set[str] = set()
+        #: named volumes defined by any box → the top-level ``volumes:`` block,
+        #: in first-seen order (a name shared by two boxes is defined once).
+        named_volumes: dict[str, Any] = {}
 
         services: dict[str, Any] = {}
         for box_name, box in (cluster_cfg.get("boxes") or {}).items():
             services[box_name] = self._service(
                 cluster_name, box_name, box or {}, conf_dir,
                 cluster_networks, shared_networks, referenced_shared,
+                named_volumes,
             )
 
         compose: dict[str, Any] = {}
@@ -124,6 +146,8 @@ class ComposeGenerator:
         )
         if networks:
             compose["networks"] = networks
+        if named_volumes:
+            compose["volumes"] = named_volumes
 
         # D7: per-cluster escape hatch, deep-merged verbatim.
         return self._deep_merge(compose, cluster_cfg.get("compose_extra") or {})
@@ -148,6 +172,7 @@ class ComposeGenerator:
         cluster_networks: dict[str, Any],
         shared_networks: dict[str, Any],
         referenced_shared: set[str],
+        named_volumes: dict[str, Any],
     ) -> dict[str, Any]:
         svc: dict[str, Any] = {}
 
@@ -176,12 +201,11 @@ class ComposeGenerator:
         if nets:
             svc["networks"] = nets
 
-        if box.get("volumes"):
-            self.logger.warning(
-                f"box '{cluster_name}.{box_name}': 'volumes:' is not supported "
-                f"yet (lands in Phase 5) — skipping {len(box['volumes'])} "
-                f"volume(s). Use 'compose_extra:' if you need them now."
-            )
+        vols = self._service_volumes(
+            cluster_name, box_name, box.get("volumes"), conf_dir, named_volumes
+        )
+        if vols:
+            svc["volumes"] = vols
 
         # D7: per-box escape hatch, deep-merged verbatim (last, so it can
         # override anything boxman generated).
@@ -253,6 +277,85 @@ class ComposeGenerator:
     @staticmethod
     def _abs_context(ctx: str, conf_dir: str) -> str:
         return os.path.abspath(os.path.join(conf_dir, os.path.expanduser(ctx)))
+
+    def _service_volumes(
+        self,
+        cluster_name: str,
+        box_name: str,
+        volumes: Any,
+        conf_dir: str,
+        named_volumes: dict[str, Any],
+    ) -> list[str]:
+        """Translate a box's structured ``volumes:`` to compose mount strings.
+
+        Each entry is a mapping. A ``host_path`` makes it a **bind** mount
+        (relative paths resolved absolute vs *conf_dir*, D4); otherwise it is a
+        **named** volume (needs ``name``) that is also recorded in
+        *named_volumes* for the top-level ``volumes:`` block. ``readonly: true``
+        appends ``:ro``. ``size:`` is advisory on a named volume (docker's
+        local driver does not enforce quotas) and meaningless on a bind mount —
+        both are warned, never enforced. Malformed input raises ``ConfigError``
+        rather than silently dropping a mount.
+        """
+        if not volumes:
+            return []
+        if not isinstance(volumes, (list, tuple)):
+            raise ConfigError(
+                f"box '{cluster_name}.{box_name}': 'volumes:' must be a list of "
+                f"mounts (got {type(volumes).__name__})."
+            )
+        mounts: list[str] = []
+        for entry in volumes:
+            if not isinstance(entry, dict):
+                raise ConfigError(
+                    f"box '{cluster_name}.{box_name}': each 'volumes:' entry must "
+                    f"be a mapping with 'container_path' (+ 'name' for a named "
+                    f"volume or 'host_path' for a bind mount) — got {entry!r}."
+                )
+            unknown = [k for k in entry if k not in _KNOWN_VOLUME_KEYS]
+            if unknown:
+                self.logger.warning(
+                    f"box '{cluster_name}.{box_name}': ignoring unknown "
+                    f"'volumes:' key(s) {', '.join(repr(k) for k in unknown)} — "
+                    f"use 'compose_extra:' to pass extra mount options."
+                )
+            container_path = entry.get("container_path")
+            if not container_path:
+                raise ConfigError(
+                    f"box '{cluster_name}.{box_name}': a 'volumes:' entry is "
+                    f"missing 'container_path' ({entry!r})."
+                )
+            ro = ":ro" if entry.get("readonly") else ""
+            host_path = entry.get("host_path")
+            if host_path:
+                if entry.get("size"):
+                    self.logger.warning(
+                        f"box '{cluster_name}.{box_name}': 'size:' is ignored on "
+                        f"the bind mount for '{container_path}' — it is only "
+                        f"meaningful on a named volume."
+                    )
+                abs_host = self._abs_context(str(host_path), conf_dir)
+                mounts.append(f"{abs_host}:{container_path}{ro}")
+            else:
+                name = entry.get("name")
+                if not name:
+                    raise ConfigError(
+                        f"box '{cluster_name}.{box_name}': a named 'volumes:' "
+                        f"entry needs a 'name' (or a 'host_path' for a bind "
+                        f"mount) — {entry!r}."
+                    )
+                if entry.get("size"):
+                    self.logger.warning(
+                        f"box '{cluster_name}.{box_name}': size: "
+                        f"{entry['size']!r} on named volume '{name}' is advisory "
+                        f"— docker's local driver does not enforce quotas."
+                    )
+                mounts.append(f"{name}:{container_path}{ro}")
+                if name not in named_volumes:
+                    named_volumes[name] = self._deep_merge(
+                        {"driver": "local"}, entry.get("compose_extra") or {}
+                    )
+        return mounts
 
     def _service_networks(
         self,

--- a/src/boxman/providers/docker_compose/compose_generator.py
+++ b/src/boxman/providers/docker_compose/compose_generator.py
@@ -78,6 +78,18 @@ _KNOWN_VOLUME_KEYS = frozenset({
 })
 
 
+def resolve_local_path(path: str, base_dir: str) -> str:
+    """Resolve *path* absolute against *base_dir* (``~`` expanded); an already
+    absolute *path* ignores *base_dir*.
+
+    The single source of truth for build-context, bind-mount and bind-dir
+    resolution — the docs promise bind resolution follows "the same rule as
+    ``build.context``", so both the generator (emitting the mount) and the
+    session (``mkdir``-ing the host dir) call this, and can never drift apart.
+    """
+    return os.path.abspath(os.path.join(base_dir, os.path.expanduser(path)))
+
+
 class ComposeGenerator:
     """Render a docker-compose cluster to a ``docker-compose.yml`` dict/file."""
 
@@ -276,7 +288,7 @@ class ComposeGenerator:
 
     @staticmethod
     def _abs_context(ctx: str, conf_dir: str) -> str:
-        return os.path.abspath(os.path.join(conf_dir, os.path.expanduser(ctx)))
+        return resolve_local_path(ctx, conf_dir)
 
     def _service_volumes(
         self,
@@ -325,16 +337,39 @@ class ComposeGenerator:
                     f"box '{cluster_name}.{box_name}': a 'volumes:' entry is "
                     f"missing 'container_path' ({entry!r})."
                 )
+            container_path = str(container_path)
+            # Fail fast on paths that would only error cryptically at
+            # ``docker compose up``, or a ``:`` that would silently re-split the
+            # short-syntax mount string boxman emits.
+            if not os.path.isabs(container_path):
+                raise ConfigError(
+                    f"box '{cluster_name}.{box_name}': volume container_path "
+                    f"{container_path!r} must be an absolute path."
+                )
+            if ":" in container_path:
+                raise ConfigError(
+                    f"box '{cluster_name}.{box_name}': volume container_path "
+                    f"{container_path!r} must not contain ':'."
+                )
             ro = ":ro" if entry.get("readonly") else ""
             host_path = entry.get("host_path")
             if host_path:
-                if entry.get("size"):
-                    self.logger.warning(
-                        f"box '{cluster_name}.{box_name}': 'size:' is ignored on "
-                        f"the bind mount for '{container_path}' — it is only "
-                        f"meaningful on a named volume."
+                # host_path decides the kind; a named-volume-only key here is a
+                # no-op — warn rather than drop it silently (as `size:` does).
+                for noop_key in ("name", "size", "compose_extra"):
+                    if entry.get(noop_key):
+                        self.logger.warning(
+                            f"box '{cluster_name}.{box_name}': '{noop_key}:' is "
+                            f"ignored on the bind mount for '{container_path}' — "
+                            f"it applies only to named volumes ('host_path' makes "
+                            f"this a bind mount)."
+                        )
+                if ":" in str(host_path):
+                    raise ConfigError(
+                        f"box '{cluster_name}.{box_name}': volume host_path "
+                        f"{host_path!r} must not contain ':'."
                     )
-                abs_host = self._abs_context(str(host_path), conf_dir)
+                abs_host = resolve_local_path(str(host_path), conf_dir)
                 mounts.append(f"{abs_host}:{container_path}{ro}")
             else:
                 name = entry.get("name")
@@ -344,6 +379,11 @@ class ComposeGenerator:
                         f"entry needs a 'name' (or a 'host_path' for a bind "
                         f"mount) — {entry!r}."
                     )
+                if ":" in str(name):
+                    raise ConfigError(
+                        f"box '{cluster_name}.{box_name}': volume name {name!r} "
+                        f"must not contain ':'."
+                    )
                 if entry.get("size"):
                     self.logger.warning(
                         f"box '{cluster_name}.{box_name}': size: "
@@ -351,9 +391,16 @@ class ComposeGenerator:
                         f"— docker's local driver does not enforce quotas."
                     )
                 mounts.append(f"{name}:{container_path}{ro}")
+                spec = self._deep_merge(
+                    {"driver": "local"}, entry.get("compose_extra") or {}
+                )
                 if name not in named_volumes:
-                    named_volumes[name] = self._deep_merge(
-                        {"driver": "local"}, entry.get("compose_extra") or {}
+                    named_volumes[name] = spec
+                elif named_volumes[name] != spec:
+                    self.logger.warning(
+                        f"box '{cluster_name}.{box_name}': named volume '{name}' "
+                        f"is already defined by an earlier box (first-seen wins) "
+                        f"— this box's differing volume options are ignored."
                     )
         return mounts
 

--- a/src/boxman/providers/docker_compose/session.py
+++ b/src/boxman/providers/docker_compose/session.py
@@ -19,7 +19,10 @@ from typing import Any
 
 from boxman import log
 from boxman.exceptions import ConfigError, ProvisionError
-from boxman.providers.docker_compose.compose_generator import ComposeGenerator
+from boxman.providers.docker_compose.compose_generator import (
+    ComposeGenerator,
+    resolve_local_path,
+)
 from boxman.providers.docker_compose.compose_runner import (
     DEFAULT_READINESS_TIMEOUT,
     ComposeRunner,
@@ -270,9 +273,9 @@ class DockerComposeSession:
                 host_path = entry.get("host_path")
                 if not host_path:
                     continue  # named volume — docker-managed
-                abs_host = os.path.abspath(
-                    os.path.join(conf_dir, os.path.expanduser(str(host_path)))
-                )
+                # Same resolver the generator uses to emit the mount, so the dir
+                # we create is exactly the one docker will bind.
+                abs_host = resolve_local_path(str(host_path), conf_dir)
                 if os.path.exists(abs_host):
                     continue
                 try:

--- a/src/boxman/providers/docker_compose/session.py
+++ b/src/boxman/providers/docker_compose/session.py
@@ -75,6 +75,7 @@ class DockerComposeSession:
         self._require_local_runtime(cluster_name)
         timeout = self._readiness_timeout(cluster_cfg, cluster_name)
         runner, _workdir, _compose_file = self._compose_context(cluster_name, cluster_cfg)
+        self._ensure_bind_dirs(cluster_name, cluster_cfg)
         runner.preflight()
         self.logger.info(
             f"[{cluster_name}] docker compose up (project '{runner.project}', "
@@ -247,6 +248,44 @@ class DockerComposeSession:
         """Directory of the project ``conf.yml`` (for build-context resolution)."""
         config_path = getattr(self.manager, "config_path", None)
         return os.path.dirname(os.path.abspath(config_path)) if config_path else os.getcwd()
+
+    def _ensure_bind_dirs(
+        self, cluster_name: str, cluster_cfg: dict[str, Any]
+    ) -> None:
+        """``mkdir -p`` each bind-mount host directory before ``compose up``.
+
+        A bind mount whose host path doesn't exist yet would otherwise be
+        created by the docker daemon as ``root:root``; pre-creating it here (as
+        the boxman user, the ``_ensure_writable_dir`` intent) gives saner
+        ownership. Named volumes need no pre-creation (docker-managed), and
+        bind dirs are deliberately **never removed** on teardown — they are
+        user paths (``./configs``, ``.``). A host path that already exists (or
+        is a file) is left untouched.
+        """
+        conf_dir = self._conf_dir()
+        for box_name, box in (cluster_cfg.get("boxes") or {}).items():
+            for entry in (box or {}).get("volumes") or []:
+                if not isinstance(entry, dict):
+                    continue  # malformed — the generator raises on it
+                host_path = entry.get("host_path")
+                if not host_path:
+                    continue  # named volume — docker-managed
+                abs_host = os.path.abspath(
+                    os.path.join(conf_dir, os.path.expanduser(str(host_path)))
+                )
+                if os.path.exists(abs_host):
+                    continue
+                try:
+                    os.makedirs(abs_host, exist_ok=True)
+                    self.logger.info(
+                        f"[{cluster_name}] created bind-mount dir {abs_host} "
+                        f"(box '{box_name}')"
+                    )
+                except OSError as exc:
+                    self.logger.warning(
+                        f"[{cluster_name}] could not create bind-mount dir "
+                        f"{abs_host}: {exc} — docker will create it as root."
+                    )
 
     def compose_project_name(self, cluster_name: str) -> str:
         """Public accessor for the ``docker compose -p`` name of *cluster_name*.

--- a/tests/test_docker_compose_provider.py
+++ b/tests/test_docker_compose_provider.py
@@ -9,9 +9,9 @@ cover four seams:
 
 - :class:`ComposeGenerator` — ``boxes:`` → compose ``services:`` translation,
   cluster-internal bridge networks, ``shared_networks`` → macvlan attach
-  (Phase 4: static/auto IPs, IPAM, reference-gating), absolute
-  ``build.context`` (D4), ``compose_extra:`` deep-merge (D7), and the warn+skip
-  of still-out-of-phase box features (``volumes:`` → Phase 5).
+  (Phase 4: static/auto IPs, IPAM, reference-gating), structured ``volumes:``
+  (Phase 5: named / bind / workdir, readonly, advisory size, fail-fast),
+  absolute ``build.context`` (D4), and ``compose_extra:`` deep-merge (D7).
 - :class:`ComposeRunner` — the exact ``docker compose`` command strings and
   the preflight / failure error paths (``boxman.utils.shell.run`` mocked).
 - :class:`DockerComposeSession` — satisfies the ``ProviderSession`` protocol,
@@ -200,14 +200,104 @@ class TestComposeGenerator:
         assert net["internal"] is True
         assert net["driver"] == "bridge"
 
-    def test_volumes_warn_and_skip(self):
+    # -- Phase 5: volumes -------------------------------------------------
+    def test_named_volume_emits_mount_and_top_level(self):
         gen = ComposeGenerator()
-        cluster = {"boxes": {"db": {"image": "postgres", "volumes": ["data:/var/lib"]}}}
+        cluster = {"boxes": {"db": {"image": "postgres", "volumes": [
+            {"name": "pg_data", "container_path": "/var/lib/postgresql/data"}]}}}
+        compose = gen.generate("s", cluster, conf_dir="/proj")
+        assert compose["services"]["db"]["volumes"] == [
+            "pg_data:/var/lib/postgresql/data"]
+        assert compose["volumes"] == {"pg_data": {"driver": "local"}}
+
+    def test_bind_mount_resolves_abs_and_readonly(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"w": {"image": "nginx", "volumes": [
+            {"host_path": "./configs", "container_path": "/etc/app",
+             "readonly": True}]}}}
+        compose = gen.generate("s", cluster, conf_dir="/proj")
+        assert compose["services"]["w"]["volumes"] == ["/proj/configs:/etc/app:ro"]
+        assert "volumes" not in compose  # bind mounts have no top-level entry
+
+    def test_workdir_is_a_bind_at_conf_dir(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"w": {"image": "x", "volumes": [
+            {"host_path": ".", "container_path": "/workspace"}]}}}
+        svc = gen.generate("s", cluster, conf_dir="/proj")["services"]["w"]
+        assert svc["volumes"] == ["/proj:/workspace"]
+
+    def test_named_volume_size_is_advisory_warn(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"db": {"image": "postgres", "volumes": [
+            {"name": "pg_data", "container_path": "/data", "size": "10G"}]}}}
         with mock.patch.object(gen.logger, "warning") as warn:
-            svc = gen.generate("s", cluster, conf_dir="/proj")["services"]["db"]
-        assert "volumes" not in svc
-        assert warn.called
-        assert "Phase 5" in warn.call_args[0][0]
+            compose = gen.generate("s", cluster, conf_dir="/proj")
+        assert compose["services"]["db"]["volumes"] == ["pg_data:/data"]  # still emitted
+        assert compose["volumes"] == {"pg_data": {"driver": "local"}}      # no size enforced
+        assert any("advisory" in str(c.args[0]) for c in warn.call_args_list)
+
+    def test_size_on_bind_warns_ignored(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"w": {"image": "x", "volumes": [
+            {"host_path": "./d", "container_path": "/d", "size": "5G"}]}}}
+        with mock.patch.object(gen.logger, "warning") as warn:
+            gen.generate("s", cluster, conf_dir="/proj")
+        assert any("ignored on the bind mount" in str(c.args[0])
+                   for c in warn.call_args_list)
+
+    def test_shared_named_volume_defined_once(self):
+        """Two boxes mounting the same named volume → one top-level entry."""
+        gen = ComposeGenerator()
+        cluster = {"boxes": {
+            "a": {"image": "x", "volumes": [{"name": "shared", "container_path": "/a"}]},
+            "b": {"image": "x", "volumes": [{"name": "shared", "container_path": "/b"}]},
+        }}
+        compose = gen.generate("s", cluster, conf_dir="/proj")
+        assert compose["volumes"] == {"shared": {"driver": "local"}}
+        assert compose["services"]["a"]["volumes"] == ["shared:/a"]
+        assert compose["services"]["b"]["volumes"] == ["shared:/b"]
+
+    def test_named_volume_compose_extra_merges(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"db": {"image": "x", "volumes": [
+            {"name": "v", "container_path": "/d",
+             "compose_extra": {"driver_opts": {"type": "none", "o": "bind"}}}]}}}
+        vol = gen.generate("s", cluster, conf_dir="/proj")["volumes"]["v"]
+        assert vol == {"driver": "local",
+                       "driver_opts": {"type": "none", "o": "bind"}}
+
+    def test_volume_missing_container_path_raises(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"db": {"image": "x", "volumes": [{"name": "v"}]}}}
+        with pytest.raises(ConfigError, match=r"missing 'container_path'"):
+            gen.generate("s", cluster, conf_dir="/proj")
+
+    def test_named_volume_missing_name_raises(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"db": {"image": "x",
+                                    "volumes": [{"container_path": "/d"}]}}}
+        with pytest.raises(ConfigError, match=r"needs a 'name'"):
+            gen.generate("s", cluster, conf_dir="/proj")
+
+    def test_non_dict_volume_entry_raises(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"db": {"image": "x", "volumes": ["data:/var/lib"]}}}
+        with pytest.raises(ConfigError, match=r"must\s+be a mapping"):
+            gen.generate("s", cluster, conf_dir="/proj")
+
+    def test_volumes_not_a_list_raises(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"db": {"image": "x", "volumes": {"name": "v"}}}}
+        with pytest.raises(ConfigError, match=r"'volumes:' must be a list"):
+            gen.generate("s", cluster, conf_dir="/proj")
+
+    def test_unknown_volume_key_warns(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"db": {"image": "x", "volumes": [
+            {"name": "v", "container_path": "/d", "typo": 1}]}}}
+        with mock.patch.object(gen.logger, "warning") as warn:
+            gen.generate("s", cluster, conf_dir="/proj")
+        assert any("unknown" in str(c.args[0]) for c in warn.call_args_list)
 
     # -- Phase 4: shared_networks → macvlan ------------------------------
     def _shared(self, **over):
@@ -617,6 +707,36 @@ class TestDockerComposeSession:
         with self._patch_context(session, runner):
             session.up_cluster("stack", {})
         assert ("up", DEFAULT_READINESS_TIMEOUT) in runner.calls
+
+    def test_up_cluster_precreates_bind_dirs(self):
+        """Bind-mount host dirs are mkdir -p'd before compose up; named volumes
+        (docker-managed) are not."""
+        session = self._session()
+        runner = _FakeRunner()
+        cluster = {"boxes": {"w": {"image": "x", "volumes": [
+            {"host_path": "./data", "container_path": "/d"},
+            {"name": "vol", "container_path": "/v"},
+        ]}}}
+        with self._patch_context(session, runner), \
+             mock.patch("boxman.providers.docker_compose.session.os.path.exists",
+                        return_value=False), \
+             mock.patch("boxman.providers.docker_compose.session.os.makedirs") as md:
+            session.up_cluster("stack", cluster)
+        made = [c.args[0] for c in md.call_args_list]
+        assert "/proj/data" in made                 # bind dir created
+        assert all("vol" not in p for p in made)     # named volume is not a dir
+
+    def test_ensure_bind_dirs_skips_existing_and_named(self):
+        session = self._session()
+        cluster = {"boxes": {"w": {"volumes": [
+            {"host_path": "./data", "container_path": "/d"},   # exists → skip
+            {"name": "vol", "container_path": "/v"},           # named → skip
+        ]}}}
+        with mock.patch("boxman.providers.docker_compose.session.os.path.exists",
+                        return_value=True), \
+             mock.patch("boxman.providers.docker_compose.session.os.makedirs") as md:
+            session._ensure_bind_dirs("stack", cluster)
+        md.assert_not_called()
 
     def test_readiness_timeout_non_integer_raises(self):
         session = self._session()

--- a/tests/test_docker_compose_provider.py
+++ b/tests/test_docker_compose_provider.py
@@ -299,6 +299,68 @@ class TestComposeGenerator:
             gen.generate("s", cluster, conf_dir="/proj")
         assert any("unknown" in str(c.args[0]) for c in warn.call_args_list)
 
+    # -- Phase 5 review: fail-fast paths + no-op warnings -----------------
+    def test_relative_container_path_raises(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"db": {"image": "x", "volumes": [
+            {"name": "v", "container_path": "data"}]}}}
+        with pytest.raises(ConfigError, match=r"must be an absolute path"):
+            gen.generate("s", cluster, conf_dir="/proj")
+
+    @pytest.mark.parametrize("entry", [
+        {"name": "v", "container_path": "/d:x"},        # colon in container_path
+        {"name": "v:x", "container_path": "/d"},        # colon in name
+        {"host_path": "./h:x", "container_path": "/d"}, # colon in host_path
+    ])
+    def test_colon_in_path_or_name_raises(self, entry):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"db": {"image": "x", "volumes": [entry]}}}
+        with pytest.raises(ConfigError, match=r"must not contain ':'"):
+            gen.generate("s", cluster, conf_dir="/proj")
+
+    def test_bind_named_only_keys_warn_ignored(self):
+        """`name:`/`compose_extra:` on a bind mount are no-ops → warned."""
+        gen = ComposeGenerator()
+        cluster = {"boxes": {"w": {"image": "x", "volumes": [
+            {"host_path": "./h", "container_path": "/d",
+             "name": "ignored", "compose_extra": {"x": 1}}]}}}
+        with mock.patch.object(gen.logger, "warning") as warn:
+            compose = gen.generate("s", cluster, conf_dir="/proj")
+        assert compose["services"]["w"]["volumes"] == ["/proj/h:/d"]
+        assert "volumes" not in compose  # no top-level entry for a bind
+        msgs = " ".join(str(c.args[0]) for c in warn.call_args_list)
+        assert "'name:' is ignored on the bind mount" in msgs
+        assert "'compose_extra:' is ignored on the bind mount" in msgs
+
+    def test_shared_named_volume_divergent_compose_extra_warns(self):
+        """First-seen spec wins; a later box's differing compose_extra warns."""
+        gen = ComposeGenerator()
+        cluster = {"boxes": {
+            "a": {"image": "x", "volumes": [
+                {"name": "v", "container_path": "/a",
+                 "compose_extra": {"driver_opts": {"o": "bind"}}}]},
+            "b": {"image": "x", "volumes": [
+                {"name": "v", "container_path": "/b",
+                 "compose_extra": {"driver_opts": {"o": "tmpfs"}}}]},
+        }}
+        with mock.patch.object(gen.logger, "warning") as warn:
+            compose = gen.generate("s", cluster, conf_dir="/proj")
+        # first-seen (box a) spec is kept
+        assert compose["volumes"]["v"]["driver_opts"] == {"o": "bind"}
+        assert any("already defined by an earlier box" in str(c.args[0])
+                   for c in warn.call_args_list)
+
+    def test_shared_named_volume_same_spec_no_warn(self):
+        gen = ComposeGenerator()
+        cluster = {"boxes": {
+            "a": {"image": "x", "volumes": [{"name": "v", "container_path": "/a"}]},
+            "b": {"image": "x", "volumes": [{"name": "v", "container_path": "/b"}]},
+        }}
+        with mock.patch.object(gen.logger, "warning") as warn:
+            gen.generate("s", cluster, conf_dir="/proj")
+        assert not any("already defined" in str(c.args[0])
+                       for c in warn.call_args_list)
+
     # -- Phase 4: shared_networks → macvlan ------------------------------
     def _shared(self, **over):
         base = {"bridge": "br-lab", "subnet": "10.10.0.0/24"}


### PR DESCRIPTION
Phase 5 of the docker-compose provider epic (#42). Closes #53.
Base: `feat/docker-compose-provider`.

## What this does
Translates a box's structured `volumes:` (until now warn+skipped) into compose
mounts. The lifecycle (down keeps volumes / destroy removes them) was already
wired in Phase 3 via the runner's `down` vs `down --volumes`, so this PR is
generation + bind-dir pre-creation + the `size:` decision.

## Volume schema
A list of structured mounts on a box; `container_path` is required, and a
`host_path` decides the kind:

| Kind | Trigger | Emitted | Top-level `volumes:` |
|---|---|---|---|
| **named** | has `name`, no `host_path` | `<name>:<container_path>[:ro]` | `{<name>: {driver: local}}` |
| **bind** | has `host_path` (relative → vs conf.yml dir, D4) | `<abs host>:<container_path>[:ro]` | — |
| **workdir** | a bind with `host_path: .` | `<conf dir>:<container_path>[:ro]` | — |

- `readonly: true` → `:ro`; `compose_extra:` on a named entry deep-merges onto
  its top-level spec.
- **`size:` is advisory** (agreed design decision) — docker's `local` driver
  can't enforce quotas, so boxman emits the volume + warns rather than
  pretending to cap it (`compose_extra: {driver_opts: …}` stays available for
  setups that can).
- Malformed input fails fast with `ConfigError` (non-list `volumes:`,
  non-mapping entry, missing `container_path`, named entry missing `name`)
  rather than silently dropping a mount.

## Bind-dir handling
`session._ensure_bind_dirs` `mkdir -p`s each bind host dir before `up` (as the
boxman user, so docker doesn't create it `root`-owned). Named volumes are
docker-managed; bind dirs are **never** removed on teardown (they're user
paths).

## Testing
- **Host unit:** 1269 passed (`pytest -m "not integration"`), +13 volume cases
  (emission for all three kinds, readonly, advisory/ignored size, shared named
  volume defined once, `compose_extra` merge, the four `ConfigError` paths,
  unknown-key warn, bind-dir pre-creation).
- **Live e2e in stage01** (dc-only, pure docker): a service with a named volume
  + a bind mount →
  - **AC13** named volume survives `down`/`up` (marker file intact)
  - **AC14** bind mount works both directions (host↔container)
  - **AC15** `destroy` removes the named volume and **leaves** the bind dir + its files
  - bind dir pre-created `admin:admin` (not root)

## Notes
- A committed volumes **example box** is deferred to Phase 8 (#56), consistent
  with the plan; this PR used a throwaway conf for the live e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
