### PR TITLE
feat(verbosity): minimal output by default with opt-in -v/-vv/-vvv

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,24 @@ transparently — no flag needed at revert time. See
 [Disk Reclaim and Storage](doc/storage.md) for the full reclaim
 workflow and the `boxman storage` subcommand.
 
+### Output verbosity
+
+By default boxman prints terse, docker-compose-style progress lines (the
+important milestones only). Add `-v`/`-vv`/`-vvv` — either before or after the
+sub-command — to reveal more detail, or `-q`/`--quiet` for warnings and errors
+only:
+
+```bash
+boxman up            # terse (default)
+boxman -v up         # + info-level detail
+boxman up -vv        # + full [time LEVEL file:func] debug lines
+boxman up -vvv       # also echo the underlying shell commands
+boxman up -q         # warnings and errors only
+```
+
+The default level can also be set with the `BOXMAN_VERBOSITY` environment
+variable (e.g. `BOXMAN_VERBOSITY=2`); any explicit `-v`/`-q` flag overrides it.
+
 ### SSH into VMs
 
 ```bash

--- a/doc/tutorial/README.md
+++ b/doc/tutorial/README.md
@@ -186,6 +186,10 @@ cd doc/tutorial/tutorial1
 boxman provision
 ```
 
+> Boxman prints terse, docker-compose-style progress by default; add
+> `-v`/`-vv`/`-vvv` (before or after the sub-command) for more detail, `-q`
+> for warnings and errors only, or set `BOXMAN_VERBOSITY`.
+
 Behind the scenes, boxman:
 
 1. Renders Jinja2 templates in the YAML

--- a/src/boxman/loggers/logger.py
+++ b/src/boxman/loggers/logger.py
@@ -1,11 +1,21 @@
 import logging
 import sys
+from contextlib import contextmanager
 
 BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
 
 RESET_SEQ = "\033[0m"
 COLOR_SEQ = "\033[%dm"
 BOLD_SEQ = "\033[1m"
+
+# Custom "STATUS" level sits between INFO (20) and WARNING (30). It is the
+# default-visible level: concise, docker-compose-style progress lines. Regular
+# info() chatter is hidden until the user asks for it with -v.
+STATUS = 25
+logging.addLevelName(STATUS, "STATUS")
+
+# Single source of truth for the default verbosity.
+DEFAULT_LEVEL = STATUS
 
 
 def formatter_message(message, use_color=True):
@@ -15,62 +25,119 @@ def formatter_message(message, use_color=True):
         message = message.replace("$RESET", "").replace("$BOLD", "")
     return message
 
+
 COLORS = {
     'WARNING': YELLOW,
     'INFO': GREEN,
     'DEBUG': BLUE,
     'CRITICAL': MAGENTA,
-    'ERROR': RED
+    'ERROR': RED,
+    'STATUS': CYAN,
 }
+
+# Rich, diagnostic format — only used at DEBUG (-vv and above).
+RICH_FORMAT = (
+    "[%(asctime)s %(levelname)s "
+    "$BOLD%(filename)s{%(lineno)d}$RESET:%(funcName)s()] "
+    "%(message)s"
+)
 
 
 class ColoredFormatter(logging.Formatter):
-    def __init__(self, msg, use_color=True):
-        logging.Formatter.__init__(self, msg)
-        self.use_color = use_color
+    """Level-aware, colorized formatter.
 
-    def format(self, record):
-        levelname = record.levelname
+    - DEBUG: full ``[time LEVEL file{line}:func()] message`` diagnostic line.
+    - WARNING/ERROR/CRITICAL: ``LEVEL: message`` with a colorized level tag.
+    - STATUS/INFO: just ``message`` (docker-compose-style).
+    """
+
+    def __init__(self, use_color=True):
+        logging.Formatter.__init__(self)
+        self.use_color = use_color
+        self._rich = formatter_message(RICH_FORMAT, use_color)
+
+    def _colorize(self, levelname):
         if self.use_color and levelname in COLORS:
             color_code = 30 + COLORS[levelname]
-            levelname_color = (
-                COLOR_SEQ % color_code + BOLD_SEQ + levelname + RESET_SEQ
-            )
-            # Pad to a fixed visible width (8 chars) before adding ANSI codes
-            # so columns align. ANSI escapes add ~12 invisible chars.
-            pad = 8 - len(levelname)
-            record.levelname = levelname_color + " " * pad
+            return COLOR_SEQ % color_code + BOLD_SEQ + levelname + RESET_SEQ
+        return levelname
+
+    def format(self, record):
+        if record.levelno <= logging.DEBUG:
+            self._style._fmt = self._rich
+            pad = max(0, 8 - len(record.levelname))
+            record.levelname = self._colorize(record.levelname) + " " * pad
+        elif record.levelno >= logging.WARNING:
+            self._style._fmt = "%(levelname)s: %(message)s"
+            record.levelname = self._colorize(record.levelname)
+        else:  # STATUS, INFO
+            self._style._fmt = "%(message)s"
         return logging.Formatter.format(self, record)
 
 
 # create logger
 logger = logging.getLogger('boxman')
-logger.log_depth = 0
-logger.setLevel(logging.DEBUG)
+logger.setLevel(DEFAULT_LEVEL)
 
 # Only configure the logger if it doesn't have handlers already
 if not logger.handlers:
-
-    # remove all existing handlers first to ensure we don't add duplicates
     for handler in logger.handlers[:]:
         logger.removeHandler(handler)
 
-    # create console handler and set level to debug
+    # handler stays wide open; the *logger* level is the effective gate
     ch = logging.StreamHandler(sys.stdout)
     ch.setLevel(logging.DEBUG)
 
-    # create formatter
-    FORMAT = (
-        "[%(asctime)s %(levelname)s "
-        "$BOLD%(filename)s{%(lineno)d}$RESET:%(funcName)s()] "
-        "%(message)s"
-    )
-    COLOR_FORMAT = formatter_message(FORMAT, True)
-    formatter = ColoredFormatter(COLOR_FORMAT)
-
-    # add formatter to the console handler and then add the console handler to the logger
+    formatter = ColoredFormatter(use_color=True)
     ch.setFormatter(formatter)
     logger.addHandler(ch)
 
-    # Prevent propagation to prevent duplicate logs if this is a child logger
+    # Prevent propagation to avoid duplicate logs if this is a child logger
     logger.propagate = False
+
+
+def status(self, message, *args, **kws):
+    """``logger.status(...)`` — emit at the default-visible STATUS level."""
+    if self.isEnabledFor(STATUS):
+        self._log(STATUS, message, args, **kws)
+
+
+logging.Logger.status = status
+
+
+def set_verbosity(count):
+    """Map a -v count to a level and apply it. 0->STATUS, 1->INFO, >=2->DEBUG."""
+    if count <= 0:
+        level = DEFAULT_LEVEL
+    elif count == 1:
+        level = logging.INFO
+    else:
+        level = logging.DEBUG
+    logger.setLevel(level)
+    return level
+
+
+def set_quiet():
+    """Silence everything below WARNING (used by -q/--quiet)."""
+    logger.setLevel(logging.WARNING)
+    return logging.WARNING
+
+
+def is_verbose(level=logging.DEBUG):
+    """True if the boxman logger currently emits at ``level`` (default DEBUG)."""
+    return logger.isEnabledFor(level)
+
+
+@contextmanager
+def suppressed(level=logging.CRITICAL + 1):
+    """Temporarily raise the boxman logger level, restoring the prior level after.
+
+    Replaces the old pattern of hardcoding a restore to logging.DEBUG, which
+    clobbered any user-selected verbosity.
+    """
+    prev = logger.level
+    logger.setLevel(level)
+    try:
+        yield
+    finally:
+        logger.setLevel(prev)

