### PR TITLE
fix: make hybrid-libvirt-containerlab boxes deploy (netlab path + cisco_vios + shared-bridge)

### DIFF
--- a/boxes/hybrid-libvirt-containerlab-arista-ceos/conf.yml
+++ b/boxes/hybrid-libvirt-containerlab-arista-ceos/conf.yml
@@ -159,6 +159,14 @@ containerlab:
         kind: arista_ceos
         image: ceos:4.32.0F
         startup-config: configs/sw1.cfg.j2
+      # A `kind: bridge` node references the *existing* shared Linux
+      # bridge that boxman creates from `shared_networks.clab_mgmt` (and
+      # that host01's second NIC also joins) — it attaches, it does not
+      # create one. (`host:<name>` would create a new host interface and
+      # collide with the bridge.)
+      clab_mgmt:
+        kind: bridge
     links:
-      # sw1's Ethernet1 lands on the same host bridge as host01's second NIC.
-      - endpoints: ["sw1:eth1", "host:clab_mgmt"]
+      # sw1's Ethernet1 lands on the same host bridge as host01's second
+      # NIC; eth-sw1 is the bridge-side veth on the shared bridge.
+      - endpoints: ["sw1:eth1", "clab_mgmt:eth-sw1"]

--- a/boxes/hybrid-libvirt-containerlab-cisco-iosvl2/README.md
+++ b/boxes/hybrid-libvirt-containerlab-cisco-iosvl2/README.md
@@ -40,32 +40,35 @@ Cisco Modeling Labs / Enterprise Agreement are the usual paths.
 
   ```bash
   git clone https://github.com/srl-labs/vrnetlab.git
-  cd vrnetlab/cisco/vios_l2
+  cd vrnetlab/cisco/vios
   ```
 
-**3. Copy the qcow2 into the vios_l2 directory and build.**
+**3. Copy the qcow2 into the `cisco/vios` directory and build.**
 
-  vrnetlab's Makefile derives the image tag from the qcow2 filename,
-  so rename the file to encode the version cleanly first.
+  srl-labs/vrnetlab builds both the router and the L2 switch from this
+  one directory and auto-selects the switch personality from a
+  `vios_l2` filename. The Makefile derives the image tag from the
+  filename, so keep the `vios_l2-` prefix and a clean date/version.
 
   ```bash
-  # rename to make the version unambiguous
+  # keep the vios_l2 prefix so the build detects the L2 switch;
+  # the trailing date becomes the image tag (L2-<date>)
   cp /path/to/vios_l2-adventerprisek9-m.SSA.high_iron_20200929.qcow2 \
-     vios_l2-15.2.2020T.qcow2
+     vios_l2-20200929.qcow2
 
   # build the vrnetlab container (takes a few minutes; boots the qcow2
   # once to snapshot the post-init state)
   make
 
   # verify
-  docker images | grep cisco_vios_l2
-  # vrnetlab/cisco_vios_l2   15.2.2020T   <id>   <time>   ~600MB
+  docker images | grep cisco_vios
+  # vrnetlab/cisco_vios   L2-20200929   <id>   <time>   ~600MB
   ```
 
-  If your build tags the image differently (say `vrnetlab/vr-iosvl2`),
-  update `containerlab.topology.nodes.sw1.image` in `conf.yml` to
-  match. Containerlab's kind for this image is `cisco_vios_l2`
-  regardless of tag.
+  If your build tags the image differently, update
+  `containerlab.topology.nodes.sw1.image` in `conf.yml` to match.
+  Containerlab's kind for this image is `cisco_vios` with
+  `type: switch` (there is no `cisco_vios_l2` kind), regardless of tag.
 
 **4. Smoke-test the image with containerlab alone.**
 
@@ -78,8 +81,9 @@ Cisco Modeling Labs / Enterprise Agreement are the usual paths.
   topology:
     nodes:
       sw1:
-        kind: cisco_vios_l2
-        image: vrnetlab/cisco_vios_l2:15.2.2020T
+        kind: cisco_vios
+        type: switch
+        image: vrnetlab/cisco_vios:L2-20200929
   EOF
 
   sudo containerlab deploy -t /tmp/iosvl2-smoke.clab.yml

--- a/boxes/hybrid-libvirt-containerlab-cisco-iosvl2/conf.yml
+++ b/boxes/hybrid-libvirt-containerlab-cisco-iosvl2/conf.yml
@@ -6,8 +6,8 @@
 # IOSvL2 Catalyst-style L2 device running via vrnetlab.
 #
 # The only real differences vs. the cEOS variant are:
