### PR TITLE
feat(snapshot): add --force/--overwrite/--replace to snapshot take

### DIFF
--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -4022,6 +4022,7 @@ class BoxmanManager:
 
         compress_memory = getattr(cli_args, 'compress_memory', False)
         compress_level = getattr(cli_args, 'memory_compress_level', 3)
+        force = getattr(cli_args, 'force', False)
 
         def _take(full_vm_name, vm_dir, snapshot_name, description):
             cls.provider.snapshot_take(
@@ -4030,7 +4031,8 @@ class BoxmanManager:
                 snapshot_name=snapshot_name,
                 description=description,
                 compress_memory=compress_memory,
-                compress_level=compress_level)
+                compress_level=compress_level,
+                force=force)
 
         processes = [
             Process(target=_take, args=(full_vm_name, vm_dir,

--- a/src/boxman/providers/libvirt/session.py
+++ b/src/boxman/providers/libvirt/session.py
@@ -880,7 +880,8 @@ class LibVirtSession:
                       snapshot_name=None,
                       description=None,
                       compress_memory: bool = False,
-                      compress_level: int = 3):
+                      compress_level: int = 3,
+                      force: bool = False):
         """
         Create a snapshot of a specific VM
 
@@ -893,6 +894,9 @@ class LibVirtSession:
                 a successful snapshot. The next ``snapshot restore``
                 decompresses it transparently.
             compress_level: zstd level (default 3).
+            force: overwrite an existing snapshot of the same name (and
+                clear any leftover overlay/memory files from a prior
+                deletion) instead of failing on a name collision.
 
         Returns:
             bool: True if successful, False otherwise
@@ -906,7 +910,8 @@ class LibVirtSession:
             snapshot_name=snapshot_name,
             description=description,
             compress_memory=compress_memory,
-            compress_level=compress_level)
+            compress_level=compress_level,
+            force=force)
 
     def snapshot_log_data(self, vm_name: str) -> dict:
         """

--- a/src/boxman/providers/libvirt/snapshot.py
+++ b/src/boxman/providers/libvirt/snapshot.py
@@ -140,7 +140,8 @@ class SnapshotManager:
                         snapshot_name: str,
                         description: str,
                         compress_memory: bool = False,
-                        compress_level: int = 3) -> bool:
+                        compress_level: int = 3,
+                        force: bool = False) -> bool:
         """
         Create a snapshot of a VM.
 
@@ -156,11 +157,19 @@ class SnapshotManager:
                 decompresses transparently.
             compress_level: zstd compression level (default 3 — sweet spot
                 of ~71% reduction at sub-second/GB on commodity CPUs).
+            force: If True, first clear anything that would make
+                *snapshot_name* collide — an existing libvirt snapshot with
+                that name, or orphaned per-disk overlay / memory files a
+                prior deletion left behind — so the name can be re-used.
+                See :meth:`_force_clear_for_retake`.
 
         Returns:
             bool: True if successful, False otherwise
         """
         try:
+            if force and not self._force_clear_for_retake(
+                    vm_name, vm_dir, snapshot_name):
+                return False
             # Before saving memory state, ensure cdroms point directly at
             # their raw ISO backing files (not qcow2 overlays of them).
             # This prevents snapshot-revert from failing with
@@ -195,6 +204,80 @@ class SnapshotManager:
         except Exception as exc:
             self.logger.error(f"error creating snapshot for vm {vm_name}: {exc}")
             return False