--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -1,3 +1,4 @@
+import contextlib
 import hashlib
 import json
 import logging
@@ -15,6 +16,7 @@ import yaml
 from boxman.utils.shell import run
 
 from boxman import log
+from boxman.loggers.logger import suppressed
 from boxman.config_cache import BoxmanCache
 from boxman.image_cache import ImageCache
 from boxman.netlab import ContainerlabManager, shared_bridges
@@ -2048,7 +2050,7 @@ class BoxmanManager:
                     info=network_info,
                     workdir=cluster['workdir']
                 )
-                self.logger.info(f"defined network {_network_name} in {cluster['workdir']}")
+                self.logger.status(f"defined network {_network_name} in {cluster['workdir']}")
 
     def destroy_networks(self) -> None:
         """
@@ -2135,31 +2137,30 @@ class BoxmanManager:
 
         def _clone(cluster, vm_info, new_vm_name):
             max_retries = 5
-            boxman_logger = logging.getLogger('boxman')
             for attempt in range(1, max_retries + 1):
                 last_attempt = attempt == max_retries
+                # Suppress error-level logs on all retryable attempts so that
+                # transient pool-busy failures don't appear as errors; only the
+                # final attempt logs errors normally. suppressed() restores the
+                # prior level (not a hardcoded DEBUG) so -v/-vv survives retries.
+                _cm = (contextlib.nullcontext() if last_attempt
+                       else suppressed(logging.CRITICAL))
                 try:
-                    # Suppress error-level logs on all retryable attempts so
-                    # that transient pool-busy failures don't appear as errors.
-                    # Only the final attempt logs errors normally.
-                    if not last_attempt:
-                        boxman_logger.setLevel(logging.CRITICAL)
-                    src_vm_name = vm_info.get('base_image') or cluster.get('base_image')
-                    if not src_vm_name and not self._is_diskless_boot(vm_info):
-                        raise ValueError(
-                            f"no base_image for VM '{new_vm_name}': "
-                            f"set base_image at the cluster or VM level"
+                    with _cm:
+                        src_vm_name = vm_info.get('base_image') or cluster.get('base_image')
+                        if not src_vm_name and not self._is_diskless_boot(vm_info):
+                            raise ValueError(
+                                f"no base_image for VM '{new_vm_name}': "
+                                f"set base_image at the cluster or VM level"
+                            )
+                        self.provider.clone_vm(
+                            src_vm_name=src_vm_name,
+                            new_vm_name=new_vm_name,
+                            info=vm_info,
+                            workdir=cluster['workdir']
                         )
-                    self.provider.clone_vm(
-                        src_vm_name=src_vm_name,
-                        new_vm_name=new_vm_name,
-                        info=vm_info,
-                        workdir=cluster['workdir']
-                    )
-                    boxman_logger.setLevel(logging.DEBUG)
                     return
                 except Exception:
-                    boxman_logger.setLevel(logging.DEBUG)
                     if not last_attempt:
                         delay = attempt * 2
                         self.logger.warning(
@@ -2512,29 +2513,28 @@ class BoxmanManager:
         This method displays the VM names, hostnames, IP addresses, and
         other connection details for all configured VMs.
         """
-        self.logger.info("=== vm connection information ===")
+        self.logger.status("=== vm connection information ===")
         ws_path = self.config.get('workspace', {}).get('path', '')
 
         prj_name = f'bprj__{self.config["project"]}__bprj'
         for cluster_name, cluster in self.config['clusters'].items():
-            self.logger.info(f"cluster: {cluster_name}")
-            self.logger.info("-" * 60)
+            self.logger.status(f"cluster: {cluster_name}")
 
             for vm_name, vm_info in cluster['vms'].items():
                 full_vm_name = f"{prj_name}_{cluster_name}_{vm_name}"
                 hostname = vm_info.get('hostname', vm_name)
 
-                self.logger.info(f"vm: {vm_name} (hostname: {hostname})")
+                self.logger.status(f"vm: {vm_name} (hostname: {hostname})")
 
                 # get the ip addresses for all interfaces
                 ip_addresses = self.provider.get_vm_ip_addresses(full_vm_name)
 
                 if ip_addresses:
-                    self.logger.info("  ip addresses:")
+                    self.logger.status("  ip addresses:")
                     for iface, ip in ip_addresses.items():
-                        self.logger.info(f"    {iface}: {ip}")
+                        self.logger.status(f"    {iface}: {ip}")
                 else:
-                    self.logger.info("  ip addresses: not available")
+                    self.logger.status("  ip addresses: not available")
 
                 # get ssh connection information
                 admin_user = cluster.get('admin_user', '<placeholder>')
@@ -2544,11 +2544,11 @@ class BoxmanManager:
                     cluster.get('admin_key_name', 'id_ed25519_boxman')
                 ))
 
-                self.logger.info("  connect via ssh:")
+                self.logger.status("  connect via ssh:")
                 # show direct connection if ip is available
                 if ip_addresses:
                     first_ip = next(iter(ip_addresses.values()))
-                    self.logger.info(f"    direct: ssh -i {admin_key} {admin_user}@{first_ip}")
+                    self.logger.status(f"    direct: ssh -i {admin_key} {admin_user}@{first_ip}")
 
                 # show connection using ssh_config if available
                 if 'ssh_config' in cluster:
@@ -2556,11 +2556,11 @@ class BoxmanManager:
                         base_path,
                         cluster.get('ssh_config', 'ssh_config')
                     ))
-                    self.logger.info(f"    via config: ssh -F {ssh_config} {cluster_name}_{hostname}")
+                    self.logger.status(f"    via config: ssh -F {ssh_config} {cluster_name}_{hostname}")
 
-                self.logger.info("")
+                self.logger.status("")
 
-            self.logger.info("")
+            self.logger.status("")
 
     #: Alias of the ProxyJump stanza written into ``ssh_config`` when the
     #: docker runtime is active. Kept as a class constant so tests and
@@ -4897,28 +4897,30 @@ class BoxmanManager:
         # clone new VMs (parallel with retry)
         def _clone(cluster, vm_info, new_vm_name):
             max_retries = 5
-            boxman_logger = logging.getLogger('boxman')
             for attempt in range(1, max_retries + 1):
                 last_attempt = attempt == max_retries
+                # Suppress error-level logs on all retryable attempts so that
+                # transient pool-busy failures don't appear as errors; only the
+                # final attempt logs errors normally. suppressed() restores the
+                # prior level (not a hardcoded DEBUG) so -v/-vv survives retries.
+                _cm = (contextlib.nullcontext() if last_attempt
+                       else suppressed(logging.CRITICAL))
                 try:
-                    if not last_attempt:
-                        boxman_logger.setLevel(logging.CRITICAL)
-                    src_vm_name = vm_info.get('base_image') or cluster.get('base_image')
-                    if not src_vm_name and not self._is_diskless_boot(vm_info):
-                        raise ValueError(
-                            f"no base_image for VM '{new_vm_name}': "
-                            f"set base_image at the cluster or VM level"
+                    with _cm:
+                        src_vm_name = vm_info.get('base_image') or cluster.get('base_image')
+                        if not src_vm_name and not self._is_diskless_boot(vm_info):
+                            raise ValueError(
+                                f"no base_image for VM '{new_vm_name}': "
+                                f"set base_image at the cluster or VM level"
+                            )
+                        self.provider.clone_vm(
+                            src_vm_name=src_vm_name,
+                            new_vm_name=new_vm_name,
+                            info=vm_info,
+                            workdir=cluster['workdir']
                         )
-                    self.provider.clone_vm(
-                        src_vm_name=src_vm_name,
-                        new_vm_name=new_vm_name,
-                        info=vm_info,
-                        workdir=cluster['workdir']
-                    )
-                    boxman_logger.setLevel(logging.DEBUG)
                     return
                 except Exception:
-                    boxman_logger.setLevel(logging.DEBUG)
                     if not last_attempt:
                         delay = attempt * 2
                         self.logger.warning(

--- a/src/boxman/providers/libvirt/clone_vm.py
+++ b/src/boxman/providers/libvirt/clone_vm.py
@@ -63,7 +63,7 @@ class CloneVM:
                 'auto_clone': True
             }
 
-            self.logger.info(f"cloning the vm {self.src_vm_name} to {self.new_vm_name}")
+            self.logger.status(f"cloning the vm {self.src_vm_name} to {self.new_vm_name}")
             self.virt_clone.execute(*cmd_args, **cmd_kwargs)
 
             # after cloning, remove all inherited network interfaces if the machine has network

--- a/src/boxman/providers/libvirt/cloudinit.py
+++ b/src/boxman/providers/libvirt/cloudinit.py
@@ -16,6 +16,7 @@ compatibility.
 import base64
 import hashlib
 import json
+import logging
 import os
 import re
 import shutil
@@ -28,6 +29,7 @@ from typing import Any
 import invoke
 
 from boxman import log
+from boxman.loggers.logger import is_verbose
 from boxman.image_cache import ImageCache
 from boxman.utils.shell import run as _shell_run
 
@@ -133,7 +135,7 @@ class CloudInitTemplate:
 
         result = self.virsh.execute_shell(
             f'cloud-localds{network_flag} "{seed_iso_path}" "{nocloud_dir}/user-data" "{nocloud_dir}/meta-data"',
-            hide=False, warn=True,
+            hide=not is_verbose(logging.DEBUG), warn=True,
         )
         if result.ok:
             self.logger.info("seed ISO created with cloud-localds")
@@ -148,7 +150,7 @@ class CloudInitTemplate:
             result = self.virsh.execute_shell(
                 f'{tool} -output "{seed_iso_path}" -volid cidata -joliet -rock '
                 f'"{nocloud_dir}/user-data" "{nocloud_dir}/meta-data"{extra_files}',
-                hide=False, warn=True,
+                hide=not is_verbose(logging.DEBUG), warn=True,
             )
             if result.ok:
                 self.logger.info(f"seed ISO created with {tool}")
@@ -410,7 +412,7 @@ class CloudInitTemplate:
         self.logger.info(f"copying image {src} -> {dst}")
         result = self.virsh.execute_shell(
             f'rsync --sparse --progress "{src}" "{dst}"',
-            hide=False, warn=True,
+            hide=not is_verbose(logging.DEBUG), warn=True,
         )
         if result.ok:
             self.logger.info("image copied (sparse via rsync)")
@@ -439,7 +441,7 @@ class CloudInitTemplate:
         self.logger.info(f"resizing disk image {image_path} to {size}")
         result = self.virsh.execute_shell(
             f'qemu-img resize "{image_path}" {size}',
-            hide=False, warn=True,
+            hide=not is_verbose(logging.DEBUG), warn=True,
         )
         if result.ok:
             self.logger.info(f"disk image resized to {size}")
@@ -450,12 +452,12 @@ class CloudInitTemplate:
 
     def _download_image(self, url: str, dst_path: str) -> bool:
         """Download a cloud image from a URL with progress and fallbacks."""
-        self.logger.info(f"downloading base image {url} -> {dst_path}")
+        self.logger.status(f"downloading base image {url} -> {dst_path}")
 
         # Try wget first (handles redirects, proxies, SSL better)
         result = _shell_run(
             f'wget --progress=dot:mega -O "{dst_path}" "{url}"',
-            hide=False, warn=True,
+            hide=not is_verbose(logging.DEBUG), warn=True,
         )
         if result.ok and os.path.isfile(dst_path) and os.path.getsize(dst_path) > 0:
             self.logger.info("download complete (wget)")
@@ -464,7 +466,7 @@ class CloudInitTemplate:
         # Try curl as second fallback
         result = _shell_run(
             f'curl -L --progress-bar -o "{dst_path}" "{url}"',
-            hide=False, warn=True,
+            hide=not is_verbose(logging.DEBUG), warn=True,
         )
         if result.ok and os.path.isfile(dst_path) and os.path.getsize(dst_path) > 0:
             self.logger.info("download complete (curl)")
@@ -653,10 +655,9 @@ class CloudInitTemplate:
             return
         output = self._guest_exec_output(res.stdout)
         if output:
-            self.logger.info("=== Cloud-Init Output Log ===")
+            self.logger.debug("cloud-init output log:")
             for line in output.splitlines():
-                self.logger.info(f"  {line}")
-            self.logger.info("=============================")
+                self.logger.debug(f"  {line}")
 
     def verify_and_shutdown(self) -> bool:
         self.logger.info("verifying VM health: waiting for QEMU guest agent (this may take a few minutes while cloud-init installs it)...")
@@ -672,7 +673,7 @@ class CloudInitTemplate:
                 break
 
             if i > 0 and i % 15 == 0:
-                self.logger.info(f"still waiting for QEMU guest agent... ({i * 2}s elapsed)")
+                self.logger.debug(f"still waiting for QEMU guest agent... ({i * 2}s elapsed)")
 
             time.sleep(2)
 
@@ -802,9 +803,7 @@ class CloudInitTemplate:
             return False
 
     def create_template(self, force: bool = False) -> bool:
-        self.logger.info("=" * 70)
-        self.logger.info(f"creating cloud-init template: {self.template_name}")
-        self.logger.info("=" * 70)
+        self.logger.status(f"creating cloud-init template: {self.template_name}")
 
         if self._check_vm_exists():
             if not force:
@@ -925,10 +924,8 @@ class CloudInitTemplate:
                             "--eject", "--config",
                             warn=True)
 
-        self.logger.info("=" * 70)
-        self.logger.info(f"template VM '{self.template_name}' created successfully")
+        self.logger.status(f"template VM '{self.template_name}' created successfully")
         self.logger.info(f"  disk image: {dst_image_path}")
-        self.logger.info("=" * 70)
         return True
 
     @staticmethod