-#   - `kind: cisco_vios_l2`  (containerlab kind)
-#   - `image: vrnetlab/cisco_vios_l2:15.2.2020T`  (vrnetlab-built container)
+#   - `kind: cisco_vios` + `type: switch`  (containerlab kind; IOSvL2 switch)
+#   - `image: vrnetlab/cisco_vios:L2-20200929`  (vrnetlab-built container)
 #   - Interface name: `GigabitEthernet0/1` instead of `Ethernet1`
 #   - startup-config uses classic Cisco IOS CLI (Catalyst-style)
 #
@@ -19,11 +19,12 @@
 #     workflow:
 #
 #       git clone https://github.com/srl-labs/vrnetlab.git
-#       cp <your>/vios_l2-adventerprisek9-m.vmdk.SPA.<ver>.qcow2 \
-#          vrnetlab/cisco/vios_l2/
-#       cd vrnetlab/cisco/vios_l2
-#       make                                   # builds vrnetlab/cisco_vios_l2:<ver>
-#       docker images | grep cisco_vios_l2
+#       # a `vios_l2` filename auto-selects the switch build
+#       cp <your>/vios_l2-adventerprisek9-m.SSA.high_iron_20200929.qcow2 \
+#          vrnetlab/cisco/vios/
+#       cd vrnetlab/cisco/vios
+#       make                                   # builds vrnetlab/cisco_vios:L2-20200929
+#       docker images | grep cisco_vios
 #
 #     You must supply the qcow2 yourself — it's a Cisco-licensed image
 #     (CCO / EA / VIRL subscription). Vendor-image licensing is
@@ -171,11 +172,26 @@ containerlab:
   topology:
     nodes:
       sw1:
-        kind: cisco_vios_l2
-        image: vrnetlab/cisco_vios_l2:15.2.2020T
+        # containerlab's kind for Cisco vIOS is `cisco_vios`; the IOSvL2
+        # switch personality is selected with `type: switch`. There is no
+        # `cisco_vios_l2` kind. The vrnetlab image lives under the
+        # `vrnetlab/cisco_vios` repo (L2 builds get an `L2-<date>` tag).
+        kind: cisco_vios
+        type: switch
+        image: vrnetlab/cisco_vios:L2-20200929
         startup-config: configs/sw1.cfg.j2
+      # A `kind: bridge` node references the *existing* shared Linux
+      # bridge that boxman creates from `shared_networks.clab_mgmt` (and
+      # that host01's second NIC also joins) — containerlab attaches to
+      # it, it does NOT create one. This is what puts sw1 and host01 on
+      # the same L2 segment. (`host:<name>` would instead create a new
+      # host interface named clab_mgmt and collide with the bridge.)
+      clab_mgmt:
+        kind: bridge
     links:
-      # IOSvL2's first data port is GigabitEthernet0/1. containerlab
-      # normalises this to a plain ethN name on the container side; the
-      # host endpoint is just the shared bridge.
-      - endpoints: ["sw1:Gi0/1", "host:clab_mgmt"]
+      # containerlab's cisco_vios kind names data ports with a flat index
+      # (eth1, eth2, … — NOT IOS slot notation like Gi0/1). eth1 is the
+      # first data port, which the switch exposes in its own CLI as
+      # GigabitEthernet0/1 (that's what configs/sw1.cfg.j2 configures).
+      # The bridge-side veth is named eth-sw1 on the shared bridge.
+      - endpoints: ["sw1:eth1", "clab_mgmt:eth-sw1"]

--- a/boxes/hybrid-libvirt-containerlab-nokia-srlinux/conf.yml
+++ b/boxes/hybrid-libvirt-containerlab-nokia-srlinux/conf.yml
@@ -152,7 +152,15 @@ containerlab:
         image: ghcr.io/nokia/srlinux:24.10.1
         type: ixrd3l                         # SR Linux platform variant
         startup-config: configs/sw1.cfg.j2
+      # A `kind: bridge` node references the *existing* shared Linux
+      # bridge that boxman creates from `shared_networks.clab_mgmt` (and
+      # that host01's second NIC also joins) — it attaches, it does not
+      # create one. (`host:<name>` would create a new host interface and
+      # collide with the bridge.)
+      clab_mgmt:
+        kind: bridge
     links:
       # SR Linux port naming is `ethernet-1/N`. Containerlab abbreviates
       # with `eN` on the topology side, but the full name works too.
