### PR TITLE
feat(docker-compose): Phase 8 hardening — e2e tests, example coverage, user docs (#56)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,10 @@ test-integration:
 test-provision:
 	PYTHONPATH=src:$(PYTHONPATH) python -m pytest $(PYTEST_FLAGS) $(pytest_args) -m integration tests/test_provision_boxes.py
 
+#@help: run docker-compose *provider* e2e tests (needs docker; hybrid tier also needs /dev/kvm)
+test-dc-e2e:
+	PYTHONPATH=src:$(PYTHONPATH) python -m pytest $(PYTEST_FLAGS) $(pytest_args) -m integration tests/test_docker_compose_provider_e2e.py
+
 #@help: count lines of code per category (code/tests/docs/conf/templates/boxes/shell/docker/make/claude)
 loc:
 	@python3 scripts/count_loc.py

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The main goal is to avoid having many dependencies and to keep it simple and cus
 - **Image import**: define a libvirt VM from a pre-built `(disk + XML)` package described by a JSON manifest, served from disk or over HTTP/HTTPS — see [Image Management](doc/image-management.md)
 - **OCI registry images** (via `oras`): publish qcow2 disks + optional `vmimage.json` metadata with `boxman image push`, inspect a reference with `boxman image inspect`, and use an OCI image as a base via a template `image.uri: oci://…` or directly with `base_image: oci://…`. Both boxman's own titled-qcow2 artifacts and KubeVirt **containerDisk** images (qcow2 embedded at `/disk/`, e.g. `oci://quay.io/containerdisks/ubuntu:24.04`) are supported — see [Image Management](doc/image-management.md)
 - **Runtime environments**: execute provider commands locally or inside a Docker container
+- **Per-cluster providers**: a project can mix `libvirt` VM clusters and `docker-compose` container clusters, with every verb (`up`, `ps`, `snapshot`, `control`, ansible inventory) working across both — and VM↔container L2 adjacency over a shared bridge. See [Providers](#providers)
 - **`boxman up`**: idempotent bring-up command — provisions if no infrastructure exists, starts/resumes VMs if they are powered off or paused
 - **`boxman update`**: incrementally apply config changes to a running project — add/remove VMs, adjust CPU/memory, grow disks
 - **Disk reclaim and storage hygiene**: `boxman storage` inspects qcow2 footprint, runs guest-side fstrim, compacts qcow2 files, and compresses snapshot memory dumps with zstd — see [Disk Reclaim and Storage](doc/storage.md)
@@ -292,6 +293,70 @@ environment variable.
 files under `boxes/<name>/.boxman/` (libvirt runtime data), `make
 boxes-clean` removes them via a throwaway `alpine` container. The same
 fallback is used automatically by `destroy` and `destroy-runtime`.
+
+## Providers
+
+The **provider** controls *what* a cluster is made of. It is set per cluster,
+so one project can mix them:
+
+| Provider | Cluster contains | Declared with |
+|---|---|---|
+| `libvirt` (default) | KVM/QEMU virtual machines | `vms:` (or `boxes:`) |
+| `docker-compose` | containers, one compose project per cluster | `boxes:` |
+
+> **`docker-compose` means two different things in boxman.** As a *runtime*
+> (above) it is where libvirt commands run — inside a container. As a
+> *provider* (here) it is what a cluster is built from — containers instead of
+> VMs. They are independent axes that happen to share a name. The
+> docker-compose **provider** requires the `local` **runtime**, and says so
+> explicitly if you mix them up.
+
+```yaml
+version: '2.0'                 # required to use per-cluster providers
+project: shop
+
+provider:
+  docker-compose:
+    project_name: shop
+
+clusters:
+  web:                         # containers
+    provider: docker-compose
+    workdir: ./.boxman/web
+    boxes:
+      cache:
+        image: redis:7-alpine
+
+  compute:                     # VMs, same project
+    provider: libvirt
+    base_image: ubuntu-24.04-minimal-base-template-cloudinit
+    boxes:
+      node01: { memory: 2048 }
+```
+
+Every verb works across both: `provision`, `up`/`down`, `ps`, `destroy`,
+`snapshot`, `control`, and the ansible inventory. Two differences worth
+knowing up front:
+
+- **`boxman ssh` is VM-only.** Containers are reached with **`boxman exec
+  <cluster>.<box>`**, which runs `docker compose exec` — no sshd sidecar and no
+  keys baked into images.
+- **`--cluster` scopes either provider; `--vms` is libvirt-only** and skips
+  docker-compose clusters entirely, so `snapshot restore --vms node01` cannot
+  quietly recreate your containers.
+
+Container snapshots are `docker commit`-backed, and **named volumes are not
+captured** — see the user guide for that caveat in full.
+
+Start here:
+
+- [`boxes/docker-compose-standalone`](boxes/docker-compose-standalone) — a pure
+  container project: volumes, `exec`, inventory, snapshots. No KVM needed.
+- [`boxes/hybrid-libvirt-docker-compose`](boxes/hybrid-libvirt-docker-compose) —
+  a VM and a container sharing an L2 domain.
+- [User guide](doc/docker-compose-provider/user-guide.md) ·
+  [config schema](doc/docker-compose-provider/config-schema.md) ·
+  [v1.0 → v2.0 migration](doc/docker-compose-provider/migration-v1-to-v2.md)
 
 ## Sample configuration
 

--- a/boxes/docker-compose-standalone/README.md
+++ b/boxes/docker-compose-standalone/README.md
@@ -54,6 +54,127 @@ boxman up         # bring them back
 boxman destroy    # docker compose down --volumes + remove the generated file
 ```
 
+## Volumes
+
+Two kinds, one of each:
+
+| Box | Kind | Mount | Survives |
+|-----|------|-------|----------|
+| `cache` | named (`cache_data`) | `/data` | `down`/`up` and `deprovision` — removed by `destroy` |
+| `frontend` | bind (`./site`, read-only) | `/usr/share/nginx/html` | it is your directory; boxman never deletes it |
+
+The bind mount is live — edit and reload, no rebuild:
+
+```bash
+curl -s localhost:8080 | grep -o '<h1>.*</h1>'   # <h1>boxman</h1>
+sed -i 's|<h1>boxman</h1>|<h1>edited</h1>|' site/index.html
+curl -s localhost:8080 | grep -o '<h1>.*</h1>'   # <h1>edited</h1>
+```
+
+It is mounted `:ro`, so the container cannot write to it:
+
+```bash
+boxman exec web.frontend -- sh -c 'echo x > /usr/share/nginx/html/x' 2>&1
+# sh: can't create /usr/share/nginx/html/x: Read-only file system
+```
+
+The named volume persists across a stop/start cycle:
+
+```bash
+boxman exec web.cache -- redis-cli set greeting hello
+boxman exec web.cache -- redis-cli save          # flush to /data (the volume)
+boxman down && boxman up
+boxman exec web.cache -- redis-cli get greeting  # "hello" — survived
+```
+
+`boxman destroy` removes named volumes (`docker compose down --volumes`); the
+bind directory `./site` is left alone.
+
+## Exec into a container
+
+`boxman ssh` is for VMs. Containers get **`boxman exec`** (decision D2) — no
+sshd sidecar, no keys baked into images:
+
+```bash
+boxman exec web.cache                     # interactive shell (default: sh)
+boxman exec web.frontend --shell bash     # pick the shell
+boxman exec web.cache -- redis-cli ping   # one-shot: PONG
+```
+
+Put a command after `--` when it has its own flags, so they reach the container
+instead of boxman.
+
+## Ansible / `boxman run`
+
+Containers land in the generated inventory as ordinary hosts, reached with the
+`community.docker` connection plugin — no SSH, no keys in the image:
+
+```bash
+cat .boxman/web/inventory/01-hosts.yml
+```
+
+```yaml
+web_cache:
+  ansible_connection: "community.docker.docker"
+  ansible_host: "dc_standalone_web-cache-1"     # the real container name
+web_frontend:
+  ansible_connection: "community.docker.docker"
+  ansible_host: "dc_standalone_web-frontend-1"
+```
+
+Prerequisites on the control host:
+
+```bash
+ansible-galaxy collection install community.docker
+pip install docker            # the Docker SDK for Python
+```
+
+> **Ansible modules need a Python interpreter *inside* the container.** The
+> images here (`nginx:alpine`, `redis:alpine`) deliberately ship without one,
+> so module-based tasks such as `-m ping` or `ansible.builtin.shell` fail with
+> *"No python interpreters found"*. That is a property of minimal images, not
+> of boxman. Two ways forward:
+>
+> ```bash
+> # 1. the raw module needs no interpreter — good for minimal images
+> ansible all -m raw -a 'nginx -v'
+>
+> # 2. or use an image that has python, and the full module set works
+> ```
+>
+> `boxman run --cmd '<cmd>'` wraps `ansible.builtin.shell`, so it needs option
+> 2. For a quick command against a minimal image, `boxman exec` is the direct
+> route.
+
+## Snapshots
+
+Backed by `docker commit` (decision D3) — with one caveat worth reading twice.
+
+```bash
+boxman exec web.cache -- redis-cli set marker before-snapshot
+boxman snapshot take --name v1 -m "known good"
+boxman snapshot list
+
+# change something, then roll back
+boxman exec web.cache -- sh -c 'echo scratch > /tmp/scratch'
+boxman snapshot restore --name v1
+boxman exec web.cache -- ls /tmp/scratch     # gone — filesystem rolled back
+
+boxman snapshot delete --name v1
+```
+
+> **Named volumes are not part of a snapshot.** `docker commit` captures a
+> container's writable layer only, never the data in a mounted volume. So the
+> redis key above lives in `/data` (the `cache_data` volume) and is **not**
+> rolled back by a restore — only the container filesystem is. This is the key
+> divergence from libvirt snapshots, which capture the disk. Back volumes up
+> separately. boxman warns about this on every `take`.
+
+Snapshot names must be unused — `boxman snapshot delete --name v1` first, or
+pick a new name. A restore is a point-in-time recreate, not a permanent pin: a
+later `boxman up` regenerates from `conf.yml` and returns to the declared
+images.
+
 ## Notes
 
 - The generated `docker-compose.yml` lives under `.boxman/` (git-ignored). It
@@ -61,3 +182,6 @@ boxman destroy    # docker compose down --volumes + remove the generated file
   directly.
 - Need a compose feature boxman does not model yet? Add it under
   `compose_extra:` (per-box or per-cluster) and it is deep-merged verbatim.
+- In a **mixed** project, `--cluster <name>` scopes a command to one cluster of
+  either provider. `--vms` names libvirt VMs only, so passing it skips
+  docker-compose clusters entirely.

--- a/boxes/docker-compose-standalone/conf.yml
+++ b/boxes/docker-compose-standalone/conf.yml
@@ -13,12 +13,19 @@
 # (passed through verbatim). The generated docker-compose.yml is written to
 # the cluster `workdir` and is inspectable / hand-runnable.
 #
+# It is also the feature showcase for the provider: **volumes** (a named
+# volume that survives down/up, and a read-only bind mount), plus the CLI
+# surface — `boxman exec`, the ansible inventory, and `docker commit`-backed
+# `boxman snapshot`. The README walks each one.
+#
 # Requires the `local` runtime (the default) — the docker-compose provider
-# shells out to `docker compose` on the host.
+# shells out to `docker compose` on the host. No KVM and no VM images, so it
+# runs on any machine with Docker.
 #
 #   cd boxes/docker-compose-standalone
 #   boxman provision
 #   curl -sI localhost:8080          # nginx is up
+#   boxman exec web.cache -- redis-cli ping
 #   docker compose -p dc_standalone_web ps
 #   boxman destroy
 version: '2.0'
@@ -42,6 +49,13 @@ clusters:
       cache:
         image: redis:7-alpine
         networks: [appnet]
+        # A *named* volume: docker-managed, and it survives `boxman down` /
+        # `deprovision`. Redis persists its dump.rdb here, so data written
+        # before a down/up cycle is still there afterwards. `boxman destroy`
+        # removes it (that is the difference between destroy and deprovision).
+        volumes:
+          - name: cache_data
+            container_path: /data
         healthcheck:
           test: ["CMD", "redis-cli", "ping"]
           interval: 5s
@@ -53,6 +67,15 @@ clusters:
         ports:
           - "8080:80"
         networks: [appnet]
+        # A *bind* mount: a host directory mounted into the container. The
+        # relative host_path is resolved against this conf.yml's directory
+        # (decision D4), and boxman pre-creates it as you (not root-owned by
+        # the docker daemon). `readonly: true` emits the `:ro` flag — nginx
+        # only needs to read its content.
+        volumes:
+          - host_path: ./site
+            container_path: /usr/share/nginx/html
+            readonly: true
         depends_on:
           cache:
             condition: service_healthy

--- a/boxes/docker-compose-standalone/site/index.html
+++ b/boxes/docker-compose-standalone/site/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<title>boxman docker-compose provider</title>
+<h1>boxman</h1>
+<p>Served by nginx from a <strong>read-only bind mount</strong>
+   (<code>./site</code> on the host &rarr; <code>/usr/share/nginx/html</code>).</p>
+<p>Edit <code>site/index.html</code> and reload — no rebuild, no restart.</p>

--- a/boxes/hybrid-libvirt-docker-compose/README.md
+++ b/boxes/hybrid-libvirt-docker-compose/README.md
@@ -66,25 +66,33 @@ The container is `hybrid_libvirt_dc_services-web-1` (find it with
 `backend` address on `172.31.0.0/24`.
 
 **Step 1 — give node01 its address on the shared bridge.** It has no DHCP there,
-so assign it once (the app NIC is the second one, `enp7s0` on this box):
+so assign it once (the app NIC is the second one, `enp7s0` on this box).
+
+`boxman ssh` opens an *interactive* session and takes no trailing command, so
+run one-off commands over the ssh_config boxman generates in the workspace:
 
 ```bash
-boxman ssh compute_node01 -- sudo ip addr add 10.10.0.20/24 dev enp7s0
-boxman ssh compute_node01 -- ip -4 -br addr show enp7s0     # -> 10.10.0.20/24
+WS=~/workspaces/boxmandev/hybrid-libvirt-docker-compose   # workspace.path from conf.yml
+alias vmsh="ssh -F $WS/ssh_config compute_node01"
+
+vmsh sudo ip addr add 10.10.0.20/24 dev enp7s0
+vmsh ip -4 -br addr show enp7s0                            # -> 10.10.0.20/24
 ```
+
+(`boxman ssh compute_node01` still works for an interactive shell.)
 
 **Step 2 — ping both ways** (VM `10.10.0.20` ⇄ container `10.10.0.10`):
 
 ```bash
 docker exec hybrid_libvirt_dc_services-web-1 ping -c3 10.10.0.20   # container -> VM
-boxman ssh compute_node01 -- ping -c3 10.10.0.10                   # VM -> container
+vmsh ping -c3 10.10.0.10                                          # VM -> container
 ```
 
 **Step 3 — ARP resolves across the bridge** (each side learns the other's real
 MAC — proof this is L2, not routed):
 
 ```bash
-boxman ssh compute_node01 -- ip neigh show 10.10.0.10       # -> lladdr <container mac>
+vmsh ip neigh show 10.10.0.10                              # -> lladdr <container mac>
 docker exec hybrid_libvirt_dc_services-web-1 ip neigh show 10.10.0.20
 ```
 
@@ -93,7 +101,7 @@ docker exec hybrid_libvirt_dc_services-web-1 ip neigh show 10.10.0.20
 
 ```bash
 docker exec hybrid_libvirt_dc_services-web-1 ip -4 -br addr   # note the 172.31.0.x
-boxman ssh compute_node01 -- ping -c2 -W2 172.31.0.2          # -> 100% loss (isolated)
+vmsh ping -c2 -W2 172.31.0.2                                  # -> 100% loss (isolated)
 ```
 
 ## Tear down

--- a/doc/docker-compose-provider/README.md
+++ b/doc/docker-compose-provider/README.md
@@ -1,8 +1,28 @@
-# Docker-Compose Provider Design Documents
+# Docker-Compose Provider
 
-This directory contains the design documents for adding docker-compose as a first-class provider in boxman, enabling mixed topologies where libvirt VMs and docker containers coexist with L2 connectivity.
+Design *and* user documentation for docker-compose as a first-class provider in
+boxman, enabling mixed topologies where libvirt VMs and docker containers
+coexist with L2 connectivity.
 
-## Documents
+## Using it (start here)
+
+- **[user-guide.md](user-guide.md)** — the practical path: prerequisites, a
+  minimal project, lifecycle, volumes, networking, `exec`, ansible, snapshots,
+  scoping in mixed projects, troubleshooting.
+- **[config-schema.md](config-schema.md)** — every key and its exact semantics.
+- **[migration-v1-to-v2.md](migration-v1-to-v2.md)** — moving an existing
+  project to config v2.0 (spoiler: only needed if you want containers).
+- Example boxes:
+  [`docker-compose-standalone`](../../boxes/docker-compose-standalone)
+  (containers only — volumes, `exec`, inventory, snapshots; no KVM needed) and
+  [`hybrid-libvirt-docker-compose`](../../boxes/hybrid-libvirt-docker-compose)
+  (a VM and a container sharing an L2 domain).
+
+> `docker-compose` names two independent things in boxman: a **runtime** (where
+> libvirt commands run) and this **provider** (what a cluster is made of). See
+> [the user guide](user-guide.md#first-the-name-collision).
+
+## Design documents
 
 ### Main Design Document
 - **[design.md](design.md)** - Complete design document with Mermaid diagrams covering:
@@ -89,22 +109,28 @@ Shared bridges keep `bridge-nf-call-iptables=1`; per-bridge physdev accept rules
 
 ## Implementation Phases
 
-1. **Phase 0**: Design & Validation (this phase)
-2. **Phase 1**: Provider Registry & Multi-Provider Dispatch
-3. **Phase 2**: Config Schema v2.0 & Versioning
-4. **Phase 3**: DockerComposeSession Core Lifecycle
-5. **Phase 4**: Network Integration (macvlan, shared bridges)
-6. **Phase 5**: Volume/Storage Management
-7. **Phase 6**: CLI & User Experience Updates
-8. **Phase 7**: Snapshot & State Management
-9. **Phase 8**: Testing & Documentation
-10. **Phase 9**: Release
+| | Phase | Issue | Status |
+|---|---|---|---|
+| 0 | Design & validation (incl. netfilter spike) | [#48](https://github.com/mherkazandjian/boxman/issues/48) | done |
+| 1 | Provider registry & multi-provider dispatch | [#49](https://github.com/mherkazandjian/boxman/issues/49) | done |
+| 2 | Config schema v2.0 & versioning | [#50](https://github.com/mherkazandjian/boxman/issues/50) | done |
+| 3 | DockerComposeSession core lifecycle | [#51](https://github.com/mherkazandjian/boxman/issues/51) | done |
+| 4 | Network integration (macvlan, shared bridges) | [#52](https://github.com/mherkazandjian/boxman/issues/52) | done |
+| 5 | Volume / storage management | [#53](https://github.com/mherkazandjian/boxman/issues/53) | done |
+| 6 | CLI & user-experience updates | [#54](https://github.com/mherkazandjian/boxman/issues/54) | done |
+| 7 | Snapshot & state management | [#55](https://github.com/mherkazandjian/boxman/issues/55) | done |
+| 8 | Testing & documentation | [#56](https://github.com/mherkazandjian/boxman/issues/56) | in progress |
+| 9 | Release | [#57](https://github.com/mherkazandjian/boxman/issues/57) | pending |
+
+Each phase merged into the epic branch `feat/docker-compose-provider`, which
+merges into `main` after one final epic review. Every phase carries a drift
+retro on its tracking issue recording where the implementation diverged from
+the plan.
 
 ## Next Steps
 
-1. ~~Run the netfilter spike~~ — executed 2026-07-13 in the staging VM ([spike/findings.md](spike/findings.md))
-2. Merge the Phase 0 PR into the epic feature branch `feat/docker-compose-provider` — closes Phase 0 ([#48](https://github.com/mherkazandjian/boxman/issues/48)); the feature branch accumulates all phases and merges into `main` after one final epic review
-3. Begin Phase 1 — provider registry ([#49](https://github.com/mherkazandjian/boxman/issues/49))
+1. Finish Phase 8 — e2e tests, example coverage, user docs, migration guide ([#56](https://github.com/mherkazandjian/boxman/issues/56))
+2. Phase 9 — version bump, changelog, tag, and close the epic ([#57](https://github.com/mherkazandjian/boxman/issues/57))
 
 ## Related Issues
 

--- a/doc/docker-compose-provider/design.md
+++ b/doc/docker-compose-provider/design.md
@@ -576,6 +576,39 @@ graph TB
     end
 ```
 
+#### Coverage — where each AC is actually proven
+
+Filled in during Phase 8 ([#56](https://github.com/mherkazandjian/boxman/issues/56)).
+`e2e` = `tests/test_docker_compose_provider_e2e.py` (`make test-dc-e2e`); unit
+tests are the host suite (`make test`).
+
+| AC | Proven by |
+|----|-----------|
+| AC1 v1.0 projects unchanged | unit: `test_boxman_conf.py::test_v1_*` (a versionless/v1.0 config is returned untouched) + the full libvirt suite passing |
+| AC2 existing tests pass | the whole host suite, run green on every phase merge |
+| AC3 single-provider dispatch | unit: `test_provider_registry.py`, `test_provider_protocol.py` |
+| AC4 v2.0 libvirt-only ≡ v1.0 | unit: `test_boxman_conf.py::test_v2_libvirt_only_equals_v1_shape` |
+| AC5 `boxes:` alias for `vms:` | unit: `test_v2_libvirt_boxes_renamed_to_vms`, `test_v2_libvirt_boxes_and_vms_is_error` |
+| AC6 per-cluster `provider:` | unit: `test_boxman_conf.py` v2 normalization + `provider_type_for_cluster` |
+| AC7 dc cluster `boxman up` | e2e: `test_containers_are_running` (real `up -d --wait`) |
+| AC8 dc cluster `boxman destroy` | e2e: `test_destroy_removes_containers_and_named_volumes` |
+| AC9 readiness/health | e2e: provisioning the standalone box blocks on `--wait`; its `cache` declares a healthcheck and `frontend` a `condition: service_healthy` |
+| AC10 VM↔container ping | e2e (KVM tier): `test_container_reaches_vm_over_shared_bridge`, which **skips unless the VM's shared-bridge address was assigned first** — that L2 domain deliberately has no DHCP (box README, step 1). Verified live in Phase 8 with the precondition met: both directions 0% packet loss. |
+| AC11 ARP between them | same test asserts a learned `lladdr`, same precondition. Live: the container resolves the VM to `52:54:00:aa:00:02` — `adapter_2`'s MAC from the box conf — and the VM resolves the container's macvlan MAC, proving L2 rather than routing. |
+| AC12 internal nets isolated | e2e (KVM tier): `test_cluster_internal_network_is_isolated_from_the_bridge` — internal net is a compose-scoped `bridge`, only the shared one is a `macvlan` parented on `bx_app`. Live: the VM pinging the container's `backend` address gets 100% loss. |
+| AC13 named volumes persist | e2e: `test_named_volume_survives_down_up` |
+| AC14 bind mounts work | e2e: `test_published_port_serves_the_bind_mount`, `test_bind_mount_is_readonly` |
+| AC15 volumes cleaned on destroy | e2e: `test_destroy_removes_containers_and_named_volumes` |
+| AC16 `ps` shows both | e2e: `test_ps_reports_containers_with_provider` (+ `test_mixed_ps_shows_both_providers` on the KVM tier) |
+| AC17 `exec` for containers | e2e: `test_exec_one_shot` — and `ssh` stays VM-only per the revised D2 |
+| AC18 inventory includes containers | e2e: `test_inventory_lists_containers_with_docker_connection`, and `test_inventory_spans_both_providers` for the mixed case |
+
+Beyond the ACs, the provider's failure behaviour is unit-tested in
+`tests/test_docker_compose_provider.py` (duplicate/colliding snapshot names,
+commit rollback, `ps`-failure propagation, delete-keeps-metadata,
+missing-image validation, per-cluster failure isolation, the narrowed-`--vms`
+rule and the `runtime: local` guardrail).
+
 ---
 
 ## Breaking Changes & Versioning

--- a/doc/docker-compose-provider/migration-v1-to-v2.md
+++ b/doc/docker-compose-provider/migration-v1-to-v2.md
@@ -1,0 +1,143 @@
+# Migrating a project from config v1.0 to v2.0
+
+**Short version: you do not have to.** v1.0 configs keep working exactly as
+they did — same behaviour, byte for byte. Migrate only when you want something
+v2.0 adds, most commonly a `docker-compose` cluster in the project.
+
+---
+
+## What v2.0 actually changes
+
+Three things, all additive:
+
+| | v1.0 | v2.0 |
+|---|---|---|
+| Version marker | none | `version: '2.0'` at the top level |
+| Cluster members | `vms:` | `boxes:` (provider-neutral) — `vms:` still accepted |
+| Provider | one, project-wide | `provider:` per cluster |
+
+Everything else — `templates:`, `networks:`, `shared_networks:`, `workspace:`,
+`tasks:`, cloud-init, snapshots, the CLI — is unchanged.
+
+## Do I need to migrate?
+
+| You want to… | Migrate? |
+|---|---|
+| Keep running your libvirt project | **No.** Leave it on v1.0. |
+| Add a container cluster to it | **Yes** — per-cluster `provider:` is v2.0. |
+| Use `boxes:` for readability | Optional. |
+
+There is no deprecation deadline for v1.0 in this release.
+
+## The migration, in three steps
+
+### 1. Declare the version
+
+```yaml
+version: '2.0'      # add this line
+project: myproject
+```
+
+`version: 2` and `version: '2.0'` both select v2.0; quoting is recommended so
+YAML does not read it as a float. Anything else is refused outright
+(`unsupported config version: '3.0' (supported: '1.0', '2.0')`).
+
+Without the version line, a cluster that resolves to the docker-compose
+provider is rejected with exactly that instruction:
+
+```
+cluster 's' uses the docker-compose provider, which requires version: '2.0'
+```
+
+That guard exists because v1.0 *ignores* `boxes:` — so without it your
+containers would be silently skipped rather than provisioned. Note that a
+per-cluster `provider: libvirt` is still accepted under v1.0; it is the
+docker-compose provider specifically that requires v2.0.
+
+### 2. Rename `vms:` → `boxes:` (optional)
+
+```yaml
+clusters:
+  compute:
+    vms:                    # v1.0
+      node01: { memory: 2048 }
+```
+
+```yaml
+clusters:
+  compute:
+    boxes:                  # v2.0 — same meaning
+      node01: { memory: 2048 }
+```
+
+`boxes:` is the provider-neutral name; `vms:` remains accepted (with a
+deprecation warning) so a mixed-vintage config keeps working. Declaring **both**
+on one cluster is ambiguous and rejected:
+
+```
+cluster 'c' declares both 'boxes:' and 'vms:' — use one (prefer 'boxes:' in v2.0).
+```
+
+Under the hood a libvirt cluster's `boxes:` is renamed back to `vms:` during
+normalization, so the existing libvirt code paths are untouched — the rename is
+cosmetic for VM clusters and load-bearing only for container ones.
+
+### 3. Set the provider where you want containers
+
+Existing clusters need nothing — `libvirt` stays the default. Add
+`provider: docker-compose` only on the new cluster:
+
+```yaml
+version: '2.0'
+project: myproject
+
+provider:
+  libvirt: { uri: 'qemu:///system' }    # unchanged
+  docker-compose:
+    project_name: myproject             # new
+
+clusters:
+  compute:                              # untouched, still libvirt
+    base_image: ubuntu-24.04-minimal-base-template-cloudinit
+    boxes:
+      node01: { memory: 2048 }
+
+  services:                             # new container cluster
+    provider: docker-compose
+    workdir: ./.boxman/services
+    boxes:
+      cache:
+        image: redis:7-alpine
+```
+
+That is the whole migration.
+
+## Verifying
+
+```bash
+boxman conf            # render + validate without touching infrastructure
+boxman ps              # both clusters listed, with a Provider column
+```
+
+Your existing VMs are not redefined by adding a container cluster — libvirt
+resource names are unchanged, so `provision` will not recreate them.
+
+## Things worth knowing before you add containers
+
+- **The docker-compose provider needs the `local` runtime** (the default). The
+  `docker` *runtime* is a different axis that happens to share the name — see
+  the [user guide](user-guide.md#first-the-name-collision).
+- **`boxman ssh` stays VM-only.** Containers use `boxman exec <cluster>.<box>`.
+- **`--vms` is libvirt-only** and skips docker-compose clusters; `--cluster`
+  scopes either kind.
+- **Container snapshots do not capture named volumes** — see
+  [Snapshots](user-guide.md#snapshots).
+- Containers are ephemeral by design: anything that must survive `up` belongs
+  in a volume.
+
+## Rolling back
+
+Delete the `provider:` line from the cluster (or the cluster itself) and drop
+`version: '2.0'`. Nothing else in a v1.0 file has to change, since v2.0 only
+adds keys. Run `boxman destroy` for the container cluster first so no orphaned
+compose project is left behind.

--- a/doc/docker-compose-provider/user-guide.md
+++ b/doc/docker-compose-provider/user-guide.md
@@ -1,0 +1,260 @@
+# docker-compose provider — user guide
+
+How to run containers from a boxman project, on their own or alongside VMs.
+
+For the *why* behind the design see [design.md](design.md) and
+[ADR-001](adr-001-per-cluster-provider.md); for every key and its exact
+semantics see [config-schema.md](config-schema.md). This page is the practical
+path.
+
+---
+
+## First, the name collision
+
+`docker-compose` means two unrelated things in boxman:
+
+| | What it is | Where it is set |
+|---|---|---|
+| **runtime** | *where* commands run — libvirt inside a container | `--runtime`, `runtime:` in `boxman.yml` |
+| **provider** | *what* a cluster is made of — containers instead of VMs | `provider:` on a cluster |
+
+They are independent axes. This guide is entirely about the **provider**.
+
+The provider requires the **`local` runtime** (the default): it shells out to
+`docker compose` on the host. Mixing the two is a config error with an
+explanatory message, not a mysterious failure.
+
+## Prerequisites
+
+- Docker Engine with the **compose v2** plugin — check with
+  `docker compose version`.
+- Your user in the `docker` group, or set `use_sudo: true` under the provider
+  config.
+- For ansible against containers: `ansible-galaxy collection install
+  community.docker` and `pip install docker` on the control host.
+
+No KVM, no cloud images: a container-only project runs anywhere Docker does.
+
+## A minimal project
+
+```yaml
+version: '2.0'                 # required — per-cluster providers are v2.0
+project: shop
+
+provider:
+  docker-compose:
+    project_name: shop         # compose project prefix (default: project name)
+
+clusters:
+  web:
+    provider: docker-compose
+    workdir: ./.boxman/web     # where the generated docker-compose.yml goes
+
+    networks:
+      appnet:
+        driver: bridge
+        subnet: 172.28.0.0/24
+
+    boxes:
+      cache:
+        image: redis:7-alpine
+        networks: [appnet]
+```
+
+```bash
+boxman provision      # generate docker-compose.yml + docker compose up -d --wait
+boxman ps             # containers listed alongside any VMs
+boxman destroy        # down --volumes + remove the generated file
+```
+
+Containers are declared under **`boxes:`**, the provider-neutral key. Each box
+becomes a compose *service*. boxman writes a real `docker-compose.yml` into the
+cluster `workdir` — inspect it, or run `docker compose -f … <cmd>` against it
+directly. It is a generated artifact: edit `conf.yml`, not the output.
+
+### What boxman brings up
+
+`provision` (and the idempotent `up`) run `docker compose up -d --wait`, so the
+command returns only once every service is `running` — or `healthy`, when the
+box declares a `healthcheck:`. Raise the ceiling per cluster with
+`readiness_timeout: <seconds>` (default 120).
+
+## Lifecycle
+
+| Verb | Docker equivalent | Named volumes |
+|---|---|---|
+| `provision` / `up` | `up -d --wait` | created if missing |
+| `down` | `stop` | kept |
+| `deprovision` | `down` | **kept** |
+| `destroy` | `down --volumes` | **removed** |
+| `control suspend` / `resume` | `pause` / `unpause` | — |
+| `control start` | `start` | — |
+| `control save` | *(no equivalent)* | explains and skips |
+
+`up` is idempotent — re-running reconciles rather than recreating.
+
+## Volumes
+
+```yaml
+boxes:
+  cache:
+    volumes:
+      - name: cache_data              # named: docker-managed
+        container_path: /data
+  frontend:
+    volumes:
+      - host_path: ./site             # bind: your directory
+        container_path: /usr/share/nginx/html
+        readonly: true                # -> :ro
+```
+
+- **Named** volumes survive `down`/`up` *and* `deprovision`; only `destroy`
+  removes them.
+- **Bind** mounts point at a host directory. A relative `host_path` resolves
+  against the directory holding `conf.yml`, and boxman pre-creates it **as
+  you** — left to docker, the daemon would create it root-owned.
+- `workdir: <path>` on a box is shorthand for a bind of `.` at that path.
+- `size:` on a named volume is **advisory** — docker's `local` driver cannot
+  enforce a quota, so boxman emits the volume and warns rather than pretending
+  to cap it.
+
+## Networking
+
+Two kinds, and the difference matters:
+
+```yaml
+clusters:
+  web:
+    networks:
+      appnet:                     # cluster-internal bridge — isolated
+        driver: bridge
+        subnet: 172.28.0.0/24
+```
+
+```yaml
+shared_networks:                  # project-level: an L2 domain VMs can join
+  app_bridge:
+    bridge: bx_app
+    subnet: 10.10.0.0/24
+```
+
+A box that joins a `shared_networks` entry is attached with a **macvlan**
+network whose parent is that host bridge, so it is directly L2-adjacent to any
+VM on the same bridge — they can ping and ARP for each other. Cluster-internal
+networks stay isolated from the VMs.
+
+boxman installs a **scoped per-bridge netfilter accept rule** rather than
+disabling netfilter host-wide (decision D8). `disable_netfilter: true` forces
+the global switch; it is discouraged and logged loudly.
+
+See [`boxes/hybrid-libvirt-docker-compose`](../../boxes/hybrid-libvirt-docker-compose)
+for the full worked example.
+
+## Getting into a container
+
+`boxman ssh` stays **VM-only** — SSH into a container would mean an sshd
+sidecar and keys baked into the image. Containers get `boxman exec`:
+
+```bash
+boxman exec web.cache                     # interactive shell (default sh)
+boxman exec web.frontend --shell bash     # choose the shell
+boxman exec web.cache -- redis-cli ping   # one-shot command
+```
+
+Put the command after `--` when it carries its own flags, so they reach the
+container rather than boxman. A bare box name works when it is unique across
+your docker-compose clusters.
+
+## Ansible and `boxman run`
+
+Containers are rendered into the generated inventory as ordinary hosts, using
+the `community.docker` connection plugin:
+
+```yaml
+web_cache:
+  ansible_connection: "community.docker.docker"
+  ansible_host: "shop_web-cache-1"      # the real container name
+```
+
+so `boxman run` and `tasks:` reach containers and VMs alike.
+
+> **Ansible modules need a Python interpreter inside the container.** Minimal
+> images (`alpine`-based ones especially) do not ship one, and module-based
+> tasks fail with *"No python interpreters found"*. Use `ansible … -m raw`,
+> which needs no interpreter, or pick an image that has Python. `boxman run
+> --cmd` wraps `ansible.builtin.shell`, so it needs the latter; for a quick
+> command against a minimal image, `boxman exec` is the direct route.
+
+## Snapshots
+
+Backed by `docker commit` (decision D3):
+
+```bash
+boxman snapshot take --name v1 -m "known good"
+boxman snapshot list
+boxman snapshot restore --name v1
+boxman snapshot delete --name v1
+```
+
+Each container is committed to `boxman/<project>_<cluster>_<box>:<name>` — the
+repository carries the compose project, so same-named boxes in different
+clusters never collide — and recorded in `snapshots.json` in the cluster
+workdir.
+
+> ### Named volumes are not part of a snapshot
+>
+> `docker commit` captures a container's writable layer only, never the data in
+> a mounted volume. A restore rolls the **container filesystem** back and
+> leaves **volume data exactly as it is** — databases, uploads and anything
+> else you deliberately persisted are untouched. This is the key divergence
+> from libvirt's external snapshots, which capture the disk. Back volumes up
+> separately. boxman warns on every `take`.
+
+Practical rules:
+
+- A snapshot name must be unused — `delete` it first, or pick another. (libvirt
+  rejects duplicate snapshot names too.) Names that differ only by punctuation
+  are rejected as well, since they would sanitize to the same docker tag.
+- A restore is a **point-in-time recreate, not a permanent pin**: a later
+  `boxman up` regenerates from `conf.yml` and returns to the declared images.
+- Restore pre-validates that every recorded image still exists, so a snapshot
+  whose images were pruned outside boxman fails cleanly instead of part-way
+  through the recreate.
+- Deleting a snapshot you are *currently restored onto* untags the image but
+  leaves it dangling until those containers are replaced (`docker image prune`
+  reclaims it).
+
+## Mixed projects: scoping
+
+In a project with both kinds of cluster:
+
+- **`--cluster <name>`** scopes to one cluster, of either provider.
+- **`--vms <names>`** names libvirt VMs, so it **skips docker-compose clusters
+  entirely**. `boxman snapshot restore --vms node01 --name X` will not
+  force-recreate your containers.
+
+## Escape hatch
+
+Anything boxman does not model yet goes through `compose_extra:`, per box or
+per cluster, deep-merged into the generated file verbatim:
+
+```yaml
+boxes:
+  cache:
+    image: redis:7-alpine
+    compose_extra:
+      deploy:
+        resources:
+          limits: { cpus: '0.50' }
+```
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `requires runtime 'local'` | The provider was used under the `docker` runtime — the two axes were mixed up. |
+| `'docker compose' … not available` | Compose v2 plugin missing, or docker needs `use_sudo: true`. |
+| `snapshot 'x' already exists` | Names are single-use; `snapshot delete --name x` first. |
+| `No python interpreters found` | Ansible module against a minimal image — use `-m raw` or `boxman exec`. |
+| `no containers to snapshot` | The cluster is not up. |
+| Container state lost after `up` | Expected: the container filesystem is rebuilt from the declared image. Persist data in a **volume**. |

--- a/src/boxman/utils/env_loader.py
+++ b/src/boxman/utils/env_loader.py
@@ -185,6 +185,11 @@ def load_workspace_env(
                 # an implicit localhost. Anchoring to the cwd at load time (the
                 # project root) makes the value immune to the later chdir; when
                 # the workdir is already absolute this is identical to before.
+                # This applies to every path override (INVENTORY, SSH_CONFIG,
+                # ANSIBLE_CONFIG) — all are consumed by those same chdir'd
+                # subprocesses. Workspace-level keys are unaffected: they come
+                # through `_apply(workspace_config, None)`, where resolve_base
+                # is falsy, so they keep their historical relative handling.
                 val = os.path.abspath(os.path.join(resolve_base, val))
             env_vars[env_key] = val
             # ansible consults ANSIBLE_INVENTORY (which env.sh seeds from

--- a/src/boxman/utils/env_loader.py
+++ b/src/boxman/utils/env_loader.py
@@ -177,7 +177,15 @@ def load_workspace_env(
             # point `boxman ssh` / `run` at a file that was never created.
             resolve_base = ssh_base if (env_key == "SSH_CONFIG" and ssh_base) else base
             if resolve_base and not os.path.isabs(val):
-                val = os.path.normpath(os.path.join(resolve_base, val))
+                # abspath, not normpath: tasks run with cwd set to the workdir
+                # (or workspace.path), so a result that is still relative would
+                # be resolved a *second* time against that cwd and miss. With a
+                # relative cluster workdir like './.boxman/web' that produced
+                # '.boxman/web/.boxman/web/inventory' and ansible fell back to
+                # an implicit localhost. Anchoring to the cwd at load time (the
+                # project root) makes the value immune to the later chdir; when
+                # the workdir is already absolute this is identical to before.
+                val = os.path.abspath(os.path.join(resolve_base, val))
             env_vars[env_key] = val
             # ansible consults ANSIBLE_INVENTORY (which env.sh seeds from
             # INVENTORY); keep it in step so a repointed inventory actually

--- a/tests/test_docker_compose_provider_e2e.py
+++ b/tests/test_docker_compose_provider_e2e.py
@@ -202,9 +202,15 @@ class TestDockerComposeProviderLifecycle:
 
         assert _boxman("snapshot restore --name e2e1", cwd=standalone_up, warn=True).ok
 
-        # the container filesystem went back to the snapshot
+        # the container filesystem went back to the snapshot. Assert the
+        # specific "no such file" rather than merely a non-zero exit, which a
+        # broken `exec` (or a container left down by the restore) would also
+        # produce — that would turn a failed restore into a green test.
         gone = _boxman("exec web.cache -- ls /tmp/dirt", cwd=standalone_up, warn=True)
         assert not gone.ok, "container filesystem was not rolled back"
+        assert "No such file" in (gone.stdout + gone.stderr), (
+            f"expected /tmp/dirt to be absent after restore, but the command "
+            f"failed for a different reason:\n{gone.stdout}{gone.stderr}")
 
         # ...but the volume kept the *post-snapshot* write (docker commit never
         # captured it), which is the divergence the docs warn about
@@ -381,8 +387,15 @@ class TestHybridVmContainer:
     def test_cluster_internal_address_unreachable_from_vm(self, hybrid_up):
         """AC12, the traffic-level half: the container's cluster-internal
         address is not reachable from the VM — only the shared bridge is
-        L2-adjacent."""
+        L2-adjacent.
+
+        Asserts ping actually ran and reported total loss. A bare
+        ``not out.ok`` would also be satisfied by ssh failing outright, which
+        would pass this test without ever demonstrating isolation.
+        """
         out = _vm_ssh(hybrid_up, "ping -c2 -W2 172.31.0.2", warn=True)
-        assert not out.ok, (
-            "the cluster-internal network is reachable from the VM — isolation "
-            f"regression:\n{out.stdout}")
+        assert "100% packet loss" in out.stdout, (
+            "expected total loss to the cluster-internal address; either it is "
+            f"reachable (isolation regression) or ping never ran:\n"
+            f"{out.stdout}{out.stderr}")
+        assert not out.ok

--- a/tests/test_docker_compose_provider_e2e.py
+++ b/tests/test_docker_compose_provider_e2e.py
@@ -19,8 +19,10 @@ Two tiers:
 These are local-only, like ``make test-provision`` — they create and destroy
 real infrastructure::
 
-    make test-dc-e2e                                  # docker-only tier
-    make test-dc-e2e pytest_args="-k hybrid"          # hybrid tier too
+    make test-dc-e2e                              # both tiers; hybrid
+                                                  # auto-skips without /dev/kvm
+    make test-dc-e2e pytest_args="-k Hybrid"      # restrict to the hybrid tier
+    make test-dc-e2e pytest_args="-k Lifecycle"   # restrict to the docker-only tier
 """
 
 import json
@@ -181,21 +183,35 @@ class TestDockerComposeProviderLifecycle:
         assert "hello" in result.stdout
 
     def test_snapshot_take_restore_and_volume_divergence(self, standalone_up):
-        """D3: a restore rolls back the container filesystem but NOT volumes."""
-        _boxman("exec web.cache -- redis-cli set persisted yes", cwd=standalone_up)
+        """D3: a restore rolls back the container filesystem but NOT volumes.
+
+        Both values are changed *after* the snapshot, which is what makes the
+        two assertions discriminating: the filesystem one fails if the commit
+        is not restored, and the volume one fails if volume data *were* rolled
+        back with it. A value written before the take would read the same
+        either way and prove nothing.
+        """
+        _boxman("exec web.cache -- redis-cli set divergence before", cwd=standalone_up)
         _boxman("exec web.cache -- redis-cli save", cwd=standalone_up)
         assert _boxman("snapshot take --name e2e1 -m e2e", cwd=standalone_up, warn=True).ok
 
-        # dirty the container filesystem after the snapshot
+        # after the snapshot: dirty the container filesystem *and* the volume
         _boxman("exec web.cache -- sh -c 'echo dirt > /tmp/dirt'", cwd=standalone_up)
+        _boxman("exec web.cache -- redis-cli set divergence after", cwd=standalone_up)
+        _boxman("exec web.cache -- redis-cli save", cwd=standalone_up)
+
         assert _boxman("snapshot restore --name e2e1", cwd=standalone_up, warn=True).ok
 
+        # the container filesystem went back to the snapshot
         gone = _boxman("exec web.cache -- ls /tmp/dirt", cwd=standalone_up, warn=True)
         assert not gone.ok, "container filesystem was not rolled back"
 
-        # ...while the named volume is untouched by the snapshot
-        kept = _boxman("exec web.cache -- redis-cli get persisted", cwd=standalone_up)
-        assert "yes" in kept.stdout
+        # ...but the volume kept the *post-snapshot* write (docker commit never
+        # captured it), which is the divergence the docs warn about
+        kept = _boxman("exec web.cache -- redis-cli get divergence", cwd=standalone_up)
+        assert "after" in kept.stdout, (
+            "named volume was rolled back with the snapshot — D3 says commit "
+            f"captures the writable layer only. got: {kept.stdout!r}")
 
         assert _boxman("snapshot delete --name e2e1", cwd=standalone_up, warn=True).ok
 
@@ -206,8 +222,21 @@ class TestDockerComposeProviderLifecycle:
         _boxman("snapshot delete --name dup", cwd=standalone_up, warn=True)
 
     def test_destroy_removes_containers_and_named_volumes(self):
-        """AC15: destroy tears down containers *and* named volumes."""
-        _boxman("provision --force", cwd=STANDALONE, warn=True)
+        """AC15: destroy tears down containers *and* named volumes.
+
+        **Must stay the last test in this class.** It deliberately does not
+        take ``standalone_up`` yet tears the module deployment down, so any
+        test added below it — or any run order shuffled by a plugin such as
+        pytest-randomly — would execute against a destroyed project. (The
+        second destroy in the fixture teardown is harmless: idempotent and
+        ``warn=True``.)
+
+        The re-provision is asserted so a transient failure cannot leave both
+        emptiness checks passing vacuously against a project that was never
+        brought up.
+        """
+        assert _boxman("provision --force", cwd=STANDALONE, warn=True).ok, \
+            "re-provision failed — the emptiness assertions below would be vacuous"
         assert _boxman("destroy --auto-accept", cwd=STANDALONE, warn=True).ok
         ps = _run(f"docker compose -p {STANDALONE_PROJECT} ps -q", warn=True)
         assert not ps.stdout.strip()
@@ -221,9 +250,36 @@ class TestDockerComposeProviderLifecycle:
 # Tier 2 — hybrid: VM ↔ container on a shared L2 domain (needs KVM)
 # ---------------------------------------------------------------------------
 
+#: the VM's address on the shared bridge, and the NIC it belongs to. That L2
+#: domain has no DHCP on purpose (addressing it at boot would make boxman
+#: mistake the host-unreachable address for node01's management IP), so the
+#: fixture assigns it — see the box README, step 1.
+VM_BRIDGE_IP = "10.10.0.20"
+VM_BRIDGE_NIC = "enp7s0"
+CONTAINER_BRIDGE_IP = "10.10.0.10"
+
+
+def _vm_ssh(box_dir, command, warn=False):
+    """Run *command* on the hybrid box's VM.
+
+    ``boxman ssh`` opens an interactive session and takes no trailing command,
+    so this goes through the ssh_config boxman generates in the workspace.
+    """
+    ssh_config = os.path.join(_workspace_path(box_dir), "ssh_config")
+    return _run(
+        f"ssh -F {ssh_config} -o BatchMode=yes -o ConnectTimeout=10 "
+        f"compute_node01 {command}", warn=warn)
+
+
 @pytest.fixture(scope="module")
 def hybrid_up():
     """Provision the hybrid box for the module, destroy it after.
+
+    Also establishes the L2 precondition: the VM's address on the shared
+    bridge. Doing it here (rather than skipping later when it is absent) keeps
+    the AC10/AC11 assertions able to *fail* — a broken macvlan parent, a
+    missing bridge attachment or a firewall regression must not look like an
+    unconfigured operator.
 
     Module-scoped and defined at module level: a class-scoped fixture written
     as an instance method is deprecated by pytest.
@@ -231,6 +287,16 @@ def hybrid_up():
     _boxman("destroy --auto-accept", cwd=HYBRID, warn=True)
     result = _boxman("provision --force", cwd=HYBRID, warn=True)
     assert result.ok, f"hybrid provision failed:\n{result.stdout}\n{result.stderr}"
+
+    # idempotent: a re-run would report "File exists", so verify rather than
+    # trust the exit status
+    _vm_ssh(HYBRID, f"sudo ip addr add {VM_BRIDGE_IP}/24 dev {VM_BRIDGE_NIC}",
+            warn=True)
+    shown = _vm_ssh(HYBRID, f"ip -4 -br addr show {VM_BRIDGE_NIC}", warn=True)
+    assert VM_BRIDGE_IP in shown.stdout, (
+        f"could not put {VM_BRIDGE_IP} on {VM_BRIDGE_NIC}; the L2 assertions "
+        f"would be meaningless. got: {shown.stdout!r} {shown.stderr!r}")
+
     yield HYBRID
     _boxman("destroy --auto-accept", cwd=HYBRID, warn=True)
 
@@ -281,20 +347,42 @@ class TestHybridVmContainer:
             assert '"driver": "macvlan"' in info or '"Driver": "macvlan"' in info
             assert "bx_app" in info, "macvlan is not parented on the host bridge"
 
-    def test_container_reaches_vm_over_shared_bridge(self, hybrid_up):
-        """AC10/AC11: the macvlan container pings the VM on the shared bridge
-        and learns its MAC via ARP.
+    def test_container_and_vm_reach_each_other_over_shared_bridge(self, hybrid_up):
+        """AC10: VM and container ping each other across the shared bridge.
 
-        The VM's shared-bridge address is assigned by the README walkthrough
-        (that L2 domain has no DHCP), so skip rather than fail when it has not
-        been set up — this test asserts boxman's plumbing, not the operator's.
+        The address precondition is established by the fixture, so a failure
+        here is a real regression (macvlan parent, bridge attachment,
+        netfilter) rather than an unconfigured operator — no skipping.
         """
-        ping = _boxman(
-            "exec services.web -- ping -c2 -W2 10.10.0.20", cwd=hybrid_up, warn=True)
-        if not ping.ok:
-            pytest.skip(
-                "VM shared-bridge address 10.10.0.20 not configured — follow "
-                "the box README before running the L2 assertions")
+        out = _boxman(
+            f"exec services.web -- ping -c2 -W2 {VM_BRIDGE_IP}",
+            cwd=hybrid_up, warn=True)
+        assert out.ok, f"container could not reach the VM:\n{out.stdout}{out.stderr}"
+
+        back = _vm_ssh(hybrid_up, f"ping -c2 -W2 {CONTAINER_BRIDGE_IP}", warn=True)
+        assert back.ok, f"VM could not reach the container:\n{back.stdout}{back.stderr}"
+
+    def test_arp_resolves_across_the_shared_bridge(self, hybrid_up):
+        """AC11: each side learns the other's real MAC — proof this is L2 and
+        not routed. The VM's MAC is pinned in the box conf, so assert that
+        exact value rather than merely 'some lladdr'."""
         arp = _boxman(
-            "exec services.web -- ip neigh show 10.10.0.20", cwd=hybrid_up, warn=True)
-        assert "lladdr" in arp.stdout, "no ARP entry learned for the VM"
+            f"exec services.web -- ip neigh show {VM_BRIDGE_IP}",
+            cwd=hybrid_up, warn=True)
+        assert "lladdr" in arp.stdout, f"no ARP entry for the VM: {arp.stdout!r}"
+        # adapter_2's mac in boxes/hybrid-libvirt-docker-compose/conf.yml
+        assert "52:54:00:aa:00:02" in arp.stdout.lower(), (
+            f"container resolved the VM to an unexpected MAC: {arp.stdout!r}")
+
+        back = _vm_ssh(hybrid_up, f"ip neigh show {CONTAINER_BRIDGE_IP}", warn=True)
+        assert "lladdr" in back.stdout, (
+            f"VM learned no ARP entry for the container: {back.stdout!r}")
+
+    def test_cluster_internal_address_unreachable_from_vm(self, hybrid_up):
+        """AC12, the traffic-level half: the container's cluster-internal
+        address is not reachable from the VM — only the shared bridge is
+        L2-adjacent."""
+        out = _vm_ssh(hybrid_up, "ping -c2 -W2 172.31.0.2", warn=True)
+        assert not out.ok, (
+            "the cluster-internal network is reachable from the VM — isolation "
+            f"regression:\n{out.stdout}")

--- a/tests/test_docker_compose_provider_e2e.py
+++ b/tests/test_docker_compose_provider_e2e.py
@@ -1,0 +1,300 @@
+"""
+End-to-end integration tests for the **docker-compose provider**.
+
+Not to be confused with ``test_docker_compose.py``, which covers the
+docker-compose *runtime* (libvirt-in-a-container). The two axes share a name
+but are unrelated: this file drives real ``boxman`` verbs against real
+containers on the ``local`` runtime.
+
+Two tiers:
+
+* **docker-only** — the whole provider lifecycle against
+  ``boxes/docker-compose-standalone``: provision, ps, exec, volume
+  persistence across down/up, snapshot take/restore/delete, destroy. Needs
+  Docker + compose v2 only, so it runs anywhere Docker does.
+* **hybrid (KVM-gated)** — ``boxes/hybrid-libvirt-docker-compose``: a libvirt
+  VM and a container sharing an L2 domain, plus the mixed-project ps and
+  inventory. Skipped without ``/dev/kvm``.
+
+These are local-only, like ``make test-provision`` — they create and destroy
+real infrastructure::
+
+    make test-dc-e2e                                  # docker-only tier
+    make test-dc-e2e pytest_args="-k hybrid"          # hybrid tier too
+"""
+
+import json
+import os
+import shutil
+
+import invoke
+import pytest
+
+BOXMAN_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BOXES_DIR = os.path.join(BOXMAN_DIR, "boxes")
+STANDALONE = os.path.join(BOXES_DIR, "docker-compose-standalone")
+HYBRID = os.path.join(BOXES_DIR, "hybrid-libvirt-docker-compose")
+
+#: compose project boxman derives for the standalone box's ``web`` cluster
+#: (``<provider.project_name>_<cluster>``)
+STANDALONE_PROJECT = "dc_standalone_web"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run(cmd, cwd=None, warn=False):
+    """Run a shell command (optionally in *cwd*) and return the invoke Result."""
+    ctx = invoke.context.Context()
+    if cwd:
+        with ctx.cd(cwd):
+            return ctx.run(cmd, hide=True, warn=warn, in_stream=False)
+    return ctx.run(cmd, hide=True, warn=warn, in_stream=False)
+
+
+def _boxman(args, cwd, warn=False):
+    """Invoke the boxman CLI out of the working tree (no install required)."""
+    src = os.path.join(BOXMAN_DIR, "src")
+    app = os.path.join(src, "boxman", "scripts", "app.py")
+    return _run(
+        f"PYTHONPATH={src}:$PYTHONPATH python3 {app} {args}", cwd=cwd, warn=warn)
+
+
+def _workspace_path(box_dir):
+    """The box's ``workspace.path``, expanded — where the workspace-level
+    inventory / ssh_config / env.sh are written (a cluster ``workdir`` only
+    holds that cluster's own files)."""
+    import yaml
+    from boxman.utils.jinja_env import create_jinja_env
+
+    raw = open(os.path.join(box_dir, "conf.yml")).read()
+    rendered = create_jinja_env(box_dir).from_string(raw).render()
+    conf = yaml.safe_load(rendered)
+    path = (conf.get("workspace") or {}).get("path")
+    assert path, f"{box_dir}/conf.yml declares no workspace.path"
+    return os.path.expanduser(path)
+
+
+def _docker_available():
+    return (
+        shutil.which("docker") is not None
+        and _run("docker compose version", warn=True).ok
+    )
+
+
+def _kvm_available():
+    return os.path.exists("/dev/kvm")
+
+
+requires_docker = pytest.mark.skipif(
+    not _docker_available(),
+    reason="needs Docker with the compose v2 plugin")
+
+requires_kvm = pytest.mark.skipif(
+    not _kvm_available(), reason="needs /dev/kvm for the libvirt half")
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — docker-only: the full provider lifecycle
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def standalone_up():
+    """Provision the standalone box for the module, destroy it after.
+
+    ``--force`` so a stale cache entry from an interrupted run cannot wedge
+    the whole module.
+    """
+    _boxman("destroy --auto-accept", cwd=STANDALONE, warn=True)
+    result = _boxman("provision --force", cwd=STANDALONE, warn=True)
+    assert result.ok, f"provision failed:\n{result.stdout}\n{result.stderr}"
+    yield STANDALONE
+    _boxman("destroy --auto-accept", cwd=STANDALONE, warn=True)
+
+
+@requires_docker
+@pytest.mark.integration
+class TestDockerComposeProviderLifecycle:
+    """provision → ps → exec → volumes → snapshots → destroy, on real docker."""
+
+    def test_containers_are_running(self, standalone_up):
+        out = _run(
+            f"docker compose -p {STANDALONE_PROJECT} ps --format json --all",
+            warn=True).stdout
+        states = {
+            obj["Service"]: obj["State"]
+            for line in out.splitlines() if line.strip()
+            for obj in ([json.loads(line)] if line.strip().startswith("{")
+                        else json.loads(line))
+        }
+        assert states.get("cache") == "running"
+        assert states.get("frontend") == "running"
+
+    def test_published_port_serves_the_bind_mount(self, standalone_up):
+        """The frontend publishes :8080 and serves ./site (a read-only bind)."""
+        body = _run("curl -s localhost:8080", warn=True).stdout
+        assert "boxman" in body
+
+    def test_bind_mount_is_readonly(self, standalone_up):
+        """`readonly: true` must reach the container as :ro.
+
+        Asserts the *specific* refusal rather than merely a non-zero exit, so
+        this cannot pass because `exec` itself broke.
+        """
+        result = _boxman(
+            "exec web.frontend -- sh -c 'echo x > /usr/share/nginx/html/x'",
+            cwd=standalone_up, warn=True)
+        assert "Read-only file system" in (result.stdout + result.stderr), (
+            f"expected a read-only refusal, got:\n{result.stdout}\n{result.stderr}")
+        # and the write really did not land
+        listing = _boxman("exec web.frontend -- ls /usr/share/nginx/html",
+                          cwd=standalone_up, warn=True)
+        assert " x" not in listing.stdout.replace("\n", " ") + " "
+
+    def test_exec_one_shot(self, standalone_up):
+        result = _boxman("exec web.cache -- redis-cli ping", cwd=standalone_up)
+        assert "PONG" in result.stdout
+
+    def test_ps_reports_containers_with_provider(self, standalone_up):
+        result = _boxman("ps --json", cwd=standalone_up, warn=True)
+        rows = json.loads(result.stdout[result.stdout.index("["):])
+        dc_rows = [r for r in rows if r.get("provider") == "docker-compose"]
+        assert {r["vm"] for r in dc_rows} >= {"cache", "frontend"}
+
+    def test_inventory_lists_containers_with_docker_connection(self, standalone_up):
+        inv = os.path.join(
+            standalone_up, ".boxman", "web", "inventory", "01-hosts.yml")
+        assert os.path.isfile(inv), f"no per-cluster inventory at {inv}"
+        text = open(inv).read()
+        assert "community.docker.docker" in text
+        # ansible_host must be the real container name, not the box name
+        assert f"{STANDALONE_PROJECT}-cache-1" in text
+
+    def test_named_volume_survives_down_up(self, standalone_up):
+        """AC13: a named volume outlives a stop/start cycle."""
+        _boxman("exec web.cache -- redis-cli set greeting hello", cwd=standalone_up)
+        _boxman("exec web.cache -- redis-cli save", cwd=standalone_up)
+        assert _boxman("down", cwd=standalone_up, warn=True).ok
+        assert _boxman("up", cwd=standalone_up, warn=True).ok
+        result = _boxman("exec web.cache -- redis-cli get greeting", cwd=standalone_up)
+        assert "hello" in result.stdout
+
+    def test_snapshot_take_restore_and_volume_divergence(self, standalone_up):
+        """D3: a restore rolls back the container filesystem but NOT volumes."""
+        _boxman("exec web.cache -- redis-cli set persisted yes", cwd=standalone_up)
+        _boxman("exec web.cache -- redis-cli save", cwd=standalone_up)
+        assert _boxman("snapshot take --name e2e1 -m e2e", cwd=standalone_up, warn=True).ok
+
+        # dirty the container filesystem after the snapshot
+        _boxman("exec web.cache -- sh -c 'echo dirt > /tmp/dirt'", cwd=standalone_up)
+        assert _boxman("snapshot restore --name e2e1", cwd=standalone_up, warn=True).ok
+
+        gone = _boxman("exec web.cache -- ls /tmp/dirt", cwd=standalone_up, warn=True)
+        assert not gone.ok, "container filesystem was not rolled back"
+
+        # ...while the named volume is untouched by the snapshot
+        kept = _boxman("exec web.cache -- redis-cli get persisted", cwd=standalone_up)
+        assert "yes" in kept.stdout
+
+        assert _boxman("snapshot delete --name e2e1", cwd=standalone_up, warn=True).ok
+
+    def test_snapshot_take_rejects_duplicate_name(self, standalone_up):
+        assert _boxman("snapshot take --name dup", cwd=standalone_up, warn=True).ok
+        again = _boxman("snapshot take --name dup", cwd=standalone_up, warn=True)
+        assert "already exists" in (again.stdout + again.stderr)
+        _boxman("snapshot delete --name dup", cwd=standalone_up, warn=True)
+
+    def test_destroy_removes_containers_and_named_volumes(self):
+        """AC15: destroy tears down containers *and* named volumes."""
+        _boxman("provision --force", cwd=STANDALONE, warn=True)
+        assert _boxman("destroy --auto-accept", cwd=STANDALONE, warn=True).ok
+        ps = _run(f"docker compose -p {STANDALONE_PROJECT} ps -q", warn=True)
+        assert not ps.stdout.strip()
+        vols = _run(
+            f"docker volume ls -q --filter label=com.docker.compose.project="
+            f"{STANDALONE_PROJECT}", warn=True)
+        assert not vols.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — hybrid: VM ↔ container on a shared L2 domain (needs KVM)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def hybrid_up():
+    """Provision the hybrid box for the module, destroy it after.
+
+    Module-scoped and defined at module level: a class-scoped fixture written
+    as an instance method is deprecated by pytest.
+    """
+    _boxman("destroy --auto-accept", cwd=HYBRID, warn=True)
+    result = _boxman("provision --force", cwd=HYBRID, warn=True)
+    assert result.ok, f"hybrid provision failed:\n{result.stdout}\n{result.stderr}"
+    yield HYBRID
+    _boxman("destroy --auto-accept", cwd=HYBRID, warn=True)
+
+
+@requires_docker
+@requires_kvm
+@pytest.mark.integration
+class TestHybridVmContainer:
+    """AC10–AC12 + mixed-project ps/inventory. Boots a real VM — slow."""
+
+    def test_mixed_ps_shows_both_providers(self, hybrid_up):
+        result = _boxman("ps --json", cwd=hybrid_up, warn=True)
+        rows = json.loads(result.stdout[result.stdout.index("["):])
+        providers = {r.get("provider") for r in rows}
+        assert "docker-compose" in providers
+        assert "libvirt" in providers
+
+    def test_inventory_spans_both_providers(self, hybrid_up):
+        """AC18: the *workspace* inventory carries the VM and the container,
+        each with its own connection style.
+
+        Note this lives under ``workspace.path``, not the box directory — only
+        the per-cluster inventories are written under a cluster ``workdir``.
+        """
+        inv = os.path.join(_workspace_path(hybrid_up), "inventory", "01-hosts.yml")
+        assert os.path.isfile(inv), f"no workspace inventory at {inv}"
+        text = open(inv).read()
+        # the container: reached over the docker connection plugin
+        assert "community.docker.docker" in text
+        assert "hybrid_libvirt_dc_services-web-1" in text
+        # the VM: an ordinary ssh host, no docker connection vars
+        assert "compute_node01" in text
+
+    def test_cluster_internal_network_is_isolated_from_the_bridge(self, hybrid_up):
+        """AC12: the cluster-internal network is an ordinary compose-scoped
+        bridge, while only the *shared* network is a macvlan onto the host
+        bridge — so internal traffic never reaches the VM's L2 domain."""
+        nets = _run("docker network ls --format '{{.Name}} {{.Driver}}'", warn=True).stdout
+        internal = [l for l in nets.splitlines() if "backend" in l]
+        assert internal, f"cluster-internal network not found in:\n{nets}"
+        assert all(line.split()[1] == "bridge" for line in internal)
+
+        shared = [l for l in nets.splitlines() if "app_bridge" in l]
+        assert shared, f"shared macvlan network not found in:\n{nets}"
+        for line in shared:
+            name = line.split()[0]
+            info = _run(f"docker network inspect {name}", warn=True).stdout
+            assert '"driver": "macvlan"' in info or '"Driver": "macvlan"' in info
+            assert "bx_app" in info, "macvlan is not parented on the host bridge"
+
+    def test_container_reaches_vm_over_shared_bridge(self, hybrid_up):
+        """AC10/AC11: the macvlan container pings the VM on the shared bridge
+        and learns its MAC via ARP.
+
+        The VM's shared-bridge address is assigned by the README walkthrough
+        (that L2 domain has no DHCP), so skip rather than fail when it has not
+        been set up — this test asserts boxman's plumbing, not the operator's.
+        """
+        ping = _boxman(
+            "exec services.web -- ping -c2 -W2 10.10.0.20", cwd=hybrid_up, warn=True)
+        if not ping.ok:
+            pytest.skip(
+                "VM shared-bridge address 10.10.0.20 not configured — follow "
+                "the box README before running the L2 assertions")
+        arp = _boxman(
+            "exec services.web -- ip neigh show 10.10.0.20", cwd=hybrid_up, warn=True)
+        assert "lladdr" in arp.stdout, "no ARP entry learned for the VM"

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -143,6 +143,23 @@ class TestLoadWorkspaceEnv:
         assert result["INVENTORY"] == str(tmp_path / "inventory")
         assert result["ANSIBLE_INVENTORY"] == result["INVENTORY"]
 
+    def test_relative_cluster_workdir_yields_absolute_inventory(self, monkeypatch, tmp_path):
+        """A *relative* cluster workdir must still produce an absolute
+        INVENTORY.
+
+        Tasks run with cwd set to the workdir, so a result that stayed relative
+        got resolved a second time against that cwd — a docker-compose cluster
+        with `workdir: ./.boxman/web` produced
+        `.boxman/web/.boxman/web/inventory`, ansible parsed nothing and silently
+        fell back to an implicit localhost.
+        """
+        monkeypatch.chdir(tmp_path)
+        cluster = {"workdir": "./.boxman/web", "inventory": "inventory"}
+        result = load_workspace_env(cluster, {})
+        assert os.path.isabs(result["INVENTORY"])
+        assert result["INVENTORY"] == str(tmp_path / ".boxman" / "web" / "inventory")
+        assert result["ANSIBLE_INVENTORY"] == result["INVENTORY"]
+
     def test_cluster_absolute_inventory_left_untouched(self, tmp_path):
         """An absolute cluster inventory is used as-is, not joined to workdir."""
         abs_inv = str(tmp_path / "elsewhere" / "inv")


### PR DESCRIPTION
Phase 8 of the docker-compose provider epic (#42) — closes #56. Branches off and targets `feat/docker-compose-provider`.

The last substantive phase: e2e coverage, an example that exercises the features Phases 5–7 added, and the user-facing documentation the provider has been missing.

## Example box

`boxes/docker-compose-standalone` becomes the **feature showcase** — a named volume (redis `/data`) and a read-only bind mount (`./site` → nginx docroot), plus README walkthroughs for volumes, `boxman exec`, the ansible inventory and snapshots. It needs no KVM and no cloud images, so the whole walkthrough runs on any docker host.

`boxes/hybrid-libvirt-docker-compose` is deliberately left alone: it teaches exactly one delicate thing (VM↔container L2 over a shared bridge), and loading it with volumes and snapshots would dilute that. Discussed with @Orski174 before implementing.

## e2e tests

New `tests/test_docker_compose_provider_e2e.py` (`make test-dc-e2e`), two tiers, both `@pytest.mark.integration` and local-only:

- **docker-only** — provision, `ps`, `exec`, published port + bind mount, `:ro` enforcement, named volume across `down`/`up`, snapshot take/restore including the volume-divergence caveat, duplicate-name rejection, and `destroy` removing containers *and* named volumes.
- **hybrid, gated on `/dev/kvm`** — mixed `ps`, an inventory spanning both providers, cluster-internal vs macvlan isolation, and VM↔container ping/ARP.

Named so it does not collide with `test_docker_compose.py`, which covers the docker-compose **runtime** — an unrelated axis that happens to share the name.

**Result on the staging host: 13 passed, 1 skipped.** The skip is the L2 ping test, which requires the VM's shared-bridge address to be assigned first (that domain has no DHCP by design); verified manually instead, see below.

## Two bugs this phase surfaced

Both were found by actually running what the docs claim, which is the point of the phase.

**1. `boxman run` never reached containers.** The task runner runs with `cwd` set to the workdir, but a relative cluster `inventory` was resolved with `normpath` only — so a docker-compose cluster's `workdir: ./.boxman/web` produced `.boxman/web/.boxman/web/inventory`. Ansible parsed no inventory and **silently fell back to an implicit localhost** — the failure mode that looks like success. Phase 6 checked the inventory's *contents* but never ran `boxman run` against it.

One-line fix in `env_loader.py` (`normpath` → `abspath`). This restores the contract the existing tests already describe as "INVENTORY (absolute)" — they passed only because their workdirs were absolute `tmp_path`s. Behaviour is identical when the workdir is already absolute. Regression test added with a relative workdir.

**2. The hybrid box README documented a command that does not exist.** `boxman ssh` takes only a VM name and `--cluster`; it opens an interactive session and accepts no trailing command. Every `boxman ssh compute_node01 -- <cmd>` line in that README failed with `unrecognized arguments`. Since "fresh-host walkthrough of the hybrid example passes" is this phase's acceptance criterion, running it is what caught this. Replaced with ssh over the `ssh_config` boxman generates in the workspace.

## Docs

- **README** — a `Providers` section: the per-cluster model, a mixed example, and an explicit disambiguation of docker-compose the *runtime* from docker-compose the *provider*, plus the two differences that bite first (`ssh` is VM-only; `--vms` is libvirt-only).
- **`doc/docker-compose-provider/user-guide.md`** — the practical path: prerequisites, minimal project, lifecycle table, volumes, networking, `exec`, ansible, snapshots, mixed-project scoping, troubleshooting.
- **`doc/docker-compose-provider/migration-v1-to-v2.md`** — v1.0 → v2.0, quoting the errors boxman actually emits (checked against the code, not assumed — e.g. it is the docker-compose provider specifically that requires v2.0, not any per-cluster `provider:` key).
- **design.md** — an AC1–AC18 coverage table naming the test that proves each one; the doc index gains a user-facing section and a phase status table, replacing a stale "Begin Phase 1" next-steps list.

One limitation is now documented rather than papered over: ansible **modules** need a Python interpreter inside the container, which alpine-based images lack. `ansible -m raw` works (verified); `boxman run --cmd` wraps `ansible.builtin.shell` and so needs an image with Python. An earlier draft of the box README claimed `boxman run --cmd 'nginx -v'` just works — it does not, and that claim was corrected.

## Verification

- **Host unit suite: 1329 green** (+1 for the env_loader regression).
- **e2e on the staging host: 13 passed, 1 skipped.**
- **Live, with the L2 precondition met** (AC10/AC11/AC12): ping 0% loss in both directions; ARP resolving the VM to `52:54:00:aa:00:02` — `adapter_2`'s MAC straight out of the box conf, so this is L2 and not routing — and the container's cluster-internal address unreachable from the VM (100% loss).
- Every markdown link added here resolves; the generated compose for the enriched box was checked through the real `ComposeGenerator` (named volume + top-level declaration, bind resolved to an absolute path with `:ro`).

## Not included

- `README.md` has a pre-existing broken link, `[MIT License](../LICENSE)`, which should be `LICENSE` — left alone as unrelated to this phase.