--- a/src/boxman/providers/libvirt/import_image.py
+++ b/src/boxman/providers/libvirt/import_image.py
@@ -377,9 +377,7 @@ class ImageImporter:
         Returns:
             True if successful, False otherwise
         """
-        self._log_info("=" * 70)
         self._log_info("vm image import utility")
-        self._log_info("=" * 70)
 
         # read the manifest
         # .. todo:: this is redundant with what is done in the session and the manager and the app
@@ -479,10 +477,8 @@ class ImageImporter:
             self._log_error("Failed to define VM")
             return False
 
-        self._log_info("=" * 70)
         self._log_info(f"Successfully imported VM '{vm_name}'")
         self._log_info(f"  Disk image: {dst_image_path}")
         self._log_info(f"  Connection URI: {self.uri}")
-        self._log_info("=" * 70)
 
         return True

--- a/src/boxman/providers/libvirt/session.py
+++ b/src/boxman/providers/libvirt/session.py
@@ -491,7 +491,7 @@ class LibVirtSession:
             verify_result = virsh.execute("domstate", vm_name)
 
             if "running" in verify_result.stdout:
-                self.logger.info(f"vm {vm_name} started successfully")
+                self.logger.status(f"vm {vm_name} started successfully")
                 return True
             else:
                 self.logger.error(

--- a/src/boxman/providers/libvirt/storage.py
+++ b/src/boxman/providers/libvirt/storage.py
@@ -18,12 +18,14 @@ CLI subcommands (``df``, ``trim``, ``compact``, ``optimize``).
 from __future__ import annotations
 
 import json
+import logging
 import os
 import time
 from typing import Any
 from xml.etree import ElementTree as ET
 
 from boxman import log
+from boxman.loggers.logger import is_verbose
 
 from .commands import LibVirtCommandBase, VirshCommand
 
@@ -202,7 +204,7 @@ class StorageManager:
     def sparsify_in_place(self, disk_path: str) -> bool:
         cmd = f"virt-sparsify --in-place {disk_path}"
         self.logger.info(f"sparsifying {disk_path}")
-        result = self.cmd.execute_shell(cmd, warn=True, hide=False)
+        result = self.cmd.execute_shell(cmd, warn=True, hide=not is_verbose(logging.DEBUG))
         if not result.ok:
             self.logger.error(
                 f"virt-sparsify failed for {disk_path}: {result.stderr.strip()}")
@@ -216,7 +218,7 @@ class StorageManager:
         cmd = (f"qemu-img convert {compress_flag}-O qcow2 {disk_path} {tmp_path} "
                f"&& mv {tmp_path} {disk_path}")
         self.logger.info(f"converting {disk_path} (compress={compress})")
-        result = self.cmd.execute_shell(cmd, warn=True, hide=False)
+        result = self.cmd.execute_shell(cmd, warn=True, hide=not is_verbose(logging.DEBUG))
         if not result.ok:
             self.logger.error(
                 f"qemu-img convert failed for {disk_path}: {result.stderr.strip()}")

--- a/src/boxman/providers/libvirt/template_manager.py
+++ b/src/boxman/providers/libvirt/template_manager.py
@@ -12,11 +12,13 @@ The rest of ``create_template`` needs a follow-up pass before this
 module is put into service.
 """
 
+import logging
 import os
 import shutil
 from typing import Any
 
 from boxman import log
+from boxman.loggers.logger import is_verbose
 from boxman.utils.shell import run
 from boxman.providers.libvirt.cloudinit import CloudInitTemplate
 from boxman.providers.libvirt.commands import VirshCommand, VirtInstallCommand
@@ -84,7 +86,7 @@ class TemplateManager:
             # use sparse-aware copy
             result = run(
                 f"rsync --sparse --progress '{src_path}' '{dest_path}'",
-                hide=False, warn=True
+                hide=not is_verbose(logging.DEBUG), warn=True
             )
             if not result.ok:
                 # fallback to regular copy