-      - endpoints: ["sw1:e1-1", "host:clab_mgmt"]
+      # eth-sw1 is the bridge-side veth on the shared bridge.
+      - endpoints: ["sw1:e1-1", "clab_mgmt:eth-sw1"]

--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -2392,7 +2392,15 @@ class BoxmanManager:
         if netlab is None:
             return
         netlab.preflight()
-        source_root = os.path.dirname(self.config_path) if self.config_path else None
+        # Resolve startup-config templates relative to the *config file's*
+        # directory. abspath() is required: run the documented way
+        # (`cd boxes/<box> && boxman up`), config_path is the bare relative
+        # default "conf.yml", so os.path.dirname() would return "" — which
+        # render_topology treats as "unset" and falls back to the workspace
+        # dir, where configs/ does not exist (FileNotFoundError on sw1's
+        # startup-config).
+        source_root = (os.path.dirname(os.path.abspath(self.config_path))
+                       if self.config_path else None)
         netlab.render_topology(source_root=source_root)
         netlab.deploy()
 
@@ -2427,8 +2435,11 @@ class BoxmanManager:
             return
         netlab.preflight()
         # Render the topology so ensure_up has a .clab.yml to deploy from
-        # if the lab is missing entirely.
-        source_root = os.path.dirname(self.config_path) if self.config_path else None
+        # if the lab is missing entirely. abspath() so a bare relative
+        # --conf (the default "conf.yml") resolves to the box directory
+        # rather than "" — see deploy_netlab() for the full rationale.
+        source_root = (os.path.dirname(os.path.abspath(self.config_path))
+                       if self.config_path else None)
         netlab.render_topology(source_root=source_root)
         netlab.ensure_up()
 

--- a/tests/test_netlab_manager_integration.py
+++ b/tests/test_netlab_manager_integration.py
@@ -12,6 +12,7 @@ Covers:
 
 from __future__ import annotations
 
+import os
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -232,3 +233,57 @@ class TestNetlabCliHandlers:
         args.node = None
         BoxmanManager.netlab_ssh(mgr, args)
         mgr.logger.error.assert_called_once()
