### PR TITLE
feat(docker-compose): Phase 6 CLI/UX parity for containers (#54)

### DIFF
--- a/doc/docker-compose-provider/config-schema.md
+++ b/doc/docker-compose-provider/config-schema.md
@@ -241,6 +241,34 @@ destroy` removes **named** volumes (`down --volumes`) and the generated compose
 file. Bind-mount host directories are **never** removed — they are your paths
 (`./initdb`, `.`), so cleaning them up is your call.
 
+## CLI/UX for docker-compose clusters
+
+Every boxman verb treats a mixed (libvirt + docker-compose) project uniformly;
+containers appear alongside VMs, and no verb tracebacks on an unsupported op.
+
+- **`boxman ps`** lists VMs and containers with a `Provider` column and each
+  container's `State` (+ health). `boxman connect_info` adds a per-container
+  section with published ports and the `boxman exec` entry point.
+- **`boxman exec <cluster>.<box>`** runs `docker compose exec` on a container —
+  an interactive shell (default `sh`; `--shell bash`), or a one-shot command
+  after `--` (`boxman exec services.cache -- redis-cli ping`). A bare
+  `<box>` works when it's unique across dc clusters. **`boxman ssh` stays
+  VM-only** — exec is the container equivalent (decision D2). There is no
+  ssh_config entry for containers.
+- **Ansible / `boxman run` / `tasks:`** reach containers through the generated
+  inventory: each container is a host with
+  `ansible_connection: community.docker.docker` and
+  `ansible_host: <project>_<cluster>-<box>-1`, grouped under its cluster. So
+  `boxman run --cmd '…'` and `tasks:` hit containers and VMs alike.
+  **Prerequisite:** the `community.docker` Ansible collection
+  (`ansible-galaxy collection install community.docker`) and the Docker SDK
+  for Python on the control host.
+- **`boxman control`** for containers: `suspend` → `docker compose pause`,
+  `resume` → `docker compose unpause`, `start` → `docker compose start`.
+  `save` has no docker equivalent (containers have no save-to-file state) — it
+  logs an explanatory message and skips the dc clusters (use snapshots in a
+  later phase, or `destroy`).
+
 ## Templating caveat for compose values (`environment:`, `command:`)
 
 `load_config` pre-processes bare `{{ name }}` tokens into `{name}` task

--- a/doc/docker-compose-provider/design.md
+++ b/doc/docker-compose-provider/design.md
@@ -571,7 +571,7 @@ graph TB
     
     subgraph Phase6["Phase 6: CLI/UX"]
         AC16["✓ boxman ps shows VMs and containers"]
-        AC17["✓ boxman ssh works for containers"]
+        AC17["✓ boxman exec works for containers (ssh is VM-only, D2)"]
         AC18["✓ Inventory includes containers"]
     end
 ```
@@ -644,7 +644,7 @@ Questions" section.
 | # | Question | Decision |
 |---|---|---|
 | D1 | Container readiness | `docker compose up --wait` + per-cluster `readiness_timeout` (default 120s): waits for `healthy` when a healthcheck exists, `running` otherwise — no custom polling loop. |
-| D2 | Container access | `boxman ssh <cluster>.<box>` transparently uses `docker exec -it` — no sshd sidecars. Ansible reaches containers via the `community.docker` connection plugin. `write_ssh_config` stays VM-only. |
+| D2 | Container access | **Revised in Phase 6 ([#54](https://github.com/mherkazandjian/boxman/issues/54)):** a **distinct `boxman exec <cluster>.<box>`** verb runs `docker compose exec` (interactive shell, or a `-- <cmd>` one-shot) — `boxman ssh` stays VM-only, for a clean ssh-vs-docker split (the earlier plan overloaded `ssh`; a separate verb reads clearer). No sshd sidecars. Ansible reaches containers via the `community.docker` connection plugin. `write_ssh_config` stays VM-only. |
 | D3 | Snapshot semantics | `docker commit`-backed: `take` commits + tags `boxman/<project>_<box>:<snap>`; `restore` regenerates the compose file with snapshot tags + `up --force-recreate`; `list`/`delete` = image ls/rmi + metadata JSON in the cluster workdir. **Volumes are not snapshotted** — documented loudly. |
 | D4 | `build.context` | Resolved by boxman to an absolute path (relative to the conf.yml directory) at generation time — the generated compose file lives in the cluster workdir, so passing relative paths through would silently break. |
 | D5 | Compose file location | `<cluster_workdir>/docker-compose.yml` — inspectable and hand-runnable (`docker compose -f … ps`), same debuggability philosophy as the `.rendered.yml` dump. |

--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -284,14 +284,24 @@ class BoxmanManager:
         }
 
     def _compose_project_for(self, cluster_name: str) -> str:
-        """The ``docker compose -p`` project name for a dc cluster — mirrors
-        :meth:`DockerComposeSession._compose_project` so container names can be
-        derived (``<project>-<box>-1``) at inventory-render time without a live
-        session or a docker query."""
-        from boxman.providers.docker_compose.session import _sanitize_project_name
-        dc = (self.config.get('provider') or {}).get('docker-compose') or {}
-        base = dc.get('project_name') or self.config.get('project') or 'boxman'
-        return _sanitize_project_name(f"{base}_{cluster_name}")
+        """The ``docker compose -p`` project name for a dc cluster, so container
+        names can be derived (``<project>-<box>-1``) at inventory-render time
+        without a live session or docker query. Single-sourced with the
+        session's ``_compose_project`` so the inventory ``ansible_host`` can
+        never diverge from the real compose container name."""
+        from boxman.providers.docker_compose.session import compose_project_name
+        return compose_project_name(self.config, cluster_name)
+
+    def _select_dc_clusters(self, cli_args) -> list[tuple[str, dict]]:
+        """docker-compose clusters selected by ``--cluster`` (an unset/absent
+        ``--cluster`` selects all). ``(name, cfg)`` pairs — empty for a
+        libvirt-only project."""
+        wanted = getattr(cli_args, 'cluster', None)
+        return [
+            (name, cluster)
+            for name, cluster in self._compose_clusters.items()
+            if wanted in (None, name)
+        ]
 
     def _vm_cluster_map(self) -> dict[str, str]:
         """
@@ -5143,7 +5153,7 @@ class BoxmanManager:
         for vm_name, _ in cls.process_vm_list(cli_args):
             cls.session_for_vm(vm_name).suspend_vm(vm_name)
             cls.logger.info(f"vm {vm_name} suspended")
-        for cluster_name, cluster in cls._compose_clusters.items():
+        for cluster_name, cluster in cls._select_dc_clusters(cli_args):
             cls._dc_session(cluster_name).pause_cluster(cluster_name, cluster)
 
     @staticmethod
@@ -5155,7 +5165,7 @@ class BoxmanManager:
         for vm_name, _ in cls.process_vm_list(cli_args):
             cls.session_for_vm(vm_name).resume_vm(vm_name)
             cls.logger.info(f"VM {vm_name} resumed")
-        for cluster_name, cluster in cls._compose_clusters.items():
+        for cluster_name, cluster in cls._select_dc_clusters(cli_args):
             cls._dc_session(cluster_name).unpause_cluster(cluster_name, cluster)
 
     @staticmethod
@@ -5167,7 +5177,7 @@ class BoxmanManager:
         """
         for vm_name, workdir in cls.process_vm_list(cli_args):
             cls.session_for_vm(vm_name).save_vm(vm_name, workdir)
-        for cluster_name in cls._compose_clusters:
+        for cluster_name, _cluster in cls._select_dc_clusters(cli_args):
             cls.logger.warning(
                 f"'control save' is not supported for docker-compose cluster "
                 f"'{cluster_name}' — containers have no save-to-file state; use "
@@ -5185,7 +5195,7 @@ class BoxmanManager:
                 cls.session_for_vm(vm_name).restore_vm(vm_name, workdir)
             else:
                 cls.session_for_vm(vm_name).start_vm(vm_name)
-        for cluster_name, cluster in cls._compose_clusters.items():
+        for cluster_name, cluster in cls._select_dc_clusters(cli_args):
             if getattr(cli_args, "restore", False):
                 cls.logger.info(
                     f"[{cluster_name}] --restore has no docker-compose "
@@ -5433,7 +5443,7 @@ class BoxmanManager:
         records = []
         for idx, (cluster_name, vm_name, full_name) in enumerate(vm_list):
             virsh_id, state = vm_info.get(full_name, ("-", "not created"))
-            rec = {"id": idx, "cluster": cluster_name, "name": vm_name,
+            rec = {"id": idx, "cluster": cluster_name, "vm": vm_name,
                    "provider": cls.provider_type_for_cluster(cluster_name),
                    "state": state}
             if provider_info:
@@ -5458,7 +5468,7 @@ class BoxmanManager:
                 if row:
                     state = row["state"] + (
                         f" ({row['health']})" if row.get("health") else "")
-                rec = {"id": "-", "cluster": cluster_name, "name": box_name,
+                rec = {"id": "-", "cluster": cluster_name, "vm": box_name,
                        "provider": "docker-compose", "state": state}
                 if provider_info:
                     rec["virsh_id"] = "-"
@@ -5477,11 +5487,11 @@ class BoxmanManager:
         if provider_info:
             headers = ("Id", "Cluster", "Name", "Provider", "State",
                        "Virsh Id", "Virsh Name")
-            rows = [(str(r["id"]), r["cluster"], r["name"], r["provider"],
+            rows = [(str(r["id"]), r["cluster"], r["vm"], r["provider"],
                      r["state"], r["virsh_id"], r["virsh_name"]) for r in records]
         else:
             headers = ("Id", "Cluster", "Name", "Provider", "State")
-            rows = [(str(r["id"]), r["cluster"], r["name"], r["provider"],
+            rows = [(str(r["id"]), r["cluster"], r["vm"], r["provider"],
                      r["state"]) for r in records]
 
         col_count = len(headers)
@@ -5556,25 +5566,24 @@ class BoxmanManager:
     def exec_container(cls, cli_args):
         """Exec into a docker-compose container via ``docker compose exec``.
 
-        Interactive shell when no command is given; a trailing command (after
-        ``--``) runs non-interactively. Runs with inherited stdio so an
-        interactive shell attaches to the real terminal (mirrors ``ssh``).
+        Interactive shell when no command is given (``--shell`` picks the shell);
+        a trailing command (after ``--`` when it has flags) runs
+        non-interactively. Runs the argv list with ``shell=False`` and inherited
+        stdio, so an interactive shell attaches to the real terminal.
         """
         import subprocess
         import sys
 
         cmd = list(getattr(cli_args, 'cmd', None) or [])
-        if cmd and cmd[0] == '--':
-            cmd = cmd[1:]
         shell = getattr(cli_args, 'shell', None) or 'sh'
 
         cluster, box = cls._resolve_container_target(cli_args.target)
         cluster_cfg = cls.config['clusters'][cluster]
-        command = cls._dc_session(cluster).exec_command_for(
+        argv = cls._dc_session(cluster).exec_command_for(
             cluster, cluster_cfg, box, cmd=cmd or None, shell=shell
         )
-        cls.logger.info(f"exec: {command}")
-        result = subprocess.run(command, shell=True)
+        cls.logger.info(f"exec: {' '.join(argv)}")
+        result = subprocess.run(argv)
         if result.returncode != 0:
             sys.exit(result.returncode)
 

--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -209,6 +209,24 @@ class BoxmanManager:
             f"'{provider_type}' (needed by cluster '{cluster_name}')"
         )
 
+    def _dc_session(self, cluster_name: str) -> "ProviderSession":
+        """Return the docker-compose session for *cluster_name*, lazily creating
+        and caching one if none is registered.
+
+        The read-only display/access verbs (``ps``/``connect_info``/``exec``)
+        dispatch without the full provider-setup path, so a session may not be
+        pre-registered — a dc session is cheap and needs no libvirt, so it is
+        built on demand here rather than requiring that setup.
+        """
+        try:
+            return self.session_for_cluster(cluster_name)
+        except ValueError:
+            from boxman.providers import create_session
+            session = create_session('docker-compose', self.config)
+            session.manager = self
+            self._get_sessions()['docker-compose'] = session
+            return session
+
     def session_for_vm(self, full_vm_name: str) -> Optional["ProviderSession"]:
         """
         Resolve the provider session that manages *full_vm_name*.
@@ -264,6 +282,16 @@ class BoxmanManager:
             for name, cluster in (self.config.get('clusters') or {}).items()
             if self._is_compose_cluster(name)
         }
+
+    def _compose_project_for(self, cluster_name: str) -> str:
+        """The ``docker compose -p`` project name for a dc cluster — mirrors
+        :meth:`DockerComposeSession._compose_project` so container names can be
+        derived (``<project>-<box>-1``) at inventory-render time without a live
+        session or a docker query."""
+        from boxman.providers.docker_compose.session import _sanitize_project_name
+        dc = (self.config.get('provider') or {}).get('docker-compose') or {}
+        base = dc.get('project_name') or self.config.get('project') or 'boxman'
+        return _sanitize_project_name(f"{base}_{cluster_name}")
 
     def _vm_cluster_map(self) -> dict[str, str]:
         """
@@ -678,7 +706,7 @@ class BoxmanManager:
                 )
 
     @staticmethod
-    def _render_inventory(host_aliases, cluster_groups) -> str:
+    def _render_inventory(host_aliases, cluster_groups, host_extra_vars=None) -> str:
         """
         Render an Ansible ``01-hosts.yml`` body.
 
@@ -687,15 +715,23 @@ class BoxmanManager:
                 ``all.hosts``.
             cluster_groups: mapping of group name → list of host keys, rendered
                 as ``all.children.<group>.hosts``.
+            host_extra_vars: optional ``{host_key: {var: value}}`` of extra host
+                vars (e.g. ``ansible_connection``/``ansible_host`` for
+                docker-compose containers reached via ``community.docker``).
+                VM hosts pass nothing and render exactly as before.
 
         Returns:
             The YAML text (identical in shape to what boxman has always
             generated for the combined workspace inventory).
         """
-        host_lines = '\n'.join(
-            f'        {host}:\n          boxman_alias: "{alias}"'
-            for host, alias in host_aliases
-        )
+        host_extra_vars = host_extra_vars or {}
+        host_blocks: list[str] = []
+        for host, alias in host_aliases:
+            lines = [f'        {host}:', f'          boxman_alias: "{alias}"']
+            for var, value in (host_extra_vars.get(host) or {}).items():
+                lines.append(f'          {var}: "{value}"')
+            host_blocks.append('\n'.join(lines))
+        host_lines = '\n'.join(host_blocks)
         children_lines: list[str] = []
         for group, hosts in cluster_groups.items():
             children_lines.append(f'    {group}:')
@@ -784,7 +820,8 @@ class BoxmanManager:
             ansible_cfg_key = 'ansible.cfg'
 
         for cluster_name, cluster in clusters.items():
-            # resolve workdir: explicit > workspace.path/cluster_name
+            # resolve workdir: explicit > workspace.path/cluster_name (for both
+            # libvirt and docker-compose clusters).
             if 'workdir' not in cluster:
                 if workspace_path:
                     cluster['workdir'] = os.path.join(workspace_path, cluster_name)
@@ -793,56 +830,64 @@ class BoxmanManager:
                         f"cluster '{cluster_name}' has no workdir and "
                         f"workspace.path is not set"
                     )
-                    continue
-
-            workdir = cluster['workdir']
-            vms = cluster.get('vms', {})
-
-            if not vms:
-                continue
-
-            # --- env.sh (workspace-level) ---
-            if env_sh_key not in ws_files:
-                first_vm = next(iter(vms))
-                inv_val = custom_inventory if custom_inventory else 'inventory'
-                cfg_val = custom_ansible_config if custom_ansible_config else 'ansible.cfg'
-                ws_files[env_sh_key] = (
-                    f"export INVENTORY={inv_val}\n"
-                    f"export SSH_CONFIG=ssh_config\n"
-                    f"export GATEWAYHOST={cluster_name}_{first_vm}\n"
-                    f"export ANSIBLE_CONFIG={cfg_val}\n"
-                    f"export ANSIBLE_INVENTORY=\"$INVENTORY\"\n"
-                    f"export ANSIBLE_SSH_ARGS=\"-F $SSH_CONFIG\"\n"
-                )
 
         # --- inventory generation ---
-        # Build the project-wide ordering of (cluster, vm) once so a given
-        # host's boxman_alias is identical in the combined workspace inventory
-        # and in the per-cluster inventory below (and lines up with the
-        # node<N> aliases written into ssh_config).
-        all_vms = [
-            (cname, vm_name)
-            for cname, cluster in clusters.items()
-            for vm_name in cluster.get('vms', {})
-        ]
-        pad_width = len(str(len(all_vms) - 1)) if len(all_vms) > 1 else 1
+        # Project-wide host ordering, once, so a host's boxman_alias is
+        # identical in the combined and per-cluster inventories (and lines up
+        # with the node<N> ssh_config aliases). Rows are (cluster, name,
+        # host_key, extra_vars): libvirt VMs reach via ssh (no extra vars);
+        # docker-compose containers reach via the community.docker connection
+        # to the deterministic compose container name (<project>-<box>-1).
+        all_hosts: list[tuple[str, str, str, dict]] = []
+        for cname, cluster in clusters.items():
+            if self._is_compose_cluster(cname):
+                project = self._compose_project_for(cname)
+                for box in (cluster.get('boxes') or {}):
+                    all_hosts.append((cname, box, f'{cname}_{box}', {
+                        'ansible_connection': 'community.docker.docker',
+                        'ansible_host': f'{project}-{box}-1',
+                    }))
+            else:
+                for vm_name in (cluster.get('vms') or {}):
+                    all_hosts.append((cname, vm_name, f'{cname}_{vm_name}', {}))
+
+        pad_width = len(str(len(all_hosts) - 1)) if len(all_hosts) > 1 else 1
         alias_of = {
-            (cname, vm): f"node{str(i).zfill(pad_width)}"
-            for i, (cname, vm) in enumerate(all_vms)
+            (c, n): f"node{str(i).zfill(pad_width)}"
+            for i, (c, n, _hk, _ev) in enumerate(all_hosts)
         }
+
+        # --- env.sh (workspace-level) --- GATEWAYHOST is the first libvirt VM
+        # (the `boxman ssh` default target); a dc-only project leaves it empty
+        # since containers are reached with `boxman exec`, not ssh.
+        if all_hosts and env_sh_key not in ws_files:
+            first_vm = next((hk for (_c, _n, hk, ev) in all_hosts if not ev), '')
+            inv_val = custom_inventory if custom_inventory else 'inventory'
+            cfg_val = custom_ansible_config if custom_ansible_config else 'ansible.cfg'
+            ws_files[env_sh_key] = (
+                f"export INVENTORY={inv_val}\n"
+                f"export SSH_CONFIG=ssh_config\n"
+                f"export GATEWAYHOST={first_vm}\n"
+                f"export ANSIBLE_CONFIG={cfg_val}\n"
+                f"export ANSIBLE_INVENTORY=\"$INVENTORY\"\n"
+                f"export ANSIBLE_SSH_ARGS=\"-F $SSH_CONFIG\"\n"
+            )
 
         # Combined workspace inventory (every cluster's hosts). Kept for
         # project-wide ops and `boxman ssh <alias>` resolution. NOTE: because
         # it merges all clusters under all.hosts, an Ansible consumer that
         # iterates groups['all'] would see every cluster — which is why each
         # cluster also gets its own scoped inventory below.
-        if all_vms and inventory_key not in ws_files:
-            host_aliases = [(f'{c}_{v}', alias_of[(c, v)]) for c, v in all_vms]
+        if all_hosts and inventory_key not in ws_files:
+            host_aliases = [(hk, alias_of[(c, n)]) for (c, n, hk, _ev) in all_hosts]
             cluster_groups: dict[str, list[str]] = {}
-            for c, v in all_vms:
-                cluster_groups.setdefault(c, []).append(f'{c}_{v}')
+            host_extra: dict[str, dict] = {}
+            for (c, _n, hk, ev) in all_hosts:
+                cluster_groups.setdefault(c, []).append(hk)
+                if ev:
+                    host_extra[hk] = ev
             ws_files[inventory_key] = self._render_inventory(
-                host_aliases, cluster_groups)
+                host_aliases, cluster_groups, host_extra)
 
         # Per-cluster inventory (only that cluster's hosts). This is what a
         # `run --cluster <name>` consumes (load_workspace_env repoints
@@ -854,8 +899,10 @@ class BoxmanManager:
         combined_inv_abs = os.path.abspath(
             os.path.join(ws_path_abs, inventory_key))
         for cluster_name, cluster in clusters.items():
-            cluster_vms = list(cluster.get('vms', {}))
-            if not cluster_vms or 'workdir' not in cluster:
+            cluster_hosts = [
+                (n, hk, ev) for (c, n, hk, ev) in all_hosts if c == cluster_name
+            ]
+            if not cluster_hosts or 'workdir' not in cluster:
                 continue
             workdir_abs = os.path.abspath(os.path.expanduser(cluster['workdir']))
             cluster_inv_key = self._cluster_inventory_key(cluster)
@@ -886,12 +933,14 @@ class BoxmanManager:
             if cluster_inv_key in cluster_files:
                 continue
             host_aliases = [
-                (f'{cluster_name}_{v}', alias_of[(cluster_name, v)])
-                for v in cluster_vms
+                (hk, alias_of[(cluster_name, n)])
+                for (n, hk, _ev) in cluster_hosts
             ]
+            host_extra = {hk: ev for (n, hk, ev) in cluster_hosts if ev}
             cluster_files[cluster_inv_key] = self._render_inventory(
                 host_aliases,
-                {cluster_name: [f'{cluster_name}_{v}' for v in cluster_vms]},
+                {cluster_name: [hk for (_n, hk, _ev) in cluster_hosts]},
+                host_extra,
             )
 
         # --- ansible.cfg (workspace-level) ---
@@ -3044,6 +3093,31 @@ class BoxmanManager:
 
             self.logger.info("")
 
+        # docker-compose clusters: container status + published ports + the
+        # exec entry point (containers are reached with `boxman exec`, not ssh).
+        for cluster_name, cluster in self._compose_clusters.items():
+            self.logger.info(f"cluster: {cluster_name} (docker-compose)")
+            self.logger.info("-" * 60)
+            try:
+                status = {
+                    r["service"]: r for r in
+                    self._dc_session(cluster_name).container_status(
+                        cluster_name, cluster)
+                }
+            except Exception as exc:
+                self.logger.warning(f"  could not query containers: {exc}")
+                status = {}
+            for box_name in (cluster.get("boxes") or {}):
+                row = status.get(box_name, {})
+                state = row.get("state", "not created")
+                health = f" ({row['health']})" if row.get("health") else ""
+                self.logger.info(f"container: {box_name}  [{state}{health}]")
+                if row.get("ports"):
+                    self.logger.info(f"  published ports: {row['ports']}")
+                self.logger.info(f"  connect: boxman exec {cluster_name}.{box_name}")
+                self.logger.info("")
+            self.logger.info("")
+
     #: Alias of the ProxyJump stanza written into ``ssh_config`` when the
     #: docker runtime is active. Kept as a class constant so tests and
     #: downstream tooling can grep for it reliably.
@@ -5063,39 +5137,60 @@ class BoxmanManager:
     @staticmethod
     def suspend_vm(cls, cli_args):
         """
-        Suspend (pause) the VMs in the cluster.
+        Suspend the machines: libvirt VMs → virsh suspend; docker-compose
+        containers → ``docker compose pause``.
         """
         for vm_name, _ in cls.process_vm_list(cli_args):
             cls.session_for_vm(vm_name).suspend_vm(vm_name)
             cls.logger.info(f"vm {vm_name} suspended")
+        for cluster_name, cluster in cls._compose_clusters.items():
+            cls._dc_session(cluster_name).pause_cluster(cluster_name, cluster)
 
     @staticmethod
     def resume_vm(cls, cli_args):
         """
-        Resume previously suspended VMs in the cluster.
+        Resume the machines: libvirt VMs → virsh resume; docker-compose
+        containers → ``docker compose unpause``.
         """
         for vm_name, _ in cls.process_vm_list(cli_args):
             cls.session_for_vm(vm_name).resume_vm(vm_name)
             cls.logger.info(f"VM {vm_name} resumed")
+        for cluster_name, cluster in cls._compose_clusters.items():
+            cls._dc_session(cluster_name).unpause_cluster(cluster_name, cluster)
 
     @staticmethod
     def save_vm(cls, cli_args):
         """
-        Save the state of the VMs in the cluster to a file.
+        Save the state of libvirt VMs to a file. Not supported for
+        docker-compose containers (no save-to-file state) — an explanatory
+        message is logged, no traceback.
         """
         for vm_name, workdir in cls.process_vm_list(cli_args):
             cls.session_for_vm(vm_name).save_vm(vm_name, workdir)
+        for cluster_name in cls._compose_clusters:
+            cls.logger.warning(
+                f"'control save' is not supported for docker-compose cluster "
+                f"'{cluster_name}' — containers have no save-to-file state; use "
+                f"snapshots (Phase 7) or 'destroy'. Skipping."
+            )
 
     @staticmethod
     def start_vm(cls, cli_args):
         """
-        Start VMs in the cluster.
+        Start the machines: libvirt VMs (optionally --restore); docker-compose
+        containers → ``docker compose start``.
         """
         for vm_name, workdir in cls.process_vm_list(cli_args):
             if cli_args.restore:
                 cls.session_for_vm(vm_name).restore_vm(vm_name, workdir)
             else:
                 cls.session_for_vm(vm_name).start_vm(vm_name)
+        for cluster_name, cluster in cls._compose_clusters.items():
+            if getattr(cli_args, "restore", False):
+                cls.logger.info(
+                    f"[{cluster_name}] --restore has no docker-compose "
+                    f"equivalent; starting containers")
+            cls._dc_session(cluster_name).start_cluster(cluster_name, cluster)
     ### end control vm functions ####
 
     ### task runner functions ####
@@ -5304,58 +5399,90 @@ class BoxmanManager:
         as_json = getattr(cli_args, 'json', False)
 
         vm_list = cls._get_vm_list()
+        dc_clusters = cls._compose_clusters
 
-        if not vm_list:
+        if not vm_list and not dc_clusters:
             if as_json:
                 print(json.dumps([], indent=2))
             else:
-                print("No VMs defined in configuration")
+                print("No VMs or containers defined in configuration")
             return
 
-        # Query virsh for states
-        provider_type = primary_provider_type(cls.config)
-        provider_config = cls.config.get("provider", {}).get(provider_type, {})
-        if cls.app_config and "providers" in cls.app_config:
-            app_prov = cls.app_config["providers"].get(provider_type, {})
-            provider_config = BoxmanManager._merge_provider_configs(app_prov, provider_config)
-
-        virsh = VirshCommand(provider_config=provider_config)
-        result = virsh.execute("list", "--all", hide=True, warn=True)
-
-        # Parse virsh output into {full_name: (virsh_id, state)}
+        # Query virsh for VM states — only when there are libvirt VMs (a
+        # dc-only project has no libvirt to talk to).
         vm_info: dict[str, tuple[str, str]] = {}
-        if result.ok:
-            for line in result.stdout.strip().splitlines():
-                line = line.strip()
-                if not line or line.startswith("---") or line.startswith("Id"):
-                    continue
-                parts = line.split(None, 2)
-                if len(parts) >= 3:
-                    virsh_id, virsh_name, state = parts[0], parts[1], parts[2].strip()
-                    vm_info[virsh_name] = (virsh_id, state)
+        if vm_list:
+            provider_type = primary_provider_type(cls.config)
+            provider_config = cls.config.get("provider", {}).get(provider_type, {})
+            if cls.app_config and "providers" in cls.app_config:
+                app_prov = cls.app_config["providers"].get(provider_type, {})
+                provider_config = BoxmanManager._merge_provider_configs(app_prov, provider_config)
+            virsh = VirshCommand(provider_config=provider_config)
+            result = virsh.execute("list", "--all", hide=True, warn=True)
+            if result.ok:
+                for line in result.stdout.strip().splitlines():
+                    line = line.strip()
+                    if not line or line.startswith("---") or line.startswith("Id"):
+                        continue
+                    parts = line.split(None, 2)
+                    if len(parts) >= 3:
+                        virsh_id, virsh_name, state = parts[0], parts[1], parts[2].strip()
+                        vm_info[virsh_name] = (virsh_id, state)
 
-        # Build records
+        # Build records: libvirt VMs first (numeric ids), then dc containers.
         records = []
         for idx, (cluster_name, vm_name, full_name) in enumerate(vm_list):
             virsh_id, state = vm_info.get(full_name, ("-", "not created"))
-            rec = {"id": idx, "cluster": cluster_name, "vm": vm_name, "state": state}
+            rec = {"id": idx, "cluster": cluster_name, "name": vm_name,
+                   "provider": cls.provider_type_for_cluster(cluster_name),
+                   "state": state}
             if provider_info:
                 rec["virsh_id"] = virsh_id
                 rec["virsh_name"] = full_name
             records.append(rec)
 
+        for cluster_name, cluster in dc_clusters.items():
+            try:
+                status = {
+                    r["service"]: r for r in
+                    cls._dc_session(cluster_name).container_status(
+                        cluster_name, cluster)
+                }
+            except Exception as exc:  # a status probe must never break `ps`
+                cls.logger.warning(
+                    f"could not query containers for '{cluster_name}': {exc}")
+                status = {}
+            for box_name in (cluster.get("boxes") or {}):
+                row = status.get(box_name)
+                state = "not created"
+                if row:
+                    state = row["state"] + (
+                        f" ({row['health']})" if row.get("health") else "")
+                rec = {"id": "-", "cluster": cluster_name, "name": box_name,
+                       "provider": "docker-compose", "state": state}
+                if provider_info:
+                    rec["virsh_id"] = "-"
+                    rec["virsh_name"] = "-"
+                records.append(rec)
+
         if as_json:
             print(json.dumps(records, indent=2))
             return
 
+        if not records:
+            print("No VMs or containers defined in configuration")
+            return
+
         # Print table
         if provider_info:
-            headers = ("Id", "Cluster", "VM", "State", "Virsh Id", "Virsh Name")
-            rows = [(str(r["id"]), r["cluster"], r["vm"], r["state"],
-                     r["virsh_id"], r["virsh_name"]) for r in records]
+            headers = ("Id", "Cluster", "Name", "Provider", "State",
+                       "Virsh Id", "Virsh Name")
+            rows = [(str(r["id"]), r["cluster"], r["name"], r["provider"],
+                     r["state"], r["virsh_id"], r["virsh_name"]) for r in records]
         else:
-            headers = ("Id", "Cluster", "VM", "State")
-            rows = [(str(r["id"]), r["cluster"], r["vm"], r["state"]) for r in records]
+            headers = ("Id", "Cluster", "Name", "Provider", "State")
+            rows = [(str(r["id"]), r["cluster"], r["name"], r["provider"],
+                     r["state"]) for r in records]
 
         col_count = len(headers)
         widths = [
@@ -5388,6 +5515,68 @@ class BoxmanManager:
         if exit_code != 0:
             import sys
             sys.exit(exit_code)
+
+    def _resolve_container_target(self, target: str) -> tuple[str, str]:
+        """Resolve a ``boxman exec`` target to ``(cluster, box)``.
+
+        ``<cluster>.<box>`` is split on the last dot; a bare ``<box>`` is
+        allowed when exactly one docker-compose cluster defines it. Raises
+        ``ConfigError`` for an unknown target or one that names a libvirt VM
+        (which should use ``boxman ssh``).
+        """
+        dc_clusters = self._compose_clusters
+        if '.' in target:
+            cluster, box = target.rsplit('.', 1)
+            if cluster not in (self.config.get('clusters') or {}):
+                raise ConfigError(f"no cluster '{cluster}' in this project.")
+            if not self._is_compose_cluster(cluster):
+                raise ConfigError(
+                    f"cluster '{cluster}' is a libvirt cluster — use "
+                    f"'boxman ssh' for VMs, not 'boxman exec'."
+                )
+            return cluster, box
+        matches = [
+            cn for cn, cl in dc_clusters.items()
+            if target in (cl.get('boxes') or {})
+        ]
+        if len(matches) == 1:
+            return matches[0], target
+        if not matches:
+            raise ConfigError(
+                f"no docker-compose container '{target}' — give the target as "
+                f"'<cluster>.<box>' (dc clusters: "
+                f"{', '.join(dc_clusters) or 'none'})."
+            )
+        raise ConfigError(
+            f"container '{target}' is ambiguous across clusters "
+            f"{', '.join(matches)} — use '<cluster>.<box>'."
+        )
+
+    @staticmethod
+    def exec_container(cls, cli_args):
+        """Exec into a docker-compose container via ``docker compose exec``.
+
+        Interactive shell when no command is given; a trailing command (after
+        ``--``) runs non-interactively. Runs with inherited stdio so an
+        interactive shell attaches to the real terminal (mirrors ``ssh``).
+        """
+        import subprocess
+        import sys
+
+        cmd = list(getattr(cli_args, 'cmd', None) or [])
+        if cmd and cmd[0] == '--':
+            cmd = cmd[1:]
+        shell = getattr(cli_args, 'shell', None) or 'sh'
+
+        cluster, box = cls._resolve_container_target(cli_args.target)
+        cluster_cfg = cls.config['clusters'][cluster]
+        command = cls._dc_session(cluster).exec_command_for(
+            cluster, cluster_cfg, box, cmd=cmd or None, shell=shell
+        )
+        cls.logger.info(f"exec: {command}")
+        result = subprocess.run(command, shell=True)
+        if result.returncode != 0:
+            sys.exit(result.returncode)
 
     ### end task runner functions ####
 

--- a/src/boxman/providers/docker_compose/compose_runner.py
+++ b/src/boxman/providers/docker_compose/compose_runner.py
@@ -23,6 +23,10 @@ from boxman.utils.shell import run
 #: default per-cluster readiness timeout, seconds (D1)
 DEFAULT_READINESS_TIMEOUT = 120
 
+#: default interactive shell for ``boxman exec`` (POSIX-universal; override
+#: with ``--shell``)
+DEFAULT_EXEC_SHELL = "sh"
+
 
 class ComposeRunner:
     def __init__(
@@ -91,7 +95,45 @@ class ComposeRunner:
         """``docker compose ps`` (captured)."""
         return run(f"{self._base()} ps", hide=True, warn=True)
 
+    def ps_json(self):
+        """``docker compose ps --format json --all`` (captured).
+
+        Compose v2 emits one JSON object per line (newline-delimited); include
+        ``--all`` so stopped/paused services are reported too (for ``ps`` /
+        ``connect_info`` status columns)."""
+        return run(f"{self._base()} ps --all --format json", hide=True, warn=True)
+
+    def pause(self, services: list[str] | None = None):
+        """``docker compose pause`` (whole project, or the given services)."""
+        return run(f"{self._base()} pause{self._svc(services)}", warn=True)
+
+    def unpause(self, services: list[str] | None = None):
+        """``docker compose unpause`` (whole project, or the given services)."""
+        return run(f"{self._base()} unpause{self._svc(services)}", warn=True)
+
+    def exec_command(
+        self, box: str, cmd: list[str] | None = None,
+        shell: str = DEFAULT_EXEC_SHELL,
+    ) -> str:
+        """Build the ``docker compose exec`` command string for *box*.
+
+        With *cmd* → a one-shot ``exec -T <box> <cmd…>`` (``-T`` disables TTY
+        allocation so it works from a non-terminal / script). Without *cmd* →
+        an interactive ``exec <box> <shell>`` (TTY auto-allocated by compose).
+        Returned as a string for the caller to run with inherited stdio (like
+        the ssh path), so the interactive shell attaches to the real terminal.
+        """
+        base = self._base()
+        if cmd:
+            inner = " ".join(shlex.quote(c) for c in cmd)
+            return f"{base} exec -T {shlex.quote(box)} {inner}"
+        return f"{base} exec {shlex.quote(box)} {shlex.quote(shell)}"
+
     # -- internals ---------------------------------------------------------
+
+    @staticmethod
+    def _svc(services: list[str] | None) -> str:
+        return "".join(f" {shlex.quote(s)}" for s in (services or []))
 
     def _base(self) -> str:
         # ``-f`` / ``--project-directory`` are included only when set. A

--- a/src/boxman/providers/docker_compose/compose_runner.py
+++ b/src/boxman/providers/docker_compose/compose_runner.py
@@ -114,26 +114,37 @@ class ComposeRunner:
     def exec_command(
         self, box: str, cmd: list[str] | None = None,
         shell: str = DEFAULT_EXEC_SHELL,
-    ) -> str:
-        """Build the ``docker compose exec`` command string for *box*.
+    ) -> list[str]:
+        """Build the ``docker compose exec`` **argv list** for *box*.
 
         With *cmd* → a one-shot ``exec -T <box> <cmd…>`` (``-T`` disables TTY
         allocation so it works from a non-terminal / script). Without *cmd* →
         an interactive ``exec <box> <shell>`` (TTY auto-allocated by compose).
-        Returned as a string for the caller to run with inherited stdio (like
-        the ssh path), so the interactive shell attaches to the real terminal.
+        Returned as an argv list so the caller runs it with ``shell=False``
+        (no shell injection surface) and inherited stdio, so an interactive
+        shell attaches to the real terminal.
         """
-        base = self._base()
+        argv = self._base_argv() + ["exec"]
         if cmd:
-            inner = " ".join(shlex.quote(c) for c in cmd)
-            return f"{base} exec -T {shlex.quote(box)} {inner}"
-        return f"{base} exec {shlex.quote(box)} {shlex.quote(shell)}"
+            return argv + ["-T", box, *cmd]
+        return argv + [box, shell]
 
     # -- internals ---------------------------------------------------------
 
     @staticmethod
     def _svc(services: list[str] | None) -> str:
         return "".join(f" {shlex.quote(s)}" for s in (services or []))
+
+    def _base_argv(self) -> list[str]:
+        """The ``docker compose -p <project> …`` prefix as an argv list (for
+        commands run with ``shell=False``)."""
+        argv = (["sudo"] if self._sudo else []) + [
+            "docker", "compose", "-p", self.project]
+        if self.compose_file:
+            argv += ["-f", self.compose_file]
+        if self.workdir:
+            argv += ["--project-directory", self.workdir]
+        return argv
 
     def _base(self) -> str:
         # ``-f`` / ``--project-directory`` are included only when set. A

--- a/src/boxman/providers/docker_compose/session.py
+++ b/src/boxman/providers/docker_compose/session.py
@@ -13,6 +13,7 @@ for a docker-compose cluster and raise a clear error if called.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 from typing import Any
@@ -24,6 +25,7 @@ from boxman.providers.docker_compose.compose_generator import (
     resolve_local_path,
 )
 from boxman.providers.docker_compose.compose_runner import (
+    DEFAULT_EXEC_SHELL,
     DEFAULT_READINESS_TIMEOUT,
     ComposeRunner,
 )
@@ -130,6 +132,86 @@ class DockerComposeSession:
                 f"[{cluster_name}] could not remove {compose_file}: {exc}"
             )
         return True
+
+    # -- control / access (Phase 6) ----------------------------------------
+
+    def container_status(
+        self, cluster_name: str, cluster_cfg: dict[str, Any]
+    ) -> list[dict[str, str]]:
+        """Per-service status rows for a dc cluster via ``docker compose ps``.
+
+        Each row: ``{service, name, state, health, ports}``. Empty list when the
+        project has no containers (never provisioned / fully removed). Never
+        raises — a missing project simply reports no rows (uniform with a
+        VM-state query on an unprovisioned VM).
+        """
+        runner, _wd, _cf = self._teardown_runner(cluster_name, cluster_cfg)
+        result = runner.ps_json()
+        rows: list[dict[str, str]] = []
+        if not getattr(result, "ok", False):
+            return rows
+        for line in (getattr(result, "stdout", "") or "").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                parsed = json.loads(line)
+            except ValueError:
+                continue
+            # compose v2 emits NDJSON objects; some builds emit a JSON array
+            for obj in (parsed if isinstance(parsed, list) else [parsed]):
+                rows.append({
+                    "service": obj.get("Service", ""),
+                    "name": obj.get("Name", ""),
+                    "state": obj.get("State", ""),
+                    "health": obj.get("Health", ""),
+                    "ports": _format_ports(obj.get("Publishers")),
+                })
+        return rows
+
+    def exec_command_for(
+        self, cluster_name: str, cluster_cfg: dict[str, Any], box: str,
+        cmd: list[str] | None = None, shell: str = DEFAULT_EXEC_SHELL,
+    ) -> str:
+        """Validate *box* and return the ``docker compose exec`` command string.
+
+        The caller runs it with inherited stdio (interactive shell) — so this
+        only builds and validates, it does not execute. ``ConfigError`` if
+        *box* is not a service of this cluster.
+        """
+        boxes = cluster_cfg.get("boxes") or {}
+        if box not in boxes:
+            raise ConfigError(
+                f"box '{box}' is not a service in docker-compose cluster "
+                f"'{cluster_name}' (services: {', '.join(boxes) or 'none'})."
+            )
+        runner, _wd, _cf = self._teardown_runner(cluster_name, cluster_cfg)
+        return runner.exec_command(box, cmd=cmd, shell=shell)
+
+    def pause_cluster(
+        self, cluster_name: str, cluster_cfg: dict[str, Any],
+        boxes: list[str] | None = None,
+    ) -> bool:
+        """boxman control suspend → ``docker compose pause`` (whole cluster or
+        the named boxes)."""
+        runner, _wd, _cf = self._teardown_runner(cluster_name, cluster_cfg)
+        self.logger.info(
+            f"[{cluster_name}] docker compose pause"
+            f"{''.join(' ' + b for b in (boxes or []))}"
+        )
+        return self._check(cluster_name, "pause", runner.pause(boxes))
+
+    def unpause_cluster(
+        self, cluster_name: str, cluster_cfg: dict[str, Any],
+        boxes: list[str] | None = None,
+    ) -> bool:
+        """boxman control resume → ``docker compose unpause``."""
+        runner, _wd, _cf = self._teardown_runner(cluster_name, cluster_cfg)
+        self.logger.info(
+            f"[{cluster_name}] docker compose unpause"
+            f"{''.join(' ' + b for b in (boxes or []))}"
+        )
+        return self._check(cluster_name, "unpause", runner.unpause(boxes))
 
     def _check(self, cluster_name: str, op: str, result: Any) -> bool:
         """Warn (don't raise) when a best-effort teardown op did not succeed.
@@ -365,6 +447,23 @@ class DockerComposeSession:
 
     def snapshot_list(self, vm_name: str | None = None) -> list[dict[str, str]]:
         self._cluster_scoped("snapshot_list")
+
+
+def _format_ports(publishers: Any) -> str:
+    """Compact ``hostport->targetport`` string from a compose ps ``Publishers``
+    list (or pass through a plain string / empty)."""
+    if not isinstance(publishers, list):
+        return str(publishers or "")
+    parts: list[str] = []
+    for pub in publishers:
+        if not isinstance(pub, dict):
+            continue
+        published, target = pub.get("PublishedPort"), pub.get("TargetPort")
+        if published:
+            parts.append(f"{published}->{target}")
+        elif target:
+            parts.append(str(target))
+    return ", ".join(parts)
 
 
 def _sanitize_project_name(name: str) -> str:

--- a/src/boxman/providers/docker_compose/session.py
+++ b/src/boxman/providers/docker_compose/session.py
@@ -141,13 +141,19 @@ class DockerComposeSession:
         """Per-service status rows for a dc cluster via ``docker compose ps``.
 
         Each row: ``{service, name, state, health, ports}``. Empty list when the
-        project has no containers (never provisioned / fully removed). Never
-        raises — a missing project simply reports no rows (uniform with a
-        VM-state query on an unprovisioned VM).
+        project has no containers (never provisioned / fully removed) — or when
+        the cluster is misconfigured (e.g. no ``workdir``). Never raises, so the
+        display verbs (``ps``/``connect_info``) can't be broken by a status
+        probe (uniform with a VM-state query on an unprovisioned VM).
         """
-        runner, _wd, _cf = self._teardown_runner(cluster_name, cluster_cfg)
-        result = runner.ps_json()
         rows: list[dict[str, str]] = []
+        try:
+            runner, _wd, _cf = self._teardown_runner(cluster_name, cluster_cfg)
+        except ConfigError as exc:
+            self.logger.warning(
+                f"[{cluster_name}] cannot query container status: {exc}")
+            return rows
+        result = runner.ps_json()
         if not getattr(result, "ok", False):
             return rows
         for line in (getattr(result, "stdout", "") or "").splitlines():
@@ -189,29 +195,20 @@ class DockerComposeSession:
         return runner.exec_command(box, cmd=cmd, shell=shell)
 
     def pause_cluster(
-        self, cluster_name: str, cluster_cfg: dict[str, Any],
-        boxes: list[str] | None = None,
+        self, cluster_name: str, cluster_cfg: dict[str, Any]
     ) -> bool:
-        """boxman control suspend → ``docker compose pause`` (whole cluster or
-        the named boxes)."""
+        """boxman control suspend → ``docker compose pause`` (whole cluster)."""
         runner, _wd, _cf = self._teardown_runner(cluster_name, cluster_cfg)
-        self.logger.info(
-            f"[{cluster_name}] docker compose pause"
-            f"{''.join(' ' + b for b in (boxes or []))}"
-        )
-        return self._check(cluster_name, "pause", runner.pause(boxes))
+        self.logger.info(f"[{cluster_name}] docker compose pause")
+        return self._check(cluster_name, "pause", runner.pause())
 
     def unpause_cluster(
-        self, cluster_name: str, cluster_cfg: dict[str, Any],
-        boxes: list[str] | None = None,
+        self, cluster_name: str, cluster_cfg: dict[str, Any]
     ) -> bool:
-        """boxman control resume → ``docker compose unpause``."""
+        """boxman control resume → ``docker compose unpause`` (whole cluster)."""
         runner, _wd, _cf = self._teardown_runner(cluster_name, cluster_cfg)
-        self.logger.info(
-            f"[{cluster_name}] docker compose unpause"
-            f"{''.join(' ' + b for b in (boxes or []))}"
-        )
-        return self._check(cluster_name, "unpause", runner.unpause(boxes))
+        self.logger.info(f"[{cluster_name}] docker compose unpause")
+        return self._check(cluster_name, "unpause", runner.unpause())
 
     def _check(self, cluster_name: str, op: str, result: Any) -> bool:
         """Warn (don't raise) when a best-effort teardown op did not succeed.
@@ -385,8 +382,7 @@ class DockerComposeSession:
     def _compose_project(self, cluster_name: str) -> str:
         """Derive the ``docker compose -p`` name — one project per cluster
         (ADR-001), so clusters never share compose state."""
-        base = self._provider_config.get("project_name") or self.config.get("project") or "boxman"
-        return _sanitize_project_name(f"{base}_{cluster_name}")
+        return compose_project_name(self.config, cluster_name)
 
     def _require_local_runtime(self, cluster_name: str) -> None:
         """Defense-in-depth: the docker-compose provider requires
@@ -464,6 +460,16 @@ def _format_ports(publishers: Any) -> str:
         elif target:
             parts.append(str(target))
     return ", ".join(parts)
+
+
+def compose_project_name(config: dict[str, Any], cluster_name: str) -> str:
+    """The ``docker compose -p`` project name for a dc cluster — the single
+    source of truth shared by :meth:`DockerComposeSession._compose_project`
+    (compose ops) and ``BoxmanManager._compose_project_for`` (inventory
+    ``ansible_host`` derivation), so the two can never drift apart."""
+    dc = (config.get("provider") or {}).get("docker-compose") or {}
+    base = dc.get("project_name") or config.get("project") or "boxman"
+    return _sanitize_project_name(f"{base}_{cluster_name}")
 
 
 def _sanitize_project_name(name: str) -> str:

--- a/src/boxman/scripts/app.py
+++ b/src/boxman/scripts/app.py
@@ -426,6 +426,16 @@ def _main():
         args.func(manager, args)
         sys.exit(0)
 
+    # Handle 'exec' — container access; needs config but not the full libvirt
+    # provider setup (the dc session is created on demand via _dc_session).
+    if args.func == BoxmanManager.exec_container:
+        manager = BoxmanManager(config=args.conf)
+        if not manager.config:
+            log.error("no project config found (conf.yml)")
+            sys.exit(1)
+        args.func(manager, args)
+        sys.exit(0)
+
     else:
         # use the config of a deployment specified on the cmd line only if
         # not importing an image

--- a/src/boxman/scripts/cli_parser.py
+++ b/src/boxman/scripts/cli_parser.py
@@ -834,6 +834,13 @@ def parse_args():
         dest='vms',
         default='all'
     )
+    parser_ctrl_suspend.add_argument(
+        '--cluster',
+        type=str,
+        default=None,
+        dest='cluster',
+        help='restrict to a single cluster (honoured for docker-compose clusters)'
+    )
 
     #
     # sub parser for the 'control resume' subsubcommand
@@ -846,6 +853,13 @@ def parse_args():
         help='the names of the vms as a csv list',
         dest='vms',
         default='all'
+    )
+    parser_ctrl_resume.add_argument(
+        '--cluster',
+        type=str,
+        default=None,
+        dest='cluster',
+        help='restrict to a single cluster (honoured for docker-compose clusters)'
     )
 
     #
@@ -860,6 +874,13 @@ def parse_args():
         dest='vms',
         default='all'
     )
+    parser_ctrl_save.add_argument(
+        '--cluster',
+        type=str,
+        default=None,
+        dest='cluster',
+        help='restrict to a single cluster (honoured for docker-compose clusters)'
+    )
 
     #
     # sub parser for the 'control start' subsubcommand
@@ -872,6 +893,13 @@ def parse_args():
         help='the names of the vms as a csv list',
         dest='vms',
         default='all'
+    )
+    parser_ctrl_start.add_argument(
+        '--cluster',
+        type=str,
+        default=None,
+        dest='cluster',
+        help='restrict to a single cluster (honoured for docker-compose clusters)'
     )
     parser_ctrl_start.add_argument(
         '--restore',
@@ -1110,8 +1138,9 @@ def parse_args():
     )
     parser_exec.add_argument(
         'cmd',
-        nargs=argparse.REMAINDER,
-        help='command to run non-interactively (after `--`)'
+        nargs='*',
+        help='command to run non-interactively (put it after `--` if it has '
+             'its own flags, e.g. `-- ls -la`)'
     )
 
     # ── pxe-boot ─────────────────────────────────────────────────────

--- a/src/boxman/scripts/cli_parser.py
+++ b/src/boxman/scripts/cli_parser.py
@@ -1077,6 +1077,43 @@ def parse_args():
         dest='cluster'
     )
 
+    # ── exec ─────────────────────────────────────────────────────────
+    parser_exec = subparsers.add_parser(
+        'exec',
+        help='exec into a docker-compose container',
+        description=(
+            "Run a command in (or open an interactive shell on) a\n"
+            "docker-compose container, via `docker compose exec`.\n"
+            "\n"
+            "Target is <cluster>.<box>. With no command an interactive\n"
+            "shell (default: sh) is opened; a trailing command after `--`\n"
+            "runs non-interactively. Use `ssh` for libvirt VMs.\n"
+            "\n"
+            "examples:\n"
+            "    $ boxman exec services.web\n"
+            "    $ boxman exec services.web --shell bash\n"
+            "    $ boxman exec services.cache -- redis-cli ping\n"
+        ),
+        formatter_class=RawTextHelpFormatter
+    )
+    parser_exec.set_defaults(func=BoxmanManager.exec_container)
+    parser_exec.add_argument(
+        'target',
+        type=str,
+        help='container to exec into, as <cluster>.<box>'
+    )
+    parser_exec.add_argument(
+        '--shell',
+        type=str,
+        default=None,
+        help='interactive shell to open when no command is given (default: sh)'
+    )
+    parser_exec.add_argument(
+        'cmd',
+        nargs=argparse.REMAINDER,
+        help='command to run non-interactively (after `--`)'
+    )
+
     # ── pxe-boot ─────────────────────────────────────────────────────
     parser_pxe = subparsers.add_parser(
         'pxe-boot',

--- a/tests/test_docker_compose_provider.py
+++ b/tests/test_docker_compose_provider.py
@@ -700,10 +700,14 @@ class TestComposeRunner:
 
     # -- Phase 6: exec / pause / ps ------------------------------------
     def test_exec_command_interactive_and_cmd(self):
-        r = self._runner()
-        assert r.exec_command("web").endswith("exec web sh")
-        assert "exec -T web redis-cli ping" in r.exec_command("web", ["redis-cli", "ping"])
-        assert r.exec_command("web", shell="bash").endswith("exec web bash")
+        r = self._runner()  # project proj_stack, file /wd/docker-compose.yml, wd /wd
+        assert r.exec_command("web") == [
+            "docker", "compose", "-p", "proj_stack",
+            "-f", "/wd/docker-compose.yml", "--project-directory", "/wd",
+            "exec", "web", "sh"]
+        assert r.exec_command("web", ["redis-cli", "ping"])[-4:] == [
+            "-T", "web", "redis-cli", "ping"]
+        assert r.exec_command("web", shell="bash")[-2:] == ["web", "bash"]
 
     def test_pause_unpause_commands(self):
         r = self._runner()
@@ -772,7 +776,7 @@ class _FakeRunner:
 
     def exec_command(self, box, cmd=None, shell="sh"):
         self.calls.append(("exec_command", box, cmd, shell))
-        return f"COMPOSE exec {box} {cmd or shell}"
+        return ["compose", "exec", box, *(cmd or [shell])]
 
 
 class TestDockerComposeSession:
@@ -977,9 +981,9 @@ class TestDockerComposeSession:
         runner = _FakeRunner()
         with self._patch_teardown(session, runner):
             session.pause_cluster("services", {})
-            session.unpause_cluster("services", {}, boxes=["web"])
+            session.unpause_cluster("services", {})
         assert ("pause", None) in runner.calls
-        assert ("unpause", ["web"]) in runner.calls
+        assert ("unpause", None) in runner.calls
 
     def test_require_local_runtime_guardrail(self):
         session = self._session(runtime="docker-compose")
@@ -1209,14 +1213,16 @@ class TestPhase6CliParity:
     def test_exec_container_builds_and_runs(self):
         m = self._mgr()
         sess = mock.Mock()
-        sess.exec_command_for.return_value = "docker compose exec web sh"
-        m.session_for_cluster = lambda c: sess
+        sess.exec_command_for.return_value = ["docker", "compose", "exec", "web", "sh"]
+        m._dc_session = lambda c: sess
         args = SimpleNamespace(target="services.web", cmd=[], shell=None)
         with mock.patch("subprocess.run",
                         return_value=SimpleNamespace(returncode=0)) as sp:
             BoxmanManager.exec_container(m, args)
         assert sess.exec_command_for.call_args.args[:3] == ("services", m.config["clusters"]["services"], "web")
-        assert sp.call_args.args[0] == "docker compose exec web sh"
+        # runs the argv LIST with shell=False (no shell=True kwarg)
+        assert sp.call_args.args[0] == ["docker", "compose", "exec", "web", "sh"]
+        assert sp.call_args.kwargs.get("shell") in (None, False)
 
     # -- control -------------------------------------------------------
     def test_control_suspend_pauses_dc(self):
@@ -1241,6 +1247,38 @@ class TestPhase6CliParity:
         with mock.patch.object(m.logger, "warning") as warn:
             BoxmanManager.save_vm(m, SimpleNamespace())
         assert any("not supported" in str(c.args[0]) for c in warn.call_args_list)
+
+    def test_control_suspend_honors_cluster_scope(self):
+        """--cluster scopes the dc control op to that cluster only."""
+        m = self._mgr({"other": {"provider": "docker-compose", "boxes": {"z": {}}}})
+        paused = []
+        sess = mock.Mock()
+        sess.pause_cluster.side_effect = lambda name, cfg: paused.append(name)
+        m._dc_session = lambda c: sess
+        m.process_vm_list = lambda a: []
+        BoxmanManager.suspend_vm(m, SimpleNamespace(cluster="other"))
+        assert paused == ["other"]      # 'services' left running
+
+    def test_compose_project_for_matches_session(self):
+        """The manager's inventory derivation and the session's compose-op
+        derivation are single-sourced — they must agree."""
+        m = self._mgr()
+        session = create_session("docker-compose", m.config)
+        assert m._compose_project_for("services") == session._compose_project("services")
+
+    # -- exec parser (regression: --shell after the target) ------------
+    def test_exec_parser_shell_after_target(self):
+        from boxman.scripts.cli_parser import parse_args
+        parser = parse_args()
+        a, _ = parser.parse_known_args(["exec", "services.web", "--shell", "bash"])
+        assert a.target == "services.web" and a.shell == "bash" and a.cmd == []
+
+    def test_exec_parser_command_after_separator(self):
+        from boxman.scripts.cli_parser import parse_args
+        parser = parse_args()
+        a, _ = parser.parse_known_args(
+            ["exec", "services.web", "--", "redis-cli", "ping"])
+        assert a.target == "services.web" and a.cmd == ["redis-cli", "ping"]
 
     # -- ps ------------------------------------------------------------
     def test_ps_includes_containers(self, capsys):

--- a/tests/test_docker_compose_provider.py
+++ b/tests/test_docker_compose_provider.py
@@ -698,6 +698,36 @@ class TestComposeRunner:
         ):
             runner.preflight()  # no raise
 
+    # -- Phase 6: exec / pause / ps ------------------------------------
+    def test_exec_command_interactive_and_cmd(self):
+        r = self._runner()
+        assert r.exec_command("web").endswith("exec web sh")
+        assert "exec -T web redis-cli ping" in r.exec_command("web", ["redis-cli", "ping"])
+        assert r.exec_command("web", shell="bash").endswith("exec web bash")
+
+    def test_pause_unpause_commands(self):
+        r = self._runner()
+        with mock.patch(
+            "boxman.providers.docker_compose.compose_runner.run",
+            return_value=_ok(),
+        ) as run:
+            r.pause()
+            r.pause(["web"])
+            r.unpause()
+        cmds = [c.args[0] for c in run.call_args_list]
+        assert any(c.endswith(" pause") for c in cmds)
+        assert any(c.endswith(" pause web") for c in cmds)
+        assert any(c.endswith(" unpause") for c in cmds)
+
+    def test_ps_json_command(self):
+        r = self._runner()
+        with mock.patch(
+            "boxman.providers.docker_compose.compose_runner.run",
+            return_value=_ok("{}"),
+        ) as run:
+            r.ps_json()
+        assert "ps --all --format json" in run.call_args_list[0].args[0]
+
 
 # --------------------------------------------------------------------------
 # DockerComposeSession
@@ -708,6 +738,7 @@ class _FakeRunner:
     def __init__(self):
         self.project = "proj_stack"
         self.calls: list = []
+        self.ps_json_result = _ok("")
 
     def preflight(self):
         self.calls.append(("preflight",))
@@ -726,6 +757,22 @@ class _FakeRunner:
 
     def start(self):
         self.calls.append(("start",))
+
+    def pause(self, services=None):
+        self.calls.append(("pause", services))
+        return _ok()
+
+    def unpause(self, services=None):
+        self.calls.append(("unpause", services))
+        return _ok()
+
+    def ps_json(self):
+        self.calls.append(("ps_json",))
+        return self.ps_json_result
+
+    def exec_command(self, box, cmd=None, shell="sh"):
+        self.calls.append(("exec_command", box, cmd, shell))
+        return f"COMPOSE exec {box} {cmd or shell}"
 
 
 class TestDockerComposeSession:
@@ -889,6 +936,50 @@ class TestDockerComposeSession:
         session = self._session()
         with pytest.raises(ConfigError, match=r"no 'workdir:'"):
             session._teardown_runner("app", {})
+
+    # -- Phase 6: exec / status / pause -----------------------------------
+    def test_exec_command_for_valid_box(self):
+        session = self._session()
+        runner = _FakeRunner()
+        with self._patch_teardown(session, runner):
+            session.exec_command_for(
+                "services", {"boxes": {"web": {}}}, "web", cmd=["ls"])
+        assert ("exec_command", "web", ["ls"], "sh") in runner.calls
+
+    def test_exec_command_for_unknown_box_raises(self):
+        session = self._session()
+        with pytest.raises(ConfigError, match=r"not a service"):
+            session.exec_command_for("services", {"boxes": {"web": {}}}, "nope")
+
+    def test_container_status_parses_ps_json(self):
+        session = self._session()
+        runner = _FakeRunner()
+        runner.ps_json_result = _ok(
+            '{"Service":"web","Name":"p-web-1","State":"running",'
+            '"Health":"healthy","Publishers":[{"PublishedPort":8080,"TargetPort":80}]}\n'
+            '{"Service":"db","Name":"p-db-1","State":"exited","Health":"","Publishers":[]}'
+        )
+        with self._patch_teardown(session, runner):
+            rows = session.container_status("services", {"boxes": {}})
+        assert rows[0] == {"service": "web", "name": "p-web-1", "state": "running",
+                           "health": "healthy", "ports": "8080->80"}
+        assert rows[1]["service"] == "db" and rows[1]["ports"] == ""
+
+    def test_container_status_empty_on_failure(self):
+        session = self._session()
+        runner = _FakeRunner()
+        runner.ps_json_result = _fail()
+        with self._patch_teardown(session, runner):
+            assert session.container_status("services", {"boxes": {}}) == []
+
+    def test_pause_unpause_cluster(self):
+        session = self._session()
+        runner = _FakeRunner()
+        with self._patch_teardown(session, runner):
+            session.pause_cluster("services", {})
+            session.unpause_cluster("services", {}, boxes=["web"])
+        assert ("pause", None) in runner.calls
+        assert ("unpause", ["web"]) in runner.calls
 
     def test_require_local_runtime_guardrail(self):
         session = self._session(runtime="docker-compose")
@@ -1071,6 +1162,110 @@ class TestManagerDispatch:
         assert set(manager._compose_clusters) == {"svc"}
         manager.provision_compose_clusters()
         assert dc.calls == [("up", "svc")]
+
+
+# --------------------------------------------------------------------------
+# Phase 6 — CLI/UX parity (exec, ps, control, inventory) for dc clusters
+# --------------------------------------------------------------------------
+class TestPhase6CliParity:
+
+    def _mgr(self, extra_clusters=None):
+        import logging
+        m = BoxmanManager.__new__(BoxmanManager)
+        m.logger = logging.getLogger("boxman")
+        m.app_config = {}
+        m.config = {
+            "project": "demo",
+            "provider": {"docker-compose": {}},
+            "clusters": {
+                "services": {"provider": "docker-compose",
+                             "boxes": {"web": {"image": "x"}, "cache": {"image": "y"}}},
+            },
+        }
+        if extra_clusters:
+            m.config["clusters"].update(extra_clusters)
+        return m
+
+    # -- target resolution --------------------------------------------
+    def test_resolve_target_dotted(self):
+        assert self._mgr()._resolve_container_target("services.web") == ("services", "web")
+
+    def test_resolve_target_bare_unique(self):
+        assert self._mgr()._resolve_container_target("cache") == ("services", "cache")
+
+    def test_resolve_target_libvirt_rejected(self):
+        m = self._mgr({"compute": {"provider": "libvirt", "vms": {"node01": {}}}})
+        with pytest.raises(ConfigError, match="libvirt"):
+            m._resolve_container_target("compute.node01")
+
+    def test_resolve_target_unknown_rejected(self):
+        with pytest.raises(ConfigError, match="no docker-compose container"):
+            self._mgr()._resolve_container_target("nope")
+
+    def test_compose_project_for(self):
+        assert self._mgr()._compose_project_for("services") == "demo_services"
+
+    # -- exec verb -----------------------------------------------------
+    def test_exec_container_builds_and_runs(self):
+        m = self._mgr()
+        sess = mock.Mock()
+        sess.exec_command_for.return_value = "docker compose exec web sh"
+        m.session_for_cluster = lambda c: sess
+        args = SimpleNamespace(target="services.web", cmd=[], shell=None)
+        with mock.patch("subprocess.run",
+                        return_value=SimpleNamespace(returncode=0)) as sp:
+            BoxmanManager.exec_container(m, args)
+        assert sess.exec_command_for.call_args.args[:3] == ("services", m.config["clusters"]["services"], "web")
+        assert sp.call_args.args[0] == "docker compose exec web sh"
+
+    # -- control -------------------------------------------------------
+    def test_control_suspend_pauses_dc(self):
+        m = self._mgr()
+        sess = mock.Mock()
+        m.session_for_cluster = lambda c: sess
+        m.process_vm_list = lambda a: []
+        BoxmanManager.suspend_vm(m, SimpleNamespace())
+        sess.pause_cluster.assert_called_once()
+
+    def test_control_resume_unpauses_dc(self):
+        m = self._mgr()
+        sess = mock.Mock()
+        m.session_for_cluster = lambda c: sess
+        m.process_vm_list = lambda a: []
+        BoxmanManager.resume_vm(m, SimpleNamespace())
+        sess.unpause_cluster.assert_called_once()
+
+    def test_control_save_dc_warns_not_raises(self):
+        m = self._mgr()
+        m.process_vm_list = lambda a: []
+        with mock.patch.object(m.logger, "warning") as warn:
+            BoxmanManager.save_vm(m, SimpleNamespace())
+        assert any("not supported" in str(c.args[0]) for c in warn.call_args_list)
+
+    # -- ps ------------------------------------------------------------
+    def test_ps_includes_containers(self, capsys):
+        m = self._mgr()
+        sess = mock.Mock()
+        sess.container_status.return_value = [
+            {"service": "web", "name": "demo_services-web-1", "state": "running",
+             "health": "healthy", "ports": ""},
+        ]
+        m.session_for_cluster = lambda c: sess
+        BoxmanManager.ps(m, SimpleNamespace(provider_info=False, json=False))
+        out = capsys.readouterr().out
+        assert "docker-compose" in out and "web" in out and "running (healthy)" in out
+
+    # -- inventory -----------------------------------------------------
+    def test_inventory_includes_dc_containers(self):
+        m = self._mgr()
+        m.config["workspace"] = {"path": "/tmp/ws"}
+        m.resolve_workspace_defaults()
+        inv = yaml.safe_load(
+            m.config["workspace"]["files"]["inventory/01-hosts.yml"])
+        web = inv["all"]["hosts"]["services_web"]
+        assert web["ansible_connection"] == "community.docker.docker"
+        assert web["ansible_host"] == "demo_services-web-1"
+        assert "services" in inv["all"]["children"]
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Phase 6 of the docker-compose provider epic (#42). Closes #54.
Base: `feat/docker-compose-provider`.

## What this does
Makes every boxman verb treat a mixed libvirt + docker-compose project
uniformly — containers show up alongside VMs and no verb tracebacks on an
unsupported op.

## New verb: `boxman exec`
`boxman exec <cluster>.<box>` runs `docker compose exec` on a container: an
interactive shell (default `sh`, `--shell bash`) or a one-shot command after
`--` (`boxman exec services.cache -- redis-cli ping`). A bare `<box>` works
when unique across dc clusters. `boxman ssh` stays VM-only.

> **Revises decision D2** (which had `ssh` transparently docker-exec): a
> distinct `exec` verb reads clearer than overloading `ssh`. D2 + AC17 updated
> in `design.md`.

## Verb parity
- **`ps`** — containers listed with a `Provider` column + live `State`/health;
  a dc-only project skips the virsh query.
- **`connect_info`** — per-container section: status, published ports, the
  `boxman exec` entry point.
- **Inventory / `run` / `tasks`** — containers become Ansible hosts with
  `ansible_connection: community.docker.docker` + `ansible_host:
  <project>-<box>-1`, grouped per cluster; `env.sh`/`ansible.cfg` now generated
  for dc-only projects. So `boxman run --cmd '…'` and `tasks:` hit containers
  and VMs alike. **Prereq:** the `community.docker` collection + Docker SDK on
  the control host (documented).
- **`control`** — `suspend`→`pause`, `resume`→`unpause`, `start`→`start`;
  `save` logs a clean "unsupported" message and skips dc clusters.

## Design call: `list`
`boxman list` stays a **config-free cross-project registry** view (loading
every registered project's config there would add fragility). Per-cluster
provider + container status for the current project is surfaced by
`ps`/`connect_info`. Happy to add a cached provider column if you'd prefer it
in `list`.

## Testing
- **Host unit:** 1295 passed (+19: exec command build + target resolution, ps
  container rows, control dc branch, `container_status` parsing, pause/unpause,
  inventory `community.docker` entries). VM inventory/ps output preserved.
- **Live e2e in stage01** (dc-only, pure docker):
  - **AC16** `boxman ps` shows containers with provider + running/healthy state
  - **AC17** `boxman exec services.cache -- redis-cli ping` → `PONG`; `nginx -v`
  - **AC18** `ansible all -m raw` reaches **both** containers via the
    boxman-generated inventory + `community.docker`
  - `control suspend`→paused / `resume`→running / `save`→clean message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