@@ -126,9 +128,7 @@ class TemplateManager:
         """
         vm_name = template_config.get("name", template_name)
 
-        self.logger.info("=" * 70)
-        self.logger.info(f"creating template: {vm_name}")
-        self.logger.info("=" * 70)
+        self.logger.status(f"creating template: {vm_name}")
 
         # check if template already exists
         if self.template_exists(vm_name):
@@ -167,7 +167,7 @@ class TemplateManager:
             self.logger.info(f"resizing disk image to {disk_size}")
             result = run(
                 f"qemu-img resize '{disk_path}' {disk_size}",
-                hide=False, warn=True
+                hide=not is_verbose(logging.DEBUG), warn=True
             )
             if not result.ok:
                 self.logger.error(f"failed to resize disk image: {result.stderr}")
@@ -246,7 +246,7 @@ class TemplateManager:
             cmd = f"docker exec --user root {container} bash -c '{escaped}'"
 
         self.logger.info(f"executing: {cmd}")
-        result = run(cmd, hide=False, warn=True)
+        result = run(cmd, hide=not is_verbose(logging.DEBUG), warn=True)
 
         if not result.ok:
             self.logger.error(f"virt-install failed: {result.stderr}")
@@ -261,9 +261,7 @@ class TemplateManager:
         # clean up the seed ISO nocloud directory
         ci.cleanup()
 
-        self.logger.info("=" * 70)
-        self.logger.info(f"template '{vm_name}' is ready")
-        self.logger.info("=" * 70)
+        self.logger.status(f"template '{vm_name}' is ready")
 
         return True
 

--- a/src/boxman/runtime/docker_compose.py
+++ b/src/boxman/runtime/docker_compose.py
@@ -246,9 +246,9 @@ class DockerComposeRuntime(RuntimeBase):
                 "BOXMAN_PROJECT_DIR": abs_project_dir,
             }
 
-            self.logger.info("docker compose environment variables:")
+            self.logger.debug("docker compose environment variables:")
             for k, v in env_vars.items():
-                self.logger.info(f"  {k}={v}")
+                self.logger.debug(f"  {k}={v}")
 
             compose_env = os.environ.copy()
             compose_env.update(env_vars)
@@ -326,8 +326,7 @@ class DockerComposeRuntime(RuntimeBase):
             with open(compose_path) as fobj:
                 contents = fobj.read()
             self.logger.info(
-                f"docker-compose.yml ({compose_path}):\n"
-                f"{'─' * 60}\n{contents}{'─' * 60}")
+                f"docker-compose.yml ({compose_path}):\n{contents}")
         except Exception as exc:
             self.logger.warning(f"could not read compose file for logging: {exc}")
 

--- a/src/boxman/scripts/app.py
+++ b/src/boxman/scripts/app.py
@@ -17,7 +17,8 @@ from boxman.abstract.providers import ProviderSession as Session
 from boxman.manager import BoxmanManager
 from boxman.providers.libvirt.import_image import ImageImporter
 from boxman.providers.libvirt.session import LibVirtSession
-from boxman.scripts.cli_parser import parse_args
+from boxman.loggers.logger import set_quiet, set_verbosity, suppressed
+from boxman.scripts.cli_parser import parse_args, resolve_verbosity
 from boxman.utils.jinja_env import create_jinja_env
 from boxman.virtualbox.vboxmanage import Virtualbox
 
@@ -306,6 +307,16 @@ def main():
 
     args.remaining_args = remaining
 
+    # Verbosity: minimal (STATUS) by default; -v/-vv/-vvv (either position)
+    # reveal more, -q/--quiet shows warnings+errors only. This overrides the
+    # import-time default in loggers/logger.py.
+    _verbosity = 0
+    if getattr(args, 'quiet', 0):
+        set_quiet()
+    else:
+        _verbosity = resolve_verbosity(args)
+        set_verbosity(_verbosity)
+
     if args.version:
         print(f'v{boxman.metadata.version}')
         sys.exit(0)
@@ -331,19 +342,15 @@ def main():
 
     # Handle 'ps' — needs config and virsh but not a full provider session
     if args.func == BoxmanManager.ps:
-        _boxman_logger = logging.getLogger('boxman')
+        import contextlib
         _ps_json = getattr(args, 'json', False)
-        if _ps_json:
-            _boxman_logger.setLevel(logging.CRITICAL + 1)
-        try:
+        _cm = suppressed() if _ps_json else contextlib.nullcontext()
+        with _cm:
             manager = BoxmanManager(config=args.conf)
             if not manager.config:
-                _boxman_logger.setLevel(logging.DEBUG)
                 log.error("no project config found (conf.yml)")
                 sys.exit(1)
             args.func(manager, args)
-        finally:
-            _boxman_logger.setLevel(logging.DEBUG)
         sys.exit(0)
 
     # 'snapshot log' is a viewer command — suppress INFO logging across the
@@ -411,6 +418,13 @@ def main():
 
         # load the boxman app configuration
         boxman_config = load_boxman_config(os.path.expanduser(args.boxman_conf))
+
+        # -vvv: echo the underlying shell commands (provider 'verbose' flag).
+        if _verbosity >= 3:
+            _providers = boxman_config.setdefault('providers', {})
+            for _pname, _pcfg in list(_providers.items()):
+                if isinstance(_pcfg, dict):
+                    _pcfg['verbose'] = True
 
         # make the app-level (boxman.yml) available to the manager
         manager.load_app_config(boxman_config)

--- a/src/boxman/scripts/cli_parser.py
+++ b/src/boxman/scripts/cli_parser.py
@@ -122,12 +122,41 @@ def parse_args():
         help='display the version and exit'
     )
 
+    parser.add_argument(
+        '-v', '--verbose',
+        action='count',
+        default=0,
+        dest='verbose_global',
+        help='increase output verbosity (repeatable: -v, -vv, -vvv). '
+             'may also be given after the sub-command.'
+    )
+
+    # Shared options attached (via parents=[common]) to every sub-command so
+    # that both `boxman -vv up` and `boxman up -vv` work. The distinct dest
+    # `verbose` (vs the top-level `verbose_global`) keeps the two positions
+    # from clobbering each other; resolve_verbosity() reconciles them.
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        '-v', '--verbose',
+        action='count',
+        default=0,
+        dest='verbose',
+        help='increase output verbosity (repeatable: -v, -vv, -vvv)'
+    )
+    common.add_argument(
+        '-q', '--quiet',
+        action='count',
+        default=0,
+        dest='quiet',
+        help='minimal output: warnings and errors only'
+    )
+
     subparsers = parser.add_subparsers(help="sub-commands for boxman")
 
     #
     # sub parser for importing images
     #
-    parser_import_image = subparsers.add_parser('import-image', help='import an image')
+    parser_import_image = subparsers.add_parser('import-image', parents=[common], help='import an image')
     parser_import_image.set_defaults(func=BoxmanManager.import_image)
 
     parser_import_image.add_argument(
@@ -167,7 +196,7 @@ def parse_args():
     # sub parser for the 'image' subcommand (OCI registry image operations)
     #
     parser_image = subparsers.add_parser(
-        'image',
+        'image', parents=[common],
         help='OCI registry image operations (push, ...)')
     subparsers_image = parser_image.add_subparsers(help='sub-commands for boxman image')
 
@@ -175,7 +204,7 @@ def parse_args():
     # sub parser for the 'image push' subsubcommand
     #
     parser_image_push = subparsers_image.add_parser(
-        'push',
+        'push', parents=[common],
         help='push a qcow2 image (and optional metadata) to an OCI registry')
     parser_image_push.set_defaults(func=BoxmanManager.push_image)
     parser_image_push.add_argument(
@@ -202,7 +231,7 @@ def parse_args():
     # sub parser for the 'image inspect' subsubcommand
     #
     parser_image_inspect = subparsers_image.add_parser(
-        'inspect',
+        'inspect', parents=[common],
         help='inspect an OCI image reference (manifest + vmimage.json metadata)')
     parser_image_inspect.set_defaults(func=BoxmanManager.inspect_image)
     parser_image_inspect.add_argument(
@@ -215,7 +244,7 @@ def parse_args():
     # sub parser for creating templates from cloud images
     #
     parser_create_templates = subparsers.add_parser(
-        'create-templates',
+        'create-templates', parents=[common],
         help='create template VMs from cloud images using cloud-init')
     parser_create_templates.set_defaults(func=BoxmanManager.create_templates)
     parser_create_templates.add_argument(
@@ -236,7 +265,7 @@ def parse_args():
     #
     # sub parser for listing the registered projects
     #
-    parser_list = subparsers.add_parser('list', help='list all registered projects')
+    parser_list = subparsers.add_parser('list', parents=[common], help='list all registered projects')
     parser_list.set_defaults(func=BoxmanManager.list_projects)
 
     list_format_group = parser_list.add_mutually_exclusive_group()
@@ -270,7 +299,7 @@ def parse_args():
     #
     # sub parser for provisioning a configuration
     #
-    parser_prov = subparsers.add_parser('provision', help='provision a configuration')
+    parser_prov = subparsers.add_parser('provision', parents=[common], help='provision a configuration')
     parser_prov.set_defaults(func=BoxmanManager.provision)
     parser_prov.add_argument(
         '--docker-compose',
@@ -298,7 +327,7 @@ def parse_args():
     # sub parser for the 'up' subcommand
     #
     parser_up = subparsers.add_parser(
-        'up',
+        'up', parents=[common],
         help='bring up the infrastructure: provision if not created, start if powered off')
     parser_up.set_defaults(func=BoxmanManager.up)
     parser_up.add_argument(
@@ -327,7 +356,7 @@ def parse_args():
     # sub parser for the 'update' subcommand
     #
     parser_update = subparsers.add_parser(
-        'update',
+        'update', parents=[common],
         help='apply config changes to already-provisioned VMs (CPU, memory, disks, add/remove VMs)')
     parser_update.set_defaults(func=BoxmanManager.update)
     parser_update.add_argument(
@@ -356,7 +385,7 @@ def parse_args():
     # sub parser for the 'down' subcommand
     #
     parser_down = subparsers.add_parser(
-        'down',
+        'down', parents=[common],
         help='bring down the infrastructure: save or suspend the state of all VMs')
     parser_down.set_defaults(func=BoxmanManager.down)
     parser_down.add_argument(
@@ -371,7 +400,7 @@ def parse_args():
     # sub parser for destroying the runtime environment
     #
     parser_destroy_rt = subparsers.add_parser(
-        'destroy-runtime',
+        'destroy-runtime', parents=[common],
         help='destroy the docker-compose runtime environment and clean up .boxman')
     parser_destroy_rt.add_argument(
         '--auto-accept', '-y', action='store_true', default=False,
@@ -382,7 +411,7 @@ def parse_args():
     # sub parser for the full-teardown 'destroy' command
     #
     parser_destroy = subparsers.add_parser(
-        'destroy',
+        'destroy', parents=[common],
         help=('nuke everything provisioned by this config: VMs, networks, '
               'generated files, the docker runtime (if used) and the '
               'workspace workdir. Prompts [y/N] unless -y is given.'))
@@ -399,7 +428,7 @@ def parse_args():
     #
     # sub parser for deprovisioning a configuration
     #
-    parser_deprov = subparsers.add_parser('deprovision', help='deprovision a configuration')
+    parser_deprov = subparsers.add_parser('deprovision', parents=[common], help='deprovision a configuration')
     parser_deprov.set_defaults(func=BoxmanManager.deprovision)
     parser_deprov.add_argument(
         '--docker-compose',
@@ -425,7 +454,7 @@ def parse_args():
     #
     # sub parser for the 'snapshot' subcommand
     #
-    parser_snap = subparsers.add_parser('snapshot', help='manage snapshots the state of the vms')
+    parser_snap = subparsers.add_parser('snapshot', parents=[common], help='manage snapshots the state of the vms')
 
     subparsers_snap = parser_snap.add_subparsers(
         help="sub-commands for boxman snapshot")
@@ -433,7 +462,7 @@ def parse_args():
     #
     # sub parser for the 'snapshot take' subsubcommand
     #
-    parser_snap_take = subparsers_snap.add_parser('take', help='take a snapshot')
+    parser_snap_take = subparsers_snap.add_parser('take', parents=[common], help='take a snapshot')
     parser_snap_take.set_defaults(func=BoxmanManager.snapshot_take)
     parser_snap_take.add_argument(
         '--vms',
@@ -493,7 +522,7 @@ def parse_args():
     #
     # sub parser for the 'snapshot list' subsubcommand
     #
-    parser_snap_list = subparsers_snap.add_parser('list', help='list snapshots')
+    parser_snap_list = subparsers_snap.add_parser('list', parents=[common], help='list snapshots')
     parser_snap_list.set_defaults(func=BoxmanManager.snapshot_list)
     parser_snap_list.add_argument(
         '--vms',
@@ -507,7 +536,7 @@ def parse_args():
     # sub parser for the 'snapshot log' subsubcommand
     #
     parser_snap_log = subparsers_snap.add_parser(
-        'log',
+        'log', parents=[common],
         help='git-log-style aggregated snapshot view across all vms')
     parser_snap_log.set_defaults(func=BoxmanManager.snapshot_log)
     parser_snap_log.add_argument(
@@ -547,7 +576,7 @@ def parse_args():
     #
     # sub parser for the 'snapshot restore' subsubcommand
     #
-    parser_snap_restore = subparsers_snap.add_parser('restore', help='restore the state of vms from snapshot')
+    parser_snap_restore = subparsers_snap.add_parser('restore', parents=[common], help='restore the state of vms from snapshot')
     parser_snap_restore.set_defaults(func=BoxmanManager.snapshot_restore)
     parser_snap_restore.add_argument(
         '--vms',
@@ -574,7 +603,7 @@ def parse_args():
     #
     # sub parser for the 'snapshot delete' subsubcommand
     #
-    parser_snap_delete = subparsers_snap.add_parser('delete', help='delete a snapshot')
+    parser_snap_delete = subparsers_snap.add_parser('delete', parents=[common], help='delete a snapshot')
     parser_snap_delete.set_defaults(func=BoxmanManager.snapshot_delete)
     parser_snap_delete.add_argument(
         '--vms',
@@ -602,7 +631,7 @@ def parse_args():
     # sub parser for the 'snapshot collapse' subsubcommand
     #
     parser_snap_collapse = subparsers_snap.add_parser(
-        'collapse',
+        'collapse', parents=[common],
         help='merge snapshots newer than --to into the live head '
              '(target snapshot remains revertable)')
     parser_snap_collapse.set_defaults(func=BoxmanManager.snapshot_collapse)
@@ -646,7 +675,7 @@ def parse_args():
     # (shortcut for 'snapshot restore' with no --name: restores the latest snapshot)
     #
     parser_restore = subparsers.add_parser(
-        'restore',
+        'restore', parents=[common],
         help='restore all VMs to their latest snapshot')
     parser_restore.set_defaults(func=BoxmanManager.snapshot_restore, snapshot_name=None)
 
@@ -654,7 +683,7 @@ def parse_args():
     # sub parser for the 'storage' subcommand
     #
     parser_storage = subparsers.add_parser(
-        'storage', help='inspect and reclaim qcow2 disk space')
+        'storage', parents=[common], help='inspect and reclaim qcow2 disk space')
 
     subparsers_storage = parser_storage.add_subparsers(
         help='sub-commands for boxman storage')
@@ -663,7 +692,7 @@ def parse_args():
     # sub parser for the 'storage df' subsubcommand
     #
     parser_storage_df = subparsers_storage.add_parser(
-        'df', help='show per-vm disk usage and reclaim estimate')
+        'df', parents=[common], help='show per-vm disk usage and reclaim estimate')
     parser_storage_df.set_defaults(func=BoxmanManager.storage_df)
     parser_storage_df.add_argument(
         '--vms',
@@ -677,7 +706,7 @@ def parse_args():
     # sub parser for the 'storage trim' subsubcommand
     #
     parser_storage_trim = subparsers_storage.add_parser(
-        'trim',
+        'trim', parents=[common],
         help='run fstrim inside running guests via qemu-guest-agent')
     parser_storage_trim.set_defaults(func=BoxmanManager.storage_trim)
     parser_storage_trim.add_argument(
@@ -698,7 +727,7 @@ def parse_args():
     # sub parser for the 'storage compact' subsubcommand
     #
     parser_storage_compact = subparsers_storage.add_parser(
-        'compact',
+        'compact', parents=[common],
         help='reclaim qcow2 space (sparsify or qemu-img convert)')
     parser_storage_compact.set_defaults(func=BoxmanManager.storage_compact)
     parser_storage_compact.add_argument(
@@ -740,7 +769,7 @@ def parse_args():
     # sub parser for the 'storage optimize' subsubcommand
     #
     parser_storage_optimize = subparsers_storage.add_parser(
-        'optimize',
+        'optimize', parents=[common],
         help='trim guests then compact qcow2 files (orchestrator)')
     parser_storage_optimize.set_defaults(func=BoxmanManager.storage_optimize)
     parser_storage_optimize.add_argument(
@@ -789,7 +818,7 @@ def parse_args():
     # sub parser for the 'storage compress-snapshots' subsubcommand
     #
     parser_storage_compress = subparsers_storage.add_parser(
-        'compress-snapshots',
+        'compress-snapshots', parents=[common],
         help='zstd-compress (or decompress) snapshot memory .raw files')
     parser_storage_compress.set_defaults(
         func=BoxmanManager.storage_compress_snapshots)
@@ -817,7 +846,7 @@ def parse_args():
     #
     # sub parser for the 'control' subcommand
     #
-    parser_ctrl = subparsers.add_parser('control', help='control the state of vms')
+    parser_ctrl = subparsers.add_parser('control', parents=[common], help='control the state of vms')
 
     subparsers_ctrl = parser_ctrl.add_subparsers(
         help="sub-commands for boxman control")
@@ -825,7 +854,7 @@ def parse_args():
     #
     # sub parser for the 'control suspend' subsubcommand
     #
-    parser_ctrl_suspend = subparsers_ctrl.add_parser('suspend', help='suspend vms')
+    parser_ctrl_suspend = subparsers_ctrl.add_parser('suspend', parents=[common], help='suspend vms')
     parser_ctrl_suspend.set_defaults(func=BoxmanManager.suspend_vm)
     parser_ctrl_suspend.add_argument(
         '--vms',
@@ -838,7 +867,7 @@ def parse_args():
     #
     # sub parser for the 'control resume' subsubcommand
     #
-    parser_ctrl_resume = subparsers_ctrl.add_parser('resume', help='resume vms')
+    parser_ctrl_resume = subparsers_ctrl.add_parser('resume', parents=[common], help='resume vms')
     parser_ctrl_resume.set_defaults(func=BoxmanManager.resume_vm)
     parser_ctrl_resume.add_argument(
         '--vms',
@@ -851,7 +880,7 @@ def parse_args():
     #
     # sub parser for the 'control save' subsubcommand
     #
-    parser_ctrl_save = subparsers_ctrl.add_parser('save', help='save the state of vms')
+    parser_ctrl_save = subparsers_ctrl.add_parser('save', parents=[common], help='save the state of vms')
     parser_ctrl_save.set_defaults(func=BoxmanManager.save_vm)
     parser_ctrl_save.add_argument(
         '--vms',
@@ -864,7 +893,7 @@ def parse_args():
     #
     # sub parser for the 'control start' subsubcommand
     #
-    parser_ctrl_start = subparsers_ctrl.add_parser('start', help='start the vms')
+    parser_ctrl_start = subparsers_ctrl.add_parser('start', parents=[common], help='start the vms')
     parser_ctrl_start.set_defaults(func=BoxmanManager.start_vm)
     parser_ctrl_start.add_argument(
         '--vms',
@@ -884,7 +913,7 @@ def parse_args():
     #
     # sub parser for the 'export' subcommand
     #
-    parser_export = subparsers.add_parser('export', help='export the vms')
+    parser_export = subparsers.add_parser('export', parents=[common], help='export the vms')
     parser_export.set_defaults(func=export_config)
     parser_export.add_argument(
         '--vms',
@@ -904,7 +933,7 @@ def parse_args():
     #
     # sub parser for the 'import' subcommand
     #
-    parser_import_image = subparsers.add_parser('import', help='import the vms')
+    parser_import_image = subparsers.add_parser('import', parents=[common], help='import the vms')
     parser_import_image.set_defaults(func=import_config)
     parser_import_image.add_argument(
         '--vms',
@@ -924,7 +953,7 @@ def parse_args():
     # sub parser for the 'run' subcommand
     #
     parser_run = subparsers.add_parser(
-        'run',
+        'run', parents=[common],
         help='run tasks with the workspace environment loaded',
         description=(
             "Run named tasks or ad-hoc commands with environment variables\n"
@@ -991,7 +1020,7 @@ def parse_args():
 
     # ── ps ───────────────────────────────────────────────────────────
     parser_ps = subparsers.add_parser(
-        'ps',
+        'ps', parents=[common],
         help='show the state of VMs in the project',
         description=(
             "Display the current state of all VMs defined in the project\n"
@@ -1021,7 +1050,7 @@ def parse_args():
 
     # ── conf ─────────────────────────────────────────────────────────
     parser_conf = subparsers.add_parser(
-        'conf',
+        'conf', parents=[common],
         help='show the effective configuration',
         description=(
             "Display the effective merged configuration that boxman will use.\n"
@@ -1046,7 +1075,7 @@ def parse_args():
 
     # ── ssh ──────────────────────────────────────────────────────────
     parser_ssh = subparsers.add_parser(
-        'ssh',
+        'ssh', parents=[common],
         help='ssh into a VM',
         description=(
             "Open an interactive SSH session to a VM.\n"
@@ -1079,7 +1108,7 @@ def parse_args():
 
     # ── pxe-boot ─────────────────────────────────────────────────────
     parser_pxe = subparsers.add_parser(
-        'pxe-boot',
+        'pxe-boot', parents=[common],
         help='set a VM to network-boot and optionally wait for SSH',
         description=(
             "Set a VM's boot order to [network, hd], start it, and\n"
@@ -1130,7 +1159,7 @@ def parse_args():
 
     # ── netlab (containerlab) ────────────────────────────────────────
     parser_netlab = subparsers.add_parser(
-        'netlab',
+        'netlab', parents=[common],
         help='manage the containerlab network-gear topology',
         description=(
             "Drive the containerlab lab declared under the 'containerlab:'\n"
@@ -1150,19 +1179,19 @@ def parse_args():
         help="sub-commands for boxman netlab")
 
     parser_netlab_deploy = subparsers_netlab.add_parser(
-        'deploy', help='render topology and deploy the containerlab lab')
+        'deploy', parents=[common], help='render topology and deploy the containerlab lab')
     parser_netlab_deploy.set_defaults(func=BoxmanManager.netlab_deploy)
 
     parser_netlab_destroy = subparsers_netlab.add_parser(
-        'destroy', help='tear down the containerlab lab (leaves VMs alone)')
+        'destroy', parents=[common], help='tear down the containerlab lab (leaves VMs alone)')
     parser_netlab_destroy.set_defaults(func=BoxmanManager.netlab_destroy)
 
     parser_netlab_inspect = subparsers_netlab.add_parser(
-        'inspect', help='print containerlab inspect --format json')
+        'inspect', parents=[common], help='print containerlab inspect --format json')
     parser_netlab_inspect.set_defaults(func=BoxmanManager.netlab_inspect)
 
     parser_netlab_ssh = subparsers_netlab.add_parser(
-        'ssh',
+        'ssh', parents=[common],
         help='print the ssh command for a lab node (e.g. $(boxman netlab ssh sw1))'
     )
     parser_netlab_ssh.set_defaults(func=BoxmanManager.netlab_ssh)
@@ -1180,3 +1209,18 @@ def parse_args():
     )
 
     return parser
+
+
+def resolve_verbosity(args):
+    """Effective -v count from either flag position, with a BOXMAN_VERBOSITY
+    env fallback when no flag was given. -q is handled separately by the caller."""
+    import os
+    count = max(
+        getattr(args, 'verbose_global', 0) or 0,
+        getattr(args, 'verbose', 0) or 0,
+    )
+    if count == 0:
+        env = os.environ.get('BOXMAN_VERBOSITY', '')
+        if env.strip().isdigit():
+            count = int(env.strip())
+    return count

--- a/src/boxman/utils/http_download.py
+++ b/src/boxman/utils/http_download.py
@@ -1,9 +1,11 @@
 """HTTP/HTTPS download helper with wget -> curl -> urllib fallbacks."""
 
+import logging
 import os
 import urllib.request
 
 from boxman import log
+from boxman.loggers.logger import is_verbose
 from boxman.utils.shell import run as _shell_run
 
 
@@ -14,12 +16,12 @@ def download_url(url: str, dst_path: str) -> bool:
     finally a urllib fallback. A partial *dst_path* left by a failed
     attempt is removed before the next attempt.
     """