+
+
+class TestNetlabStartupConfigSourceRoot:
+    """Regression: startup-config templates must resolve relative to the
+    config file's *directory*, even when ``--conf`` is the bare relative
+    default ``conf.yml`` (the documented ``cd boxes/<box> && boxman up``
+    flow). Before the abspath() fix, ``os.path.dirname("conf.yml")`` was
+    ``""``, which ``render_topology`` treated as "unset" and fell back to
+    the workspace dir — so ``configs/<node>.cfg.j2`` was looked up in the
+    wrong place and raised ``FileNotFoundError``.
+    """
+
+    @staticmethod
+    def _capture_source_root(mgr):
+        captured = {}
+        fake = MagicMock()
+        fake.render_topology.side_effect = (
+            lambda source_root=None: captured.__setitem__("root", source_root)
+        )
+        mgr._netlab = fake
+        return captured
+
+    @staticmethod
+    def _assert_resolves_to_cwd(captured, tmp_path):
+        root = captured["root"]
+        assert root, "source_root must not be empty (the bug produced '')"
+        assert os.path.isabs(root), f"source_root must be absolute, got {root!r}"
+        assert os.path.realpath(root) == os.path.realpath(str(tmp_path))
+
+    def test_deploy_netlab_relative_conf_resolves_to_box_dir(
+            self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        mgr = _make_manager({
+            "workspace": {"path": str(tmp_path / "ws")},
+            "containerlab": {"lab_name": "netlab", "topology": {"nodes": {}}},
+        })
+        mgr.config_path = "conf.yml"  # bare relative default
+        captured = self._capture_source_root(mgr)
+
+        mgr.deploy_netlab()
+        self._assert_resolves_to_cwd(captured, tmp_path)
+
+    def test_ensure_netlab_up_relative_conf_resolves_to_box_dir(
+            self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        mgr = _make_manager({
+            "workspace": {"path": str(tmp_path / "ws")},
+            "containerlab": {"lab_name": "netlab", "topology": {"nodes": {}}},
+        })
+        mgr.config_path = "conf.yml"
+        captured = self._capture_source_root(mgr)
+
+        mgr.ensure_netlab_up()
+        self._assert_resolves_to_cwd(captured, tmp_path)


### PR DESCRIPTION
## What & why

The three `hybrid-libvirt-containerlab-*` boxes never deployed end-to-end. Boundary-testing the Cisco box in a nested-KVM staging VM surfaced **four** distinct blockers before the (license-gated) vendor image even matters. This PR fixes all four and adds a regression test.

## Fixes

| # | Scope | Fix |
|---|-------|-----|
| **A** — netlab path bug | boxman code — **all 3 boxes** | `deploy_netlab`/`ensure_netlab_up` resolved the startup-config against `os.path.dirname(self.config_path)`; the documented `cd boxes/<box> && boxman up` passes the relative default `conf.yml`, so that's `""` → `render_topology` falls back to the workspace dir → `FileNotFoundError`. Now uses `os.path.dirname(os.path.abspath(...))`. + regression tests. |
| **B** — Cisco kind/image | cisco box | `cisco_vios_l2` isn't a containerlab kind → `kind: cisco_vios` + `type: switch`, `image: vrnetlab/cisco_vios:L2-20200929`. |
| **C** — Cisco interface | cisco box | `sw1:Gi0/1` (IOS slot notation) invalid for `cisco_vios` → flat `sw1:eth1`. |
| **D** — shared-bridge attach | **all 3 boxes** | `host:clab_mgmt` *creates* a host interface and collides with the shared bridge. Declare `clab_mgmt` as a `kind: bridge` node and link `sw1:<port> ↔ clab_mgmt:eth-sw1`. |

A and D are feature-wide; B and C are Cisco-only (Arista/Nokia already used valid kinds + flat interface names).

## Verification

- `86` netlab unit tests pass; the 2 new regression tests fail on the pre-fix code (`source_root == ""`) and pass after.
- In a nested-KVM staging VM, `boxman netlab deploy` (documented relative-`conf.yml` flow) now renders the topology and clears **all** containerlab topology validation (kind, type, bridge node, link), stopping **only** at the image pull:
  `Failed to pull image docker.io/vrnetlab/cisco_vios:L2-20200929 ... repository does not exist` — i.e. the licensed image the user builds/supplies.
- The libvirt half (template reuse → host01 boot → DHCP → SSH) was independently confirmed working.

> Note: full end-to-end (switch actually boots, L2 forwarding works, `eth1`↔`Gi0/1` mapping) still requires a licensed Cisco IOSvL2 qcow2 and cannot be verified in CI.

## Testing on stage01 (nested-KVM staging VM)

Prereqs inside the VM: docker, libvirt/qemu-kvm (host-passthrough for nested KVM), and containerlab (`bash -c "$(curl -sL https://get.containerlab.dev)"`).

**1. Boundary test — no vendor image (proves A+B+C+D):**
```bash
cd boxes/hybrid-libvirt-containerlab-cisco-iosvl2
export BOXMAN_CISCO_ADMIN_PASS=admin BOXMAN_CISCO_ENABLE_PASS=admin
sudo ip link add clab_mgmt type bridge && sudo ip link set clab_mgmt up   # boxman up does this itself
boxman netlab deploy
# EXPECT: topology renders + validates; fails only at
#   "Failed to pull image .../cisco_vios:L2-20200929 ... repository does not exist"
```

**2. Full end-to-end — with a licensed image:**
```bash
# build the vendor image once (needs your Cisco IOSvL2 qcow2)
git clone https://github.com/srl-labs/vrnetlab.git
cp vios_l2-...-20200929.qcow2 vrnetlab/cisco/vios/     # vios_l2 filename => switch build
( cd vrnetlab/cisco/vios && make )                      # => vrnetlab/cisco_vios:L2-20200929
docker images | grep cisco_vios

cd boxes/hybrid-libvirt-containerlab-cisco-iosvl2
boxman up                       # builds Ubuntu template + host01, bridge, deploys sw1
boxman netlab inspect
$(boxman netlab ssh sw1)        # drop into IOS: sw1#
boxman ssh host01               # host01's 2nd NIC should get a DHCP lease from sw1 (192.0.2.0/24)
boxman destroy
sudo ip link delete clab_mgmt   # shared bridges are not auto-removed
```

**Free alternative (no Cisco license):** the sibling `hybrid-libvirt-containerlab-arista-ceos` box exercises the same A+D fixes with a downloadable cEOS image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