+
+    def _would_be_overlay_paths(self,
+                                vm_name: str,
+                                snapshot_name: str) -> list[str]:
+        """
+        Predict the overlay file ``snapshot-create-as`` would create for
+        each data disk of *vm_name*.
+
+        With no explicit ``file=`` in the diskspec, libvirt derives the new
+        external-overlay path from the disk's *current* source by dropping
+        its final suffix and appending ``.<snapshot_name>`` — e.g. a live
+        source ``…_provider01.qcow2`` (or ``…_provider01.1785187648``)
+        yields ``…_provider01.<snapshot_name>``. A stale file at that exact
+        path is what triggers libvirt's "external snapshot file … already
+        exists and is not a block device" error on a re-take.
+        """
+        paths = []
+        for _target, source in self._data_disk_targets(vm_name):
+            if not source or source == '-':
+                continue
+            stem = os.path.splitext(source)[0]
+            paths.append(f"{stem}.{snapshot_name}")
+        return paths
+
+    def _force_clear_for_retake(self,
+                                vm_name: str,
+                                vm_dir: str,
+                                snapshot_name: str) -> bool:
+        """
+        Remove anything that would make a fresh snapshot named
+        *snapshot_name* collide, so ``snapshot take --force`` can re-use the
+        name. Two cases:
+
+        1. A live libvirt snapshot with that name still exists → delete it
+           properly via :meth:`delete_snapshot` (blockcommit/collapse merges
+           its overlay back into base). If that delete fails (e.g. it is a
+           buried, non-most-recent snapshot), abort rather than overwrite.
+        2. The snapshot was already deleted but its per-disk overlay files
+           and/or memory ``.raw``/``.raw.zst`` were left on disk (the orphan
+           case that produced the "file already exists" error) → remove those
+           files.
+
+        Files that are part of the VM's *current* active disk chain are never
+        removed. Returns True when the name is clear to re-use.
+        """
+        info = self.virsh.execute(
+            "snapshot-info", vm_name, snapshot_name, warn=True)
+        if info.ok:
+            self.logger.info(
+                f"--force: removing existing snapshot '{snapshot_name}' on "
+                f"{vm_name} before re-taking")
+            if not self.delete_snapshot(vm_name, snapshot_name):
+                self.logger.error(
+                    f"--force: could not remove existing snapshot "
+                    f"'{snapshot_name}' on {vm_name}; refusing to overwrite")
+                return False
+
+        active = {src for _t, src in self._data_disk_targets(vm_name)}
+        removed = []
+        candidates = list(self._would_be_overlay_paths(vm_name, snapshot_name))
+        snap_fname = f"{vm_name}_snapshot_{snapshot_name}.raw"
+        candidates.append(os.path.join(vm_dir, snap_fname))
+        candidates.append(os.path.join(vm_dir, f"{snap_fname}.zst"))
+        for path in candidates:
+            if path in active:
+                continue  # in the live chain — never remove
+            if os.path.isfile(path):
+                self.virsh.execute_shell(f"rm -f '{path}'", warn=True)
+                removed.append(path)
+        if removed:
+            self.logger.info(
+                f"--force: removed {len(removed)} leftover snapshot file(s) "
+                f"for '{snapshot_name}' on {vm_name}")
+        return True
 
     # ── memory file compression (zstd) ──────────────────────────────────
     #