-    log.info(f"downloading {url} -> {dst_path}")
+    log.status(f"downloading {url} -> {dst_path}")
 
     # wget: handles redirects, proxies, SSL well; prints chunky progress.
     result = _shell_run(
         f'wget --progress=dot:mega -O "{dst_path}" "{url}"',
-        hide=False, warn=True,
+        hide=not is_verbose(logging.DEBUG), warn=True,
     )
     if result.ok and os.path.isfile(dst_path) and os.path.getsize(dst_path) > 0:
         log.info("download complete (wget)")
@@ -30,7 +32,7 @@ def download_url(url: str, dst_path: str) -> bool:
     # curl fallback.
     result = _shell_run(
         f'curl -L --progress-bar -o "{dst_path}" "{url}"',
-        hide=False, warn=True,
+        hide=not is_verbose(logging.DEBUG), warn=True,
     )
     if result.ok and os.path.isfile(dst_path) and os.path.getsize(dst_path) > 0:
         log.info("download complete (curl)")

--- a/tests/test_logging_verbosity.py
+++ b/tests/test_logging_verbosity.py
@@ -1,0 +1,187 @@
+"""
+Tests for the minimal-verbosity logging behaviour.
+
+Covers the STATUS level, the level-aware ``ColoredFormatter``, the
+verbosity helpers in :mod:`boxman.loggers.logger`, and the
+``resolve_verbosity`` reconciliation in :mod:`boxman.scripts.cli_parser`.
+
+No libvirt / provider machinery is exercised — these are pure
+logging + argparse unit tests.
+"""
+
+import logging
+import re
+
+import pytest
+
+from boxman.loggers.logger import (
+    DEFAULT_LEVEL,
+    STATUS,
+    ColoredFormatter,
+    is_verbose,
+    logger,
+    set_quiet,
+    set_verbosity,
+    suppressed,
+)
+from boxman.scripts.cli_parser import parse_args, resolve_verbosity
+
+pytestmark = pytest.mark.unit
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    """Drop SGR colour escapes so assertions compare plain text."""
+    return _ANSI_RE.sub("", text)
+
+
+def _record(level, msg="hello world", *, pathname="mymod.py", lineno=42,
+            func="myfunc"):
+    """Build a bare LogRecord for the boxman logger at *level*."""
+    return logging.LogRecord(
+        name="boxman", level=level, pathname=pathname, lineno=lineno,
+        msg=msg, args=(), exc_info=None, func=func,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _restore_logger_level():
+    """Snapshot/restore the shared 'boxman' logger level around each test
+    so verbosity mutations don't leak between tests."""
+    prev = logger.level
+    try:
+        yield
+    finally:
+        logger.setLevel(prev)
+
+
+class TestSetVerbosity:
+
+    def test_zero_is_status_default(self):
+        assert set_verbosity(0) == STATUS
+        assert STATUS == DEFAULT_LEVEL
+        assert logging.getLogger("boxman").level == STATUS
+
+    def test_one_is_info(self):
+        assert set_verbosity(1) == logging.INFO
+        assert logging.getLogger("boxman").level == logging.INFO
+
+    def test_two_is_debug(self):
+        assert set_verbosity(2) == logging.DEBUG
+        assert logging.getLogger("boxman").level == logging.DEBUG
+
+    def test_high_count_clamps_to_debug(self):
+        assert set_verbosity(5) == logging.DEBUG
+        assert logging.getLogger("boxman").level == logging.DEBUG
+
+    def test_negative_falls_back_to_default(self):
+        assert set_verbosity(-1) == DEFAULT_LEVEL
+
+
+class TestSetQuiet:
+
+    def test_quiet_is_warning(self):
+        assert set_quiet() == logging.WARNING
+        assert logging.getLogger("boxman").level == logging.WARNING
+
+
+class TestColoredFormatter:
+
+    def test_status_has_no_bracket_prefix(self):
+        fmt = ColoredFormatter(use_color=True)
+        out = _strip_ansi(fmt.format(_record(STATUS, msg="all set")))
+        assert "[" not in out
+        assert out == "all set"
+
+    def test_info_is_bare_message(self):
+        fmt = ColoredFormatter(use_color=True)
+        out = _strip_ansi(fmt.format(_record(logging.INFO, msg="detail line")))
+        assert "[" not in out
+        assert out == "detail line"
+
+    def test_debug_has_diagnostic_prefix(self):
+        fmt = ColoredFormatter(use_color=True)
+        out = _strip_ansi(
+            fmt.format(_record(logging.DEBUG, pathname="/x/y/mymod.py",
+                               lineno=99, func="do_it")))
+        # rich diagnostic: [time LEVEL file{line}:func()] message
+        assert out.startswith("[")
+        assert "mymod.py" in out
+        assert "{99}" in out
+        assert "do_it()" in out
+
+    def test_warning_starts_with_level_tag(self):
+        fmt = ColoredFormatter(use_color=True)
+        out = _strip_ansi(fmt.format(_record(logging.WARNING, msg="careful")))
+        assert out.startswith("WARNING")
+        assert "careful" in out
+
+    def test_error_starts_with_level_tag(self):
+        fmt = ColoredFormatter(use_color=True)
+        out = _strip_ansi(fmt.format(_record(logging.ERROR, msg="broke")))
+        assert out.startswith("ERROR")
+        assert "broke" in out
+
+
+class TestSuppressed:
+
+    def test_raises_then_restores_prior_level(self):
+        set_verbosity(1)  # INFO
+        prior = logger.level
+        with suppressed():
+            assert logger.level > prior
+        assert logger.level == prior
+
+    def test_restores_prior_level_on_exception(self):
+        set_verbosity(0)  # STATUS
+        prior = logger.level
+        with pytest.raises(ValueError):
+            with suppressed():
+                assert logger.level > prior
+                raise ValueError("boom")
+        assert logger.level == prior
+
+
+class TestIsVerbose:
+
+    def test_debug_gate(self):
+        set_verbosity(2)
+        assert is_verbose(logging.DEBUG) is True
+        set_verbosity(0)
+        assert is_verbose(logging.DEBUG) is False
+
+
+class TestResolveVerbosity:
+
+    def test_flag_after_subcommand(self):
+        parser = parse_args()
+        args, _ = parser.parse_known_args(["up", "-vv"])
+        assert args.verbose == 2
+        assert resolve_verbosity(args) == 2
+
+    def test_flag_before_subcommand(self):
+        parser = parse_args()
+        args, _ = parser.parse_known_args(["-vv", "up"])
+        assert args.verbose_global == 2
+        assert resolve_verbosity(args) == 2
+
+    def test_no_flag_is_zero(self, monkeypatch):
+        monkeypatch.delenv("BOXMAN_VERBOSITY", raising=False)
+        parser = parse_args()
+        args, _ = parser.parse_known_args(["up"])
+        assert resolve_verbosity(args) == 0
+
+    def test_env_fallback_when_no_flag(self, monkeypatch):
+        monkeypatch.setenv("BOXMAN_VERBOSITY", "3")
+        parser = parse_args()
+        args, _ = parser.parse_known_args(["up"])
+        assert resolve_verbosity(args) == 3
+
+    def test_explicit_flag_beats_env(self, monkeypatch):
+        monkeypatch.setenv("BOXMAN_VERBOSITY", "3")
+        parser = parse_args()
+        args, _ = parser.parse_known_args(["up", "-v"])
+        # a given flag takes precedence over the env fallback
+        assert resolve_verbosity(args) == 1


### PR DESCRIPTION
Closes #68.

## What

Makes boxman's default terminal output terse and docker-compose-like, and puts all
of today's detail behind an opt-in counted `-v` flag. No more
`[time LEVEL file{line}:func()]` prefix on every line by default — `boxman up` now
shows a handful of clean status lines (network created, vm cloned/started, connection
info) plus warnings/errors. `-v`/`-vv`/`-vvv` (accepted **before or after** the
sub-command) progressively reveal more; `-q` shows warnings/errors only;
`BOXMAN_VERBOSITY` sets it via env.

## Verbosity levels

| flag | level | shows |
|------|-------|-------|
| *(default)* | `STATUS` (25) | concise status lines + warnings + errors |
| `-v` | `INFO` | + all the per-step `info()` detail |
| `-vv` | `DEBUG` | + debug lines, and the rich `[time LEVEL file{line}:func()]` diagnostic format |
| `-vvv` | `DEBUG` + command echo | + every underlying shell command |
| `-q` | `WARNING` | warnings + errors only |

## How

- **`loggers/logger.py`** — new `STATUS` level (25) shown by default + `logger.status()`;
  single-source-of-truth `DEFAULT_LEVEL`; level-aware `ColoredFormatter` (terse by
  default, rich only at `DEBUG`); `set_verbosity`/`set_quiet`/`is_verbose`; a
  `suppressed()` context manager.
- Because the default threshold sits **above** `INFO`, the ~437 existing `info()` calls
  become the `-v` tier automatically — only ~6 milestone lines were promoted to
  `status()`. `print()`-based reports (`list`, `ps`, `conf`, …) are independent of the
  log level and unaffected.
- **`scripts/cli_parser.py`** — `-v`/`-q` shared parent parser on every sub-command
  (44 subparsers) + a top-level `-v` on a distinct dest, reconciled with `max()` so both
  positions work; `resolve_verbosity()`.
- **`scripts/app.py`** — apply verbosity before dispatch (with `BOXMAN_VERBOSITY`
  fallback); echo shell commands at `-vvv`; `ps --json` suppression now via `suppressed()`.
- **`manager.py`** — clone-retry suppression uses `suppressed()`, which restores the
  caller's chosen level instead of hard-resetting to `DEBUG` (the old bug that clobbered
  any selected verbosity); connection-info block promoted to `status()`.
- **Cleanup** — removed decorative `=`×70 / `-`×60 / `─`×60 banners; demoted the
  cloud-init log dump, guest-agent poll loop, and docker-compose env-var dump to `debug`;
  gated streamed download/copy subprocess output on `-vv`.

## Example

```
$ boxman up                    # default — terse
provisioning project demo
WARNING: low disk space

$ boxman up -vv                # DEBUG — rich diagnostic format returns
[2026-07-22 04:22:18 DEBUG commands.py{47}:run()] connecting to qemu:///system
```

## Tests

New `tests/test_logging_verbosity.py` (19 tests): level mapping, terse-vs-rich
formatter output, `suppressed()` restore (including on exception), and `-v` parsing in
both positions + env precedence.

Verified on hp3 (Python 3.12): **19/19 new tests pass; full unit suite 1141 passed**.
The only failures are 4 pre-existing, environmental `TestDockerComposeRuntime` cases
that hit a shared-host `/tmp/.env` (issue #23) — untouched by this PR. CLI confirmed
accepting `-v` in both positions; runtime output confirmed terse by default and rich at
`-vv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