--- a/src/boxman/providers/libvirt/snapshot.py
+++ b/src/boxman/providers/libvirt/snapshot.py
@@ -5,6 +5,7 @@ This module provides functionality to manage VM snapshots using command-line too
 """
 
 import os
+import shlex
 import time
 from typing import Any
 from xml.etree import ElementTree as ET
@@ -228,6 +229,19 @@ class SnapshotManager:
             paths.append(f"{stem}.{snapshot_name}")
         return paths
 
+    @staticmethod
+    def _snapshot_info_reports_absent(stderr: str | None) -> bool:
+        """
+        Whether a failed ``snapshot-info`` clearly means the snapshot does
+        not exist (vs. a transient/connectivity error). libvirt reports a
+        missing snapshot as e.g. "Domain snapshot not found: no domain
+        snapshot with matching name 'X'".
+        """
+        text = (stderr or "").lower()
+        return any(marker in text for marker in (
+            "not found", "no domain snapshot", "no snapshot",
+            "does not exist"))
+
     def _force_clear_for_retake(self,
                                 vm_name: str,
                                 vm_dir: str,
@@ -260,6 +274,17 @@ class SnapshotManager:
                     f"--force: could not remove existing snapshot "
                     f"'{snapshot_name}' on {vm_name}; refusing to overwrite")
                 return False
+        elif not self._snapshot_info_reports_absent(info.stderr):
+            # snapshot-info failed for a reason other than "snapshot does not
+            # exist" (libvirt connectivity, auth, a transient error). We can't
+            # tell whether the snapshot is really there, so removing candidate
+            # files risks deleting a live snapshot's overlay/memory — abort.
+            self.logger.error(
+                f"--force: cannot determine whether snapshot "
+                f"'{snapshot_name}' exists on {vm_name} (snapshot-info "
+                f"failed: {(info.stderr or '').strip()}); refusing to "
+                f"remove any files")
+            return False
 
         active = {src for _t, src in self._data_disk_targets(vm_name)}
         removed = []
@@ -271,7 +296,8 @@ class SnapshotManager:
             if path in active:
                 continue  # in the live chain — never remove
             if os.path.isfile(path):
-                self.virsh.execute_shell(f"rm -f '{path}'", warn=True)
+                self.virsh.execute_shell(
+                    f"rm -f -- {shlex.quote(path)}", warn=True)
                 removed.append(path)
         if removed:
             self.logger.info(

--- a/src/boxman/scripts/cli_parser.py
+++ b/src/boxman/scripts/cli_parser.py
@@ -73,6 +73,10 @@ def parse_args():
             "       # snapshot and set a name for the snapshot (all vms get the same snapshot name)\n"
             "       $ boxman snapshot take --name=mystate1\n"
             "\n"
+            "       # overwrite a snapshot name that already exists (or whose\n"
+            "       # files linger from a prior deletion)\n"
+            "       $ boxman snapshot take --name=mystate1 --force\n"
+            "\n"
             "     restore\n"
             "       # restore all vms in the default config file\n"
             "       $ boxman snapshot restore --name=mystate1\n"
@@ -488,6 +492,15 @@ def parse_args():
         default=3,
         dest='memory_compress_level',
         help='zstd compression level (default 3 — sweet spot)',
+    )
+    parser_snap_take.add_argument(
+        '--force', '--overwrite', '--replace',
+        action='store_true',
+        dest='force',
+        help='if a snapshot named --name already exists (or leftover '
+             'overlay/memory files from a prior deletion remain), remove '
+             'it/them first and re-take, instead of failing with a name '
+             'collision (aliases: --overwrite, --replace)',
     )
 
     #

--- a/tests/test_libvirt_snapshot.py
+++ b/tests/test_libvirt_snapshot.py
@@ -11,6 +11,7 @@ Part of Phase 1.2 of the review plan
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -1202,8 +1203,11 @@ class TestForceClearForRetake:
             removed_cmds.append(cmd)
             return _result()
 
-        with patch.object(sm.virsh, "execute",
-                          return_value=_result(ok=False, stderr="no such")), \
+        absent = _result(
+            ok=False,
+            stderr="Domain snapshot not found: no domain snapshot with "
+                   "matching name 'snapX'")
+        with patch.object(sm.virsh, "execute", return_value=absent), \
              patch.object(sm, "_data_disk_targets",
                           return_value=[("vda", active)]), \
              patch.object(sm.virsh, "execute_shell", side_effect=fake_shell):
@@ -1216,6 +1220,22 @@ class TestForceClearForRetake:
         assert mem_zst in joined
         # the live source is never a removal target
         assert active not in joined
+
+    def test_ambiguous_snapshot_info_failure_aborts(self, sm: SnapshotManager,
+                                                    tmp_path: Path):
+        # A transient snapshot-info failure (not "snapshot absent") must NOT
+        # lead to removing candidate files — the snapshot might really exist.
+        orphan = self._touch(tmp_path / "vm01.snapX")
+        transient = _result(
+            ok=False, stderr="error: failed to connect to the hypervisor")
+        with patch.object(sm.virsh, "execute", return_value=transient), \
+             patch.object(sm, "_data_disk_targets",
+                          return_value=[("vda", str(tmp_path / "vm01.qcow2"))]), \
+             patch.object(sm.virsh, "execute_shell") as esh:
+            assert sm._force_clear_for_retake(
+                "vm01", str(tmp_path), "snapX") is False
+        esh.assert_not_called()          # no rm attempted
+        assert os.path.isfile(orphan)    # file left intact
 
     def test_live_snapshot_deleted_first(self, sm: SnapshotManager,
                                          tmp_path: Path):

--- a/tests/test_libvirt_snapshot.py
+++ b/tests/test_libvirt_snapshot.py
@@ -1161,3 +1161,109 @@ class TestFlattenCdromOverlays:
         assert not any(
             c.args and c.args[0] == "change-media" for c in execute.call_args_list
         )
+
+
+class TestWouldBeOverlayPaths:
+    """`snapshot take --force` predicts the overlay libvirt would create."""
+
+    def test_derives_from_current_source(self, sm: SnapshotManager):
+        # libvirt drops the source's final suffix and appends .<snapshot>
+        with patch.object(sm, "_data_disk_targets",
+                          return_value=[("vda", "/ws/vm01.qcow2"),
+                                        ("vdb", "/ws/vm01-data.1784942899")]):
+            paths = sm._would_be_overlay_paths("vm01", "snapX")
+        assert paths == ["/ws/vm01.snapX", "/ws/vm01-data.snapX"]
+
+    def test_skips_placeholder_source(self, sm: SnapshotManager):
+        with patch.object(sm, "_data_disk_targets", return_value=[("vda", "-")]):
+            assert sm._would_be_overlay_paths("vm01", "snapX") == []
+
+
+class TestForceClearForRetake:
+    """Clearing a name for re-take: orphan files vs. a live snapshot."""
+
+    @staticmethod
+    def _touch(p: Path) -> str:
+        p.write_bytes(b"x")
+        return str(p)
+
+    def test_orphan_files_removed_active_kept(self, sm: SnapshotManager,
+                                              tmp_path: Path):
+        # Reproduces the bug: the snapshot name is gone from libvirt but its
+        # per-disk overlay + memory files linger and collide on re-take.
+        active = self._touch(tmp_path / "vm01.qcow2")          # live source
+        orphan_overlay = self._touch(tmp_path / "vm01.snapX")  # <stem>.snapX
+        mem = self._touch(tmp_path / "vm01_snapshot_snapX.raw")
+        mem_zst = self._touch(tmp_path / "vm01_snapshot_snapX.raw.zst")
+
+        removed_cmds = []
+
+        def fake_shell(cmd, *_a, **_k):
+            removed_cmds.append(cmd)
+            return _result()
+
+        with patch.object(sm.virsh, "execute",
+                          return_value=_result(ok=False, stderr="no such")), \
+             patch.object(sm, "_data_disk_targets",
+                          return_value=[("vda", active)]), \
+             patch.object(sm.virsh, "execute_shell", side_effect=fake_shell):
+            assert sm._force_clear_for_retake(
+                "vm01", str(tmp_path), "snapX") is True
+
+        joined = "\n".join(removed_cmds)
+        assert orphan_overlay in joined
+        assert mem in joined
+        assert mem_zst in joined
+        # the live source is never a removal target
+        assert active not in joined
+
+    def test_live_snapshot_deleted_first(self, sm: SnapshotManager,
+                                         tmp_path: Path):
+        with patch.object(sm.virsh, "execute", return_value=_result(ok=True)), \
+             patch.object(sm, "delete_snapshot", return_value=True) as dele, \
+             patch.object(sm, "_data_disk_targets", return_value=[]), \
+             patch.object(sm.virsh, "execute_shell", return_value=_result()):
+            assert sm._force_clear_for_retake(
+                "vm01", str(tmp_path), "snapX") is True
+        dele.assert_called_once_with("vm01", "snapX")
+
+    def test_live_snapshot_delete_failure_aborts(self, sm: SnapshotManager,
+                                                 tmp_path: Path):
+        with patch.object(sm.virsh, "execute", return_value=_result(ok=True)), \
+             patch.object(sm, "delete_snapshot", return_value=False), \
+             patch.object(sm, "_data_disk_targets", return_value=[]):
+            assert sm._force_clear_for_retake(
+                "vm01", str(tmp_path), "snapX") is False
+
+
+class TestCreateSnapshotForce:
+    """create_snapshot(force=...) runs the clear step before create-as."""
+
+    def test_force_invokes_clear_before_create(self, sm: SnapshotManager,
+                                               tmp_path: Path):
+        with patch.object(sm, "_force_clear_for_retake",
+                          return_value=True) as clear, \
+             patch.object(sm, "_flatten_cdrom_overlays"), \
+             patch.object(sm, "_cdrom_diskspec_args", return_value=[]), \
+             patch.object(sm.virsh, "execute", return_value=_result()):
+            assert sm.create_snapshot(
+                "vm01", str(tmp_path), "snapX", "d", force=True) is True
+        clear.assert_called_once_with("vm01", str(tmp_path), "snapX")
+
+    def test_force_clear_failure_aborts_create(self, sm: SnapshotManager,
+                                              tmp_path: Path):
+        with patch.object(sm, "_force_clear_for_retake",
+                          return_value=False), \
+             patch.object(sm.virsh, "execute", return_value=_result()) as execute:
+            assert sm.create_snapshot(
+                "vm01", str(tmp_path), "snapX", "d", force=True) is False
+        # never reaches snapshot-create-as
+        execute.assert_not_called()
+
+    def test_no_force_skips_clear(self, sm: SnapshotManager, tmp_path: Path):
+        with patch.object(sm, "_force_clear_for_retake") as clear, \
+             patch.object(sm, "_flatten_cdrom_overlays"), \
+             patch.object(sm, "_cdrom_diskspec_args", return_value=[]), \
+             patch.object(sm.virsh, "execute", return_value=_result()):
+            sm.create_snapshot("vm01", str(tmp_path), "snapX", "d")
+        clear.assert_not_called()


### PR DESCRIPTION
## Problem

Re-taking a snapshot with the name of one that was **previously deleted** fails:

```
error: unsupported configuration: external snapshot file for disk vda already
exists and is not a block device:
  .../<vm>.<snapshot-name>
```

Deleting a snapshot removes its memory `.raw` and libvirt metadata, but the
per-disk external **overlay files** (named `<disk-stem>.<snapshot-name>`) can be
left behind. `snapshot-create-as` derives its new overlay name from the snapshot
name, so re-using that name collides with the leftover file. Until now the only
workaround was to pick a different name (e.g. add a `-fresh` suffix).

## Fix

Add `--force` (aliases `--overwrite` / `--replace`) to `boxman snapshot take`.
When set, it clears anything that would block the name before taking, **per VM**:

1. if a live libvirt snapshot with that name still exists → delete it properly
   (blockcommit/collapse merges its overlay back into base); it **aborts** rather
   than silently clobber a buried, non-most-recent snapshot;
2. remove orphaned overlay files (`<disk-stem>.<snapshot-name>`) and memory
   `.raw`/`.raw.zst` left by a prior deletion.

Files that are part of the VM's **current active disk chain are never removed**.
Without `--force`, behaviour is unchanged — a colliding name still errors.

```
# overwrite a snapshot name that already exists (or whose files linger)
$ boxman snapshot take --name mystate1 --force
```

## Changes

| File | What |
|------|------|
| `providers/libvirt/snapshot.py` | `force` param on `create_snapshot`; `_force_clear_for_retake` + `_would_be_overlay_paths` (predicts libvirt's overlay naming) |
| `providers/libvirt/session.py`, `manager.py` | thread `force` through `snapshot_take` |
| `scripts/cli_parser.py` | `--force/--overwrite/--replace` flag + help example |
| `tests/test_libvirt_snapshot.py` | 8 unit tests: path prediction, orphan/live-snapshot clear logic, `create_snapshot` force wiring |

## Testing

- **8 new unit tests**; full `test_libvirt_snapshot.py` (96) + CLI/manager suites green (Python 3.10 local and 3.12 on the libvirt host).
- **End-to-end on a live 3-VM libvirt project:** a snapshot name whose overlay
  files lingered from an earlier deletion produced the exact error above; with
  `--force`, boxman removed the 3 orphan overlays and re-took the name on all
  three VMs — `all snapshots verified successfully`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
