### PR TITLE
feat(net): reconcile libvirt networks on up and update

### DIFF
--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -2038,7 +2038,7 @@ class BoxmanManager:
         and the second net-define fails with "bridge name already in use".
         """
         for cluster_name, cluster in self.config['clusters'].items():
-            for network_name, network_info in cluster.get('networks', {}).items():
+            for network_name, network_info in (cluster.get('networks') or {}).items():
                 _network_name = self.full_network_name(
                     project_config=self.config,
                     cluster_name=cluster_name,
@@ -2088,7 +2088,7 @@ class BoxmanManager:
         results: dict[str, str] = {}
 
         for cluster_name, cluster in self.config['clusters'].items():
-            for network_name, network_info in cluster.get('networks', {}).items():
+            for network_name, network_info in (cluster.get('networks') or {}).items():
                 full_name = self.full_network_name(
                     project_config=self.config,
                     cluster_name=cluster_name,
@@ -2185,6 +2185,16 @@ class BoxmanManager:
                     f"could not be reconnected")
             else:
                 self.logger.info(f"network {full_name}: {outcome}")
+
+    def _vms_worth_waiting_for(self) -> list[str]:
+        """
+        Project VMs minus the ones a recreate could not reconnect.
+
+        Waiting on a guest we already reported as unreachable only burns the
+        whole timeout before saying what we already knew.
+        """
+        unreachable = getattr(self, '_reattach_failed_vms', set())
+        return sorted(set(self._get_project_vm_names()) - unreachable)
 
     def wait_for_vm_ips(self, vm_names: list[str], max_wait: int = 300) -> bool:
         """
@@ -2383,6 +2393,11 @@ class BoxmanManager:
             outcome = self.provider.reattach_domain_network(domain, full_name)
             if outcome == 'failed':
                 reattach_failed.append(domain)
+                # remembered so the post-recreate IP wait does not sit on a
+                # guest we already know is not coming back on its own
+                if not hasattr(self, '_reattach_failed_vms'):
+                    self._reattach_failed_vms = set()
+                self._reattach_failed_vms.add(domain)
                 self.logger.error(
                     f"{domain}: could not be reconnected to {network_name}, "
                     f"start it by hand")
@@ -2418,7 +2433,7 @@ class BoxmanManager:
         processes = [
             Process(target=_destroy, args=(cluster_name, cluster, network_name, network_info))
             for cluster_name, cluster in self.config['clusters'].items()
-            for network_name, network_info in cluster.get('networks', {}).items()
+            for network_name, network_info in (cluster.get('networks') or {}).items()
         ]
         [p.start() for p in processes]
         [p.join() for p in processes]
@@ -3722,7 +3737,7 @@ class BoxmanManager:
             # written from do not exist yet
             if any(outcome in ('recreated', 'partial')
                    for outcome in network_results.values()):
-                cls.wait_for_vm_ips(sorted(cls._get_project_vm_names()))
+                cls.wait_for_vm_ips(cls._vms_worth_waiting_for())
 
             cls.ensure_netlab_up()
             cls.connect_info()
@@ -3949,7 +3964,11 @@ class BoxmanManager:
         print()
 
         if not auto_accept:
-            answer = input("Proceed? [y/N] ").strip().lower()
+            try:
+                answer = input("Proceed? [y/N] ").strip().lower()
+            except EOFError:
+                print("No input available, aborted.")
+                return
             if answer not in ("y", "yes"):
                 print("Aborted.")
                 return
@@ -5744,6 +5763,11 @@ class BoxmanManager:
 
         # regenerate SSH config and display connect info
         if not dry_run:
+            # a recreated network power-cycles the guests attached to it, so
+            # the addresses the ssh config is written from do not exist yet
+            if any(outcome in ('recreated', 'partial')
+                   for outcome in network_results.values()):
+                cls.wait_for_vm_ips(cls._vms_worth_waiting_for())
             cls.setup_ssh_access()
             cls.connect_info()
 

--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -2110,31 +2110,52 @@ class BoxmanManager:
                 if plan['action'] == 'none':
                     continue
 
-                for line in net_reconcile.describe_plan(network_name, plan):
+                # two clusters may each hold a network called 'mgmt', so the
+                # logs carry the cluster as well
+                label = f"{cluster_name}/{network_name}"
+
+                if plan['action'] == 'error':
+                    results[full_name] = 'failed'
+                    continue
+
+                for line in net_reconcile.describe_plan(label, plan):
                     self.logger.info(line)
 
                 if plan['action'] == 'create':
-                    self.logger.info(f"network {network_name}: not defined yet")
+                    self.logger.info(f"network {label}: not defined yet")
                     if dry_run:
                         results[full_name] = 'skipped'
                         continue
-                    ok = self.provider.define_network(
-                        name=full_name, info=network_info,
-                        workdir=cluster['workdir'])
-                    results[full_name] = 'created' if ok else 'failed'
+                    results[full_name] = self._define_network(
+                        label=label, full_name=full_name,
+                        network_info=network_info, workdir=cluster['workdir'])
 
                 elif plan['action'] == 'live':
                     if dry_run:
+                        if plan.get('inactive'):
+                            self.logger.info(
+                                f"[dry-run] network {label}: is defined but "
+                                f"not running, would start it")
                         results[full_name] = 'skipped'
                         continue
-                    ok = self.provider.apply_network_live_plan(
-                        name=full_name, info=network_info, plan=plan)
+
+                    ok = True
+                    if plan.get('inactive'):
+                        self.logger.info(
+                            f"network {label}: is defined but not running, "
+                            f"starting it")
+                        ok = self.provider.start_network(
+                            name=full_name, info=network_info)
+
+                    if ok and (plan['host_ops'] or plan['range_ops']):
+                        ok = self.provider.apply_network_live_plan(
+                            name=full_name, info=network_info, plan=plan)
                     results[full_name] = 'updated' if ok else 'failed'
 
                 elif plan['action'] == 'recreate':
                     results[full_name] = self._recreate_network(
                         cluster=cluster,
-                        network_name=network_name,
+                        network_name=label,
                         full_name=full_name,
                         network_info=network_info,
                         plan=plan,
@@ -2143,6 +2164,100 @@ class BoxmanManager:
                         auto_accept=auto_accept)
 
         return results
+
+    def report_network_results(self, results: dict[str, str]) -> None:
+        """
+        Log the outcome of a reconcile, loudly for the ones that went wrong.
+
+        ``failed`` and ``partial`` would otherwise be buried: the caller
+        carries on either way, so this is the only place a user learns that a
+        network did not come back or that a guest is still disconnected.
+        """
+        if not results:
+            return
+
+        for full_name, outcome in sorted(results.items()):
+            if outcome == 'failed':
+                self.logger.error(f"network {full_name}: {outcome}")
+            elif outcome == 'partial':
+                self.logger.warning(
+                    f"network {full_name}: recreated, but at least one VM "
+                    f"could not be reconnected")
+            else:
+                self.logger.info(f"network {full_name}: {outcome}")
+
+    def wait_for_vm_ips(self, vm_names: list[str], max_wait: int = 300) -> bool:
+        """
+        Wait until every named VM reports an address, or *max_wait* passes.
+
+        Returns:
+            True if they all got one.
+        """
+        if not vm_names:
+            return True
+
+        self.logger.info("waiting for VMs to get IP addresses...")
+        wait_time = 1
+        total_waited = 0
+        while total_waited < max_wait:
+            if all(self.provider.get_vm_ip_addresses(name) for name in vm_names):
+                self.logger.info(
+                    f"all VMs have IP addresses (waited {total_waited}s)")
+                return True
+            time.sleep(wait_time)
+            total_waited += wait_time
+            wait_time = min(wait_time * 2, 60)
+
+        self.logger.warning(
+            f"not every VM had an IP address after {max_wait}s; the ssh "
+            f"config may be incomplete")
+        return False
+
+    def _define_network(self,
+                        label: str,
+                        full_name: str,
+                        network_info: dict[str, Any],
+                        workdir: str) -> str:
+        """
+        Define a network, turning a conflict into a result instead of a crash.
+
+        ``define_network`` starts with ``check_network_exists()``, which raises
+        when the cache already holds an entry with this name, bridge or
+        address. That is the right guard when two projects collide, but it
+        raises before the try inside ``define_network``, so left alone it
+        reaches the CLI as a traceback.
+        """
+        try:
+            ok = self.provider.define_network(
+                name=full_name, info=network_info, workdir=workdir)
+        except RuntimeError as exc:
+            self.logger.error(f"network {label}: could not be defined: {exc}")
+            return 'failed'
+        return 'created' if ok else 'failed'
+
+    def _forget_cached_network(self, full_name: str) -> None:
+        """
+        Drop a network's entry from the projects cache.
+
+        Needed before redefining it: ``check_network_exists()`` walks every
+        cached project *including this one*, so a network's own leftover entry
+        counts as a conflict with itself -- same name, same address -- and the
+        redefine raises instead of running. ``remove_network()`` only touches
+        libvirt and iptables, never the cache.
+        """
+        try:
+            self.cache.read_projects_cache()
+            project = (self.cache.projects or {}).get(self.config['project'])
+            if not project or full_name not in project.get('networks', {}):
+                return
+            del project['networks'][full_name]
+            self.cache.write_projects_cache()
+            self.logger.debug(f"removed {full_name} from the projects cache")
+        except (KeyError, OSError, ValueError) as exc:
+            # not fatal on its own, but the redefine that follows will fail on
+            # the stale entry, so say why
+            self.logger.warning(
+                f"could not drop {full_name} from the projects cache: {exc}")
 
     @staticmethod
     def _teardown_info(plan: dict[str, Any],
@@ -2216,15 +2331,22 @@ class BoxmanManager:
             print("\nIts bridge will be deleted and recreated. These VMs lose "
                   f"their network link and will be reconnected, by a reboot "
                   f"if their machine type cannot hot-plug: {attached_text}\n")
-            answer = input(
-                f"Type the network name '{network_name}' to proceed: ").strip()
+            try:
+                answer = input(
+                    f"Type '{network_name}' to proceed: ").strip()
+            except EOFError:
+                # nothing is attached to stdin (a cron run, a pipeline): treat
+                # that as a no rather than a traceback
+                print("No input available, aborted.")
+                return 'skipped'
             if answer != network_name:
                 print("Aborted.")
                 return 'skipped'
 
         self.logger.info(f"network {network_name}: removing")
+        removed = True
         try:
-            self.provider.remove_network(
+            removed = self.provider.remove_network(
                 name=full_name, info=self._teardown_info(plan, network_info))
         except RuntimeError as exc:
             # remove_network destroys and undefines before it touches iptables,
@@ -2234,20 +2356,41 @@ class BoxmanManager:
                 f"network {network_name}: removed, but its firewall rules "
                 f"could not be cleaned up: {exc}")
 
+        if not removed:
+            # destroy or undefine failed, so the network is still there.
+            # Redefining on top of it would fail confusingly
+            self.logger.error(
+                f"network {network_name}: could not be removed, leaving it "
+                f"as it is rather than defining on top of it")
+            return 'failed'
+
+        # the cache still lists the network we just removed, and
+        # check_network_exists() would count that as a conflict with itself
+        self._forget_cached_network(full_name)
+
         self.logger.info(f"network {network_name}: defining again")
-        if not self.provider.define_network(
-                name=full_name, info=network_info, workdir=cluster['workdir']):
+        if self._define_network(
+                label=network_name, full_name=full_name,
+                network_info=network_info,
+                workdir=cluster['workdir']) == 'failed':
             self.logger.error(
                 f"network {network_name}: could not be defined again. The "
                 f"attached VMs are left disconnected: {attached_text}")
             return 'failed'
 
+        reattach_failed = []
         for domain in attached:
             outcome = self.provider.reattach_domain_network(domain, full_name)
             if outcome == 'failed':
+                reattach_failed.append(domain)
                 self.logger.error(
                     f"{domain}: could not be reconnected to {network_name}, "
                     f"start it by hand")
+
+        if reattach_failed:
+            # the network is back but not every guest is, and saying
+            # 'recreated' would paper over a VM that is still down
+            return 'partial'
 
         return 'recreated'
 
@@ -3569,9 +3712,18 @@ class BoxmanManager:
             # manual `docker stop` may have left lab containers down
             # even though the VMs stayed up.
             cls.ensure_shared_bridges()
-            cls.reconcile_networks(
+            network_results = cls.reconcile_networks(
                 allow_recreate=getattr(cli_args, 'recreate_networks', False),
                 auto_accept=getattr(cli_args, 'yes', False))
+            cls.report_network_results(network_results)
+
+            # a recreate power-cycles the guests attached to the network, so
+            # the addresses connect_info() and the ssh config are about to be
+            # written from do not exist yet
+            if any(outcome in ('recreated', 'partial')
+                   for outcome in network_results.values()):
+                cls.wait_for_vm_ips(sorted(cls._get_project_vm_names()))
+
             cls.ensure_netlab_up()
             cls.connect_info()
             # Re-write SSH config in case IPs changed (DHCP renewals after
@@ -3596,9 +3748,9 @@ class BoxmanManager:
         # to find the network it is wired to, and any reservation added to the
         # config since the last run has to be in dnsmasq before the guest asks
         # for a lease.
-        cls.reconcile_networks(
+        cls.report_network_results(cls.reconcile_networks(
             allow_recreate=getattr(cli_args, 'recreate_networks', False),
-            auto_accept=getattr(cli_args, 'yes', False))
+            auto_accept=getattr(cli_args, 'yes', False)))
 
         # Build workdir lookup from process_vm_list for restore operations
         vm_workdir_map = {vm_name: workdir for vm_name, workdir in cls.process_vm_list(cli_args)}
@@ -5435,9 +5587,7 @@ class BoxmanManager:
             allow_recreate=getattr(cli_args, 'recreate_networks', False),
             auto_accept=auto_accept)
 
-        if network_results:
-            for network_name, outcome in sorted(network_results.items()):
-                cls.logger.info(f"network {network_name}: {outcome}")
+        cls.report_network_results(network_results)
 
         # --- categorize VMs ---
         expected_vms = set(cls._get_project_vm_names())

--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -18,6 +18,7 @@ from boxman import log
 from boxman.config_cache import BoxmanCache
 from boxman.image_cache import ImageCache
 from boxman.netlab import ContainerlabManager, shared_bridges
+from boxman.providers.libvirt import net_reconcile
 from boxman.providers.libvirt.commands import VirshCommand
 from boxman.providers.libvirt.session import LibVirtSession
 from boxman.runtime import RuntimeBase, create_runtime
@@ -2050,6 +2051,206 @@ class BoxmanManager:
                 )
                 self.logger.info(f"defined network {_network_name} in {cluster['workdir']}")
 
+    def reconcile_networks(self,
+                           dry_run: bool = False,
+                           allow_recreate: bool = False,
+                           auto_accept: bool = False) -> dict[str, str]:
+        """
+        Bring the libvirt networks in line with the configuration.
+
+        Three outcomes per network, decided by comparing the configuration
+        against ``virsh net-dumpxml``:
+
+        - **create** -- the network is not defined yet. Defined and started.
+        - **live** -- only the dhcp reservations or the dhcp range differ.
+          Applied with ``virsh net-update ... --live --config``: dnsmasq is
+          reloaded, the bridge stays up, no guest is disturbed.
+        - **recreate** -- the forward mode, address, netmask, bridge or mac
+          differ. libvirt cannot change these in place, so the network has to
+          be destroyed and defined again. That deletes the bridge and leaves
+          attached guests with a dead nic, so it only happens with
+          *allow_recreate*, and the guests are re-attached afterwards.
+
+        Args:
+            dry_run: report the plan and change nothing
+            allow_recreate: permit the disruptive path
+            auto_accept: skip the confirmation prompt for a recreate
+
+        Returns:
+            A mapping of network name to the action taken: one of ``created``,
+            ``updated``, ``recreated``, ``skipped`` or ``failed``.
+        """
+        if not hasattr(self.provider, 'plan_network'):
+            self.logger.debug(
+                "provider does not support network reconciliation, skipping")
+            return {}
+
+        results: dict[str, str] = {}
+
+        for cluster_name, cluster in self.config['clusters'].items():
+            for network_name, network_info in cluster.get('networks', {}).items():
+                full_name = self.full_network_name(
+                    project_config=self.config,
+                    cluster_name=cluster_name,
+                    network_name=network_name)
+
+                try:
+                    plan = self.provider.plan_network(
+                        name=full_name, info=network_info)
+                except ValueError as exc:
+                    # the network block itself does not validate (a bad dhcp
+                    # reservation, say). Report it against the network it came
+                    # from and carry on: the other networks, and the VMs, are
+                    # not necessarily affected
+                    self.logger.error(
+                        f"network {network_name}: {exc}")
+                    results[full_name] = 'failed'
+                    continue
+
+                if plan['action'] == 'none':
+                    continue
+
+                for line in net_reconcile.describe_plan(network_name, plan):
+                    self.logger.info(line)
+
+                if plan['action'] == 'create':
+                    self.logger.info(f"network {network_name}: not defined yet")
+                    if dry_run:
+                        results[full_name] = 'skipped'
+                        continue
+                    ok = self.provider.define_network(
+                        name=full_name, info=network_info,
+                        workdir=cluster['workdir'])
+                    results[full_name] = 'created' if ok else 'failed'
+
+                elif plan['action'] == 'live':
+                    if dry_run:
+                        results[full_name] = 'skipped'
+                        continue
+                    ok = self.provider.apply_network_live_plan(
+                        name=full_name, info=network_info, plan=plan)
+                    results[full_name] = 'updated' if ok else 'failed'
+
+                elif plan['action'] == 'recreate':
+                    results[full_name] = self._recreate_network(
+                        cluster=cluster,
+                        network_name=network_name,
+                        full_name=full_name,
+                        network_info=network_info,
+                        plan=plan,
+                        dry_run=dry_run,
+                        allow_recreate=allow_recreate,
+                        auto_accept=auto_accept)
+
+        return results
+
+    @staticmethod
+    def _teardown_info(plan: dict[str, Any],
+                       network_info: dict[str, Any]) -> dict[str, Any]:
+        """
+        Describe the network **as it is now**, for the removal step.
+
+        The iptables rules to withdraw are the ones that were installed for the
+        current definition, so they follow its forward mode, bridge and subnet
+        -- not the ones being defined in its place. Handing ``remove_network``
+        the new configuration would, on a ``nat`` -> ``route`` change, try to
+        withdraw route rules that were never added and leave the nat rules
+        behind.
+
+        No dhcp block is carried over: nothing in the teardown reads it, and
+        reservations validated against the new subnet would be rejected when
+        paired with the old address.
+        """
+        actual = plan.get('actual') or {}
+        if not actual.get('mode'):
+            return network_info
+
+        info: dict[str, Any] = {'mode': actual['mode']}
+
+        if actual.get('bridge_name'):
+            info['bridge'] = {'name': actual['bridge_name']}
+        if actual.get('ip_address'):
+            info['ip'] = {'address': actual['ip_address']}
+            if actual.get('netmask'):
+                info['ip']['netmask'] = actual['netmask']
+
+        return info
+
+    def _recreate_network(self,
+                          cluster: dict[str, Any],
+                          network_name: str,
+                          full_name: str,
+                          network_info: dict[str, Any],
+                          plan: dict[str, Any],
+                          dry_run: bool,
+                          allow_recreate: bool,
+                          auto_accept: bool) -> str:
+        """
+        Destroy and redefine one network, then reconnect its guests.
+
+        Split out of :meth:`reconcile_networks` because the disruptive path is
+        where all the caveats live and it deserves to be read on its own.
+        """
+        attached = plan.get('attached_vms', [])
+        attached_text = ', '.join(attached) if attached else 'none'
+
+        if not allow_recreate:
+            self.logger.warning(
+                f"network {network_name}: the changes above need the network "
+                f"to be destroyed and defined again, which libvirt cannot do "
+                f"in place. Re-run with --recreate-networks to apply them "
+                f"(attached VMs that would be restarted: {attached_text})")
+            return 'skipped'
+
+        if dry_run:
+            self.logger.info(
+                f"[dry-run] would recreate network {network_name} and "
+                f"reconnect: {attached_text}")
+            return 'skipped'
+
+        if not auto_accept:
+            print(f"\nNetwork '{network_name}' has to be destroyed and "
+                  f"redefined to apply:")
+            for change in plan['structural']:
+                print(f"  - {change}")
+            print("\nIts bridge will be deleted and recreated. These VMs lose "
+                  f"their network link and will be reconnected, by a reboot "
+                  f"if their machine type cannot hot-plug: {attached_text}\n")
+            answer = input(
+                f"Type the network name '{network_name}' to proceed: ").strip()
+            if answer != network_name:
+                print("Aborted.")
+                return 'skipped'
+
+        self.logger.info(f"network {network_name}: removing")
+        try:
+            self.provider.remove_network(
+                name=full_name, info=self._teardown_info(plan, network_info))
+        except RuntimeError as exc:
+            # remove_network destroys and undefines before it touches iptables,
+            # so the network is already gone: say what was left behind rather
+            # than aborting half way
+            self.logger.warning(
+                f"network {network_name}: removed, but its firewall rules "
+                f"could not be cleaned up: {exc}")
+
+        self.logger.info(f"network {network_name}: defining again")
+        if not self.provider.define_network(
+                name=full_name, info=network_info, workdir=cluster['workdir']):
+            self.logger.error(
+                f"network {network_name}: could not be defined again. The "
+                f"attached VMs are left disconnected: {attached_text}")
+            return 'failed'
+
+        for domain in attached:
+            outcome = self.provider.reattach_domain_network(domain, full_name)
+            if outcome == 'failed':
+                self.logger.error(
+                    f"{domain}: could not be reconnected to {network_name}, "
+                    f"start it by hand")
+
+        return 'recreated'
+
     def destroy_networks(self) -> None:
         """
         Destroy the networks specified in the cluster configuration (parallel).
@@ -3368,6 +3569,9 @@ class BoxmanManager:
             # manual `docker stop` may have left lab containers down
             # even though the VMs stayed up.
             cls.ensure_shared_bridges()
+            cls.reconcile_networks(
+                allow_recreate=getattr(cli_args, 'recreate_networks', False),
+                auto_accept=getattr(cli_args, 'yes', False))
             cls.ensure_netlab_up()
             cls.connect_info()
             # Re-write SSH config in case IPs changed (DHCP renewals after
@@ -3387,6 +3591,14 @@ class BoxmanManager:
 
         # Shared bridges must exist before VMs attach to them on boot.
         cls.ensure_shared_bridges()
+
+        # Same for the libvirt networks: a VM that is about to be started has
+        # to find the network it is wired to, and any reservation added to the
+        # config since the last run has to be in dnsmasq before the guest asks
+        # for a lease.
+        cls.reconcile_networks(
+            allow_recreate=getattr(cli_args, 'recreate_networks', False),
+            auto_accept=getattr(cli_args, 'yes', False))
 
         # Build workdir lookup from process_vm_list for restore operations
         vm_workdir_map = {vm_name: workdir for vm_name, workdir in cls.process_vm_list(cli_args)}
@@ -5212,6 +5424,20 @@ class BoxmanManager:
         # ensure provider config reflects runtime settings
         if hasattr(cls.provider, 'update_provider_config_with_runtime'):
             cls.provider.update_provider_config_with_runtime()
+
+        # --- networks first ---
+        # a new VM further down may be wired to a network that does not exist
+        # yet, and this runs before the early return below so that a change
+        # which only touches networks is not silently a no-op
+        cls.ensure_shared_bridges()
+        network_results = cls.reconcile_networks(
+            dry_run=dry_run,
+            allow_recreate=getattr(cli_args, 'recreate_networks', False),
+            auto_accept=auto_accept)
+
+        if network_results:
+            for network_name, outcome in sorted(network_results.items()):
+                cls.logger.info(f"network {network_name}: {outcome}")
 
         # --- categorize VMs ---
         expected_vms = set(cls._get_project_vm_names())

--- a/src/boxman/providers/libvirt/net.py
+++ b/src/boxman/providers/libvirt/net.py
@@ -12,6 +12,7 @@ from jinja2 import Environment, FileSystemLoader
 
 from boxman import log
 
+from . import net_reconcile
 from .commands import LibVirtCommandBase, VirshCommand
 
 
@@ -326,6 +327,124 @@ class Network(VirshCommand):
 
         log.info(f"wrote network XML to {abs_path} ({os.path.getsize(abs_path)} bytes)")
         return abs_path
+
+    def dump_xml(self) -> str | None:
+        """
+        Return the network XML as libvirt currently has it.
+
+        Returns:
+            The XML text, or None when the network is not defined.
+        """
+        result = self.execute("net-dumpxml", self.name, hide=True, warn=True)
+        if not result.ok:
+            return None
+        return result.stdout
+
+    def is_active(self) -> bool:
+        """Return True when the network is defined *and* running."""
+        result = self.execute("net-list", "--name", hide=True, warn=True)
+        if not result.ok:
+            return False
+        return self.name in [
+            line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    def apply_net_update(self,
+                         command: str,
+                         section: str,
+                         element: str) -> bool:
+        """
+        Run a single ``virsh net-update`` against this network.
+
+        The element is handed over in a temporary file rather than inline.
+        ``net-update`` accepts both, but the inline form is a shell argument
+        full of spaces and quotes, and under a container runtime the command is
+        re-wrapped as a string -- a quoting bug waiting to happen.
+
+        ``--live`` is only added when the network is running; applying it to a
+        defined-but-stopped network is an error, while ``--config`` alone is
+        exactly right.
+
+        Args:
+            command: ``add-last``, ``modify`` or ``delete``
+            section: the section to update, e.g. ``ip-dhcp-host``
+            element: the XML element to add, match or modify
+
+        Returns:
+            True on success.
+        """
+        temp = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.xml', prefix='boxman-netupdate-', delete=False)
+        try:
+            temp.write(element)
+            temp.close()
+
+            args = ["net-update", self.name, command, section, temp.name,
+                    "--config"]
+            if self.is_active():
+                args.append("--live")
+
+            result = self.execute(*args, hide=True, warn=True)
+            if not result.ok:
+                self.logger.error(
+                    f"network {self.name}: {command} {section} failed: "
+                    f"{result.stderr.strip()}")
+                return False
+
+            self.logger.info(
+                f"network {self.name}: {command} {section} {element}")
+            return True
+        finally:
+            if os.path.exists(temp.name):
+                os.unlink(temp.name)
+
+    def apply_live_plan(self, plan: dict[str, Any]) -> bool:
+        """
+        Apply the non-disruptive half of a reconciliation plan.
+
+        Ranges are applied before reservations so that a reservation moving
+        into freshly-widened space does not transiently look out of range.
+
+        Args:
+            plan: as produced by :func:`net_reconcile.diff_network`
+
+        Returns:
+            True when every operation succeeded.
+        """
+        ok = True
+        for command, entry in plan.get('range_ops', []):
+            ok &= self.apply_net_update(
+                command, 'ip-dhcp-range', net_reconcile.range_element(entry))
+        for command, entry in plan.get('host_ops', []):
+            # a delete matches on the mac alone; sending the whole element
+            # makes libvirt match every attribute, so a stale ip would miss
+            match = {'mac': entry['mac']} if command == 'delete' else entry
+            ok &= self.apply_net_update(
+                command, 'ip-dhcp-host', net_reconcile.host_element(match))
+        return bool(ok)
+
+    def attached_domains(self) -> list[str]:
+        """
+        Return the names of domains whose interfaces use this network.
+
+        Used to tell the user which guests a recreate would disconnect.
+        """
+        result = self.execute("list", "--all", "--name", hide=True, warn=True)
+        if not result.ok:
+            return []
+
+        attached = []
+        for domain in [line.strip() for line in result.stdout.splitlines() if line.strip()]:
+            iflist = self.execute(
+                "domiflist", domain, hide=True, warn=True)
+            if not iflist.ok:
+                continue
+            for line in iflist.stdout.splitlines():
+                fields = line.split()
+                # columns: Interface Type Source Model MAC
+                if len(fields) >= 3 and fields[1] == 'network' and fields[2] == self.name:
+                    attached.append(domain)
+                    break
+        return attached
 
     def update_network_cache(self) -> bool:
         """

--- a/src/boxman/providers/libvirt/net.py
+++ b/src/boxman/providers/libvirt/net.py
@@ -54,25 +54,34 @@ class Network(VirshCommand):
         #: the cache object to be used to store network information
         self.manager = manager
 
+        #: str | None: the bridge name the configuration pinned, if any. Kept
+        #: separate from the one actually in use so that reconciliation can
+        #: tell "the config asked for virbr42" apart from "boxman picked one"
+        self.pinned_bridge_name = bridge_info.get('name')
+
         if assign_new_bridge:
             # handle the bridge name - if not specified, find the first available virbrX
-            bridge_name = bridge_info.get('name')
+            bridge_name = self.pinned_bridge_name
             if not bridge_name:
                 bridge_name = self.find_available_bridge_name()
         else:
             if bridge_name := Network.get_bridge_from_network(name, provider_config=self.provider_config):
-                self.logger.info(f"found existing bridge {bridge_name} for network {name}")
+                self.logger.debug(f"found existing bridge {bridge_name} for network {name}")
             else:
-                self.logger.warning(f"no existing bridge found for network {name}, "
-                                    f"assigning new bridge name")
+                # not an error: an undefined network has no bridge yet, which
+                # is exactly what reconciliation asks about before creating one
+                bridge_name = self.pinned_bridge_name
+                self.logger.debug(
+                    f"no bridge in libvirt for network {name} "
+                    f"(it is not defined yet)")
 
         #: str: the name of the bridge interface
         self.bridge_name = bridge_name
 
         #: str: use stp on/off for the bridge
-        self.bridge_stp = bridge_info.get('stp', 'on')
+        self.bridge_stp = self._normalise_stp(bridge_info.get('stp', 'on'))
         #: str: the delay for the stp
-        self.bridge_delay = bridge_info.get('delay', '0')
+        self.bridge_delay = str(bridge_info.get('delay', '0'))
 
         #: str: set the mac address for the bridge
         self.mac_address = info.get(
@@ -123,6 +132,21 @@ class Network(VirshCommand):
 
         #: bool: whether the network should be enabled
         self.enable = info.get('enable', True)
+
+    @staticmethod
+    def _normalise_stp(value: Any) -> str:
+        """
+        Coerce a configured ``stp`` value to the ``on``/``off`` libvirt echoes.
+
+        yaml reads an unquoted ``stp: on`` as the boolean True, which would be
+        rendered as ``stp='True'``. libvirt accepts that and stores it as
+        ``stp='on'`` -- so without this the configuration and the live network
+        never agree, and every reconcile reports drift that a recreate cannot
+        fix.
+        """
+        if isinstance(value, bool):
+            return 'on' if value else 'off'
+        return 'on' if str(value).strip().lower() in ('on', 'true', 'yes', '1') else 'off'
 
     def _parse_dhcp_hosts(self, hosts_info: list) -> list:
         """
@@ -249,10 +273,28 @@ class Network(VirshCommand):
 
             # optional, and worth setting: it becomes the dnsmasq hostname, so
             # the guest also resolves by name for everything on this network
-            if name := entry.get('name'):
+            name = entry.get('name')
+            if name is not None and str(name) != '':
+                # stored as a string: yaml reads `name: 101` as an int, which
+                # would never compare equal to the '101' read back out of the
+                # network XML, and every reconcile would re-apply it
+                name = str(name)
+
+                # libvirt round-trips this name through its own files
+                # unescaped, so an xml metacharacter defines cleanly and then
+                # breaks `net-start` with a parse error ("EntityRef: expecting
+                # ';'", "Unescaped '<' not allowed in attributes"). Escaping on
+                # the way out does not help; the name simply cannot hold one
+                if bad := set(name) & set('&<>"\''):
+                    raise ValueError(
+                        f"network {self.name}: the dhcp reservation name "
+                        f"{name!r} contains {''.join(sorted(bad))!r}. libvirt "
+                        f"defines such a network but then fails to start it, "
+                        f"so the name may not hold & < > \" or '")
+
                 # hostnames are case-insensitive, and libvirt accepts the same
                 # one twice: dnsmasq then resolves it to whichever it likes
-                if (key := str(name).lower()) in seen_names:
+                if (key := name.lower()) in seen_names:
                     raise ValueError(
                         f"network {self.name}: name {name!r} is reserved "
                         f"twice, for {seen_names[key]} and {ip}")
@@ -261,7 +303,9 @@ class Network(VirshCommand):
 
             hosts.append(host)
 
-        self.logger.info(
+        # debug rather than info: reconciliation builds a Network per plan and
+        # per apply, so this would print several times per network per `up`
+        self.logger.debug(
             f"network {self.name}: {len(hosts)} static dhcp reservation(s): " +
             ', '.join(f"{host['mac']} -> {host['ip']}" for host in hosts))
 
@@ -328,12 +372,33 @@ class Network(VirshCommand):
         log.info(f"wrote network XML to {abs_path} ({os.path.getsize(abs_path)} bytes)")
         return abs_path
 
+    def _listed_networks(self, active_only: bool = False) -> list[str] | None:
+        """Names of the networks libvirt knows, or None if it could not be asked."""
+        args = ["net-list", "--name"] if active_only else ["net-list", "--all", "--name"]
+        result = self.execute(*args, hide=True, warn=True)
+        if not result.ok:
+            return None
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    def exists(self) -> bool | None:
+        """
+        Whether the network is defined.
+
+        Returns:
+            True/False, or None when libvirt could not be reached at all --
+            which is not the same as "not defined" and must not be treated as
+            an invitation to create it.
+        """
+        listed = self._listed_networks()
+        return None if listed is None else self.name in listed
+
     def dump_xml(self) -> str | None:
         """
         Return the network XML as libvirt currently has it.
 
         Returns:
-            The XML text, or None when the network is not defined.
+            The XML text, or None when it could not be read (undefined, or
+            libvirt unreachable -- use :meth:`exists` to tell those apart).
         """
         result = self.execute("net-dumpxml", self.name, hide=True, warn=True)
         if not result.ok:
@@ -342,16 +407,26 @@ class Network(VirshCommand):
 
     def is_active(self) -> bool:
         """Return True when the network is defined *and* running."""
-        result = self.execute("net-list", "--name", hide=True, warn=True)
+        listed = self._listed_networks(active_only=True)
+        return bool(listed) and self.name in listed
+
+    def start(self) -> bool:
+        """Start a defined network, and make it come back after a host reboot."""
+        result = self.execute("net-start", self.name, hide=True, warn=True)
         if not result.ok:
+            self.logger.error(
+                f"network {self.name}: could not be started: "
+                f"{result.stderr.strip()}")
             return False
-        return self.name in [
-            line.strip() for line in result.stdout.splitlines() if line.strip()]
+        self.execute("net-autostart", self.name, hide=True, warn=True)
+        self.logger.info(f"network {self.name}: started")
+        return True
 
     def apply_net_update(self,
                          command: str,
                          section: str,
-                         element: str) -> bool:
+                         element: str,
+                         live: bool | None = None) -> bool:
         """
         Run a single ``virsh net-update`` against this network.
 
@@ -368,10 +443,16 @@ class Network(VirshCommand):
             command: ``add-last``, ``modify`` or ``delete``
             section: the section to update, e.g. ``ip-dhcp-host``
             element: the XML element to add, match or modify
+            live: whether the network is running. Left to be looked up when
+                not given, but the caller should pass it so that a plan of a
+                dozen operations does not run a dozen ``net-list`` calls.
 
         Returns:
             True on success.
         """
+        if live is None:
+            live = self.is_active()
+
         temp = tempfile.NamedTemporaryFile(
             mode='w', suffix='.xml', prefix='boxman-netupdate-', delete=False)
         try:
@@ -380,7 +461,7 @@ class Network(VirshCommand):
 
             args = ["net-update", self.name, command, section, temp.name,
                     "--config"]
-            if self.is_active():
+            if live:
                 args.append("--live")
 
             result = self.execute(*args, hide=True, warn=True)
@@ -411,15 +492,30 @@ class Network(VirshCommand):
             True when every operation succeeded.
         """
         ok = True
+        live = self.is_active()
+
+        # a range change is a delete followed by an add. If the delete fails,
+        # adding anyway would leave the network with two ranges -- and the diff
+        # only ever reads the first, so every later run would try to add again
         for command, entry in plan.get('range_ops', []):
-            ok &= self.apply_net_update(
-                command, 'ip-dhcp-range', net_reconcile.range_element(entry))
+            if not self.apply_net_update(
+                    command, 'ip-dhcp-range',
+                    net_reconcile.range_element(entry), live=live):
+                self.logger.error(
+                    f"network {self.name}: stopping the dhcp range update "
+                    f"after a failed {command} rather than leaving the "
+                    f"network with a half-applied range")
+                ok = False
+                break
+
         for command, entry in plan.get('host_ops', []):
             # a delete matches on the mac alone; sending the whole element
             # makes libvirt match every attribute, so a stale ip would miss
             match = {'mac': entry['mac']} if command == 'delete' else entry
             ok &= self.apply_net_update(
-                command, 'ip-dhcp-host', net_reconcile.host_element(match))
+                command, 'ip-dhcp-host',
+                net_reconcile.host_element(match), live=live)
+
         return bool(ok)
 
     def attached_domains(self) -> list[str]:

--- a/src/boxman/providers/libvirt/net.py
+++ b/src/boxman/providers/libvirt/net.py
@@ -84,8 +84,14 @@ class Network(VirshCommand):
         self.bridge_delay = str(bridge_info.get('delay', '0'))
 
         #: str: set the mac address for the bridge
-        self.mac_address = info.get(
-            'mac', f"52:54:00:{':'.join(['%02x' % (i + 10) for i in range(3)])}")
+        #: canonicalised because libvirt zero-pads this one when it stores it
+        #: (52:54:0:a:b:c comes back as 52:54:00:0a:0b:0c). Left short, the
+        #: configuration and the live network never match, and reconciliation
+        #: would rebuild the network -- rebooting its guests -- on every run.
+        #: Reservation macs are deliberately *not* padded: libvirt stores those
+        #: verbatim, so padding them would create the mismatch instead
+        self.mac_address = self._canonical_mac(info.get(
+            'mac', f"52:54:00:{':'.join(['%02x' % (i + 10) for i in range(3)])}"))
 
         #: bool: whether the ip has been provided or dummy values are injected
         self.ip_provided = 'ip' in info
@@ -134,6 +140,23 @@ class Network(VirshCommand):
         self.enable = info.get('enable', True)
 
     @staticmethod
+    def _canonical_mac(value: str) -> str:
+        """
+        Zero-pad and lowercase a mac, the way libvirt stores a network's own.
+
+        Left alone if it does not look like six hex groups, so that anything
+        unexpected still reaches libvirt and gets libvirt's own error rather
+        than being silently mangled here.
+        """
+        groups = str(value).split(':')
+        if len(groups) != 6:
+            return str(value).lower()
+        try:
+            return ':'.join(f"{int(group, 16):02x}" for group in groups)
+        except ValueError:
+            return str(value).lower()
+
+    @staticmethod
     def _normalise_stp(value: Any) -> str:
         """
         Coerce a configured ``stp`` value to the ``on``/``off`` libvirt echoes.
@@ -143,10 +166,21 @@ class Network(VirshCommand):
         ``stp='on'`` -- so without this the configuration and the live network
         never agree, and every reconcile reports drift that a recreate cannot
         fix.
+
+        Raises:
+            ValueError: on a value that is neither, rather than quietly
+                turning a typo like ``stp: enabled`` into ``off``
         """
         if isinstance(value, bool):
             return 'on' if value else 'off'
-        return 'on' if str(value).strip().lower() in ('on', 'true', 'yes', '1') else 'off'
+
+        text = str(value).strip().lower()
+        if text in ('on', 'true', 'yes', '1'):
+            return 'on'
+        if text in ('off', 'false', 'no', '0'):
+            return 'off'
+        raise ValueError(
+            f"bridge stp must be on or off, got {value!r}")
 
     def _parse_dhcp_hosts(self, hosts_info: list) -> list:
         """
@@ -274,6 +308,12 @@ class Network(VirshCommand):
             # optional, and worth setting: it becomes the dnsmasq hostname, so
             # the guest also resolves by name for everything on this network
             name = entry.get('name')
+            if isinstance(name, bool):
+                # `name: false` would otherwise become the hostname 'False'
+                raise ValueError(
+                    f"network {self.name}: the dhcp reservation name for "
+                    f"{mac} must be a hostname, got the boolean {name!r}")
+
             if name is not None and str(name) != '':
                 # stored as a string: yaml reads `name: 101` as an int, which
                 # would never compare equal to the '101' read back out of the
@@ -289,8 +329,9 @@ class Network(VirshCommand):
                     raise ValueError(
                         f"network {self.name}: the dhcp reservation name "
                         f"{name!r} contains {''.join(sorted(bad))!r}. libvirt "
-                        f"defines such a network but then fails to start it, "
-                        f"so the name may not hold & < > \" or '")
+                        f"defines a network holding & < or ' and then fails to "
+                        f"start it; \" and > are refused with them because "
+                        f"none of the five belong in a hostname")
 
                 # hostnames are case-insensitive, and libvirt accepts the same
                 # one twice: dnsmasq then resolves it to whichever it likes
@@ -418,7 +459,15 @@ class Network(VirshCommand):
                 f"network {self.name}: could not be started: "
                 f"{result.stderr.strip()}")
             return False
-        self.execute("net-autostart", self.name, hide=True, warn=True)
+
+        autostart = self.execute(
+            "net-autostart", self.name, hide=True, warn=True)
+        if not autostart.ok:
+            # not fatal, but it means the network is gone again after a reboot
+            self.logger.warning(
+                f"network {self.name}: started, but could not be set to "
+                f"autostart: {autostart.stderr.strip()}")
+
         self.logger.info(f"network {self.name}: started")
         return True
 
@@ -502,11 +551,11 @@ class Network(VirshCommand):
                     command, 'ip-dhcp-range',
                     net_reconcile.range_element(entry), live=live):
                 self.logger.error(
-                    f"network {self.name}: stopping the dhcp range update "
-                    f"after a failed {command} rather than leaving the "
-                    f"network with a half-applied range")
-                ok = False
-                break
+                    f"network {self.name}: stopping after a failed range "
+                    f"{command} rather than leaving the network with a "
+                    f"half-applied range; the reservations are left for the "
+                    f"next run")
+                return False
 
         for command, entry in plan.get('host_ops', []):
             # a delete matches on the mac alone; sending the whole element
@@ -594,6 +643,14 @@ class Network(VirshCommand):
             if 'networks' in project_data:
                 conflicts[project_name]['networks'] = {}
                 for net_name, net_info in project_data['networks'].items():
+                    # a network is not in conflict with its own cache entry.
+                    # Redefining one -- after a recreate, or after a define that
+                    # failed and left the entry behind -- would otherwise be
+                    # refused forever, by name and by address, against itself
+                    if (project_name == self.manager.config['project']
+                            and net_name == self.name):
+                        continue
+
                     conflicts[project_name]['networks'][net_name] = {}
                     if net_name == self.name:
                         # network already exists in the cache
@@ -657,13 +714,25 @@ class Network(VirshCommand):
                 f"bridge '{self.bridge_name}' is already in use by another "
                 f"active network. Cannot define network '{self.name}'.")
             self._log_bridge_usage(self.bridge_name)
-            sys.exit(1)
-
-        self.update_network_cache()
+            # RuntimeError rather than sys.exit: reconciliation calls this per
+            # network and turns a failure into a result, and a bare exit would
+            # take the process down mid-run, after a recreate has already
+            # destroyed the old network
+            raise RuntimeError(
+                f"bridge '{self.bridge_name}' is already in use by another "
+                f"active network, cannot define network '{self.name}'")
 
         # define the network
         try:
             self.execute("net-define", written_path)
+
+            # the cache is written only once the network really exists. Written
+            # before the define, a failed define (a rejected netmask, a libvirtd
+            # blip) would leave the cache claiming a network that is not there,
+            # and check_network_exists() would then refuse to create it on every
+            # later run -- wedged until projects.json is edited by hand
+            self.update_network_cache()
+
             self.execute("net-start", self.name)
             self.execute("net-autostart", self.name)
 

--- a/src/boxman/providers/libvirt/net_reconcile.py
+++ b/src/boxman/providers/libvirt/net_reconcile.py
@@ -1,0 +1,272 @@
+"""Diff a network's desired configuration against its live libvirt definition.
+
+libvirt splits network changes into two very different classes, and the whole
+point of this module is to tell them apart before anything is touched:
+
+- ``ip-dhcp-host`` and ``ip-dhcp-range`` can be changed on a running network
+  with ``virsh net-update ... --live --config``. dnsmasq is reloaded, the
+  bridge stays up and no guest notices.
+- everything else -- the forward mode, the address, the netmask, the bridge
+  attributes, the network mac -- cannot. libvirt answers ``can't update 'ip'
+  section of network`` / ``can't update 'bridge' section``. The only way to
+  apply those is to destroy and redefine the network, which deletes the bridge
+  and leaves every attached guest with a dead nic: libvirt does **not**
+  reconnect them when the network comes back.
+
+So the diff returns the two classes separately and the caller decides. The
+functions here are pure -- they take the desired configuration and the XML
+libvirt reports, and return a plan. Nothing in this module talks to virsh.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import xml.etree.ElementTree as ET
+from typing import Any
+
+#: fields that force a destroy + redefine because libvirt refuses to update
+#: them in place. ``bridge_name`` is only compared when the configuration
+#: pinned one, otherwise boxman assigned it and libvirt is authoritative
+STRUCTURAL_FIELDS = (
+    ('mode', 'forward mode'),
+    ('ip_address', 'ip address'),
+    ('netmask', 'netmask'),
+    ('bridge_name', 'bridge name'),
+    ('bridge_stp', 'bridge stp'),
+    ('bridge_delay', 'bridge delay'),
+    ('mac', 'mac address'),
+)
+
+
+def parse_network_xml(xml_text: str) -> dict[str, Any]:
+    """
+    Turn the output of ``virsh net-dumpxml`` into a comparable dict.
+
+    Args:
+        xml_text: the network XML as libvirt reports it
+
+    Returns:
+        A dict with the same shape :func:`desired_state` produces. The uuid is
+        deliberately dropped: it is regenerated on every definition and would
+        otherwise read as permanent drift.
+    """
+    root = ET.fromstring(xml_text)
+
+    forward = root.find('forward')
+    bridge = root.find('bridge')
+    mac = root.find('mac')
+    ip = root.find('ip')
+
+    state: dict[str, Any] = {
+        'mode': forward.get('mode') if forward is not None else None,
+        'bridge_name': bridge.get('name') if bridge is not None else None,
+        'bridge_stp': bridge.get('stp') if bridge is not None else None,
+        'bridge_delay': bridge.get('delay') if bridge is not None else None,
+        'mac': mac.get('address').lower() if mac is not None and mac.get('address') else None,
+        'ip_address': None,
+        'netmask': None,
+        'dhcp_range': None,
+        'dhcp_hosts': [],
+    }
+
+    if ip is None:
+        return state
+
+    state['ip_address'] = ip.get('address')
+
+    # libvirt accepts either spelling and echoes back whichever was given, so
+    # normalise a prefix into the netmask boxman's schema uses
+    if ip.get('netmask'):
+        state['netmask'] = ip.get('netmask')
+    elif ip.get('prefix'):
+        state['netmask'] = str(ipaddress.IPv4Network(
+            f"0.0.0.0/{ip.get('prefix')}").netmask)
+
+    dhcp = ip.find('dhcp')
+    if dhcp is None:
+        return state
+
+    dhcp_range = dhcp.find('range')
+    if dhcp_range is not None:
+        state['dhcp_range'] = {'start': dhcp_range.get('start'),
+                               'end': dhcp_range.get('end')}
+
+    for host in dhcp.findall('host'):
+        entry = {'mac': (host.get('mac') or '').lower(), 'ip': host.get('ip')}
+        if host.get('name'):
+            entry['name'] = host.get('name')
+        state['dhcp_hosts'].append(entry)
+
+    return state
+
+
+def desired_state(network) -> dict[str, Any]:
+    """
+    Read the desired state off an already-constructed :class:`Network`.
+
+    The ``Network`` constructor is where defaults are applied and where the
+    reservations are validated and normalised, so going through it keeps the
+    two sides of the diff honest rather than re-implementing that here.
+
+    Args:
+        network: a ``Network`` built from the configuration
+
+    Returns:
+        A dict shaped like :func:`parse_network_xml`.
+    """
+    dhcp_range = None
+    if network.dhcp_range_start and network.dhcp_range_end:
+        dhcp_range = {'start': network.dhcp_range_start,
+                      'end': network.dhcp_range_end}
+
+    return {
+        'mode': network.forward_mode,
+        'bridge_name': network.bridge_name,
+        'bridge_stp': str(network.bridge_stp),
+        'bridge_delay': str(network.bridge_delay),
+        'mac': network.mac_address.lower() if network.mac_address else None,
+        'ip_address': network.ip_address,
+        'netmask': network.netmask,
+        'dhcp_range': dhcp_range,
+        'dhcp_hosts': list(network.dhcp_hosts),
+    }
+
+
+def _host_key(entry: dict[str, Any]) -> str:
+    return (entry.get('mac') or '').lower()
+
+
+def diff_dhcp_hosts(desired: list, actual: list) -> list[tuple[str, dict]]:
+    """
+    Reduce two reservation lists to the ``virsh net-update`` operations that
+    turn *actual* into *desired*.
+
+    Keyed on the mac, because that is what libvirt itself matches on: the same
+    mac with a different address is a ``modify``, not a delete plus an add.
+
+    Returns:
+        A list of ``(command, entry)`` tuples where command is one of
+        ``add-last``, ``modify`` or ``delete``.
+    """
+    desired_by_mac = {_host_key(entry): entry for entry in desired}
+    actual_by_mac = {_host_key(entry): entry for entry in actual}
+
+    ops: list[tuple[str, dict]] = []
+
+    # deletions first: frees an address that a later addition may want to reuse
+    for mac in actual_by_mac:
+        if mac not in desired_by_mac:
+            ops.append(('delete', actual_by_mac[mac]))
+
+    for mac, entry in desired_by_mac.items():
+        if mac not in actual_by_mac:
+            ops.append(('add-last', entry))
+        elif entry != actual_by_mac[mac]:
+            ops.append(('modify', entry))
+
+    return ops
+
+
+def diff_dhcp_range(desired: dict | None,
+                    actual: dict | None) -> list[tuple[str, dict]]:
+    """
+    Reduce two dhcp ranges to ``virsh net-update`` operations.
+
+    libvirt refuses ``modify`` on this section -- *"dhcp ranges cannot be
+    modified, only added or deleted"* -- so a change becomes a delete of the
+    old range followed by an add of the new one.
+    """
+    if desired == actual:
+        return []
+
+    ops: list[tuple[str, dict]] = []
+    if actual:
+        ops.append(('delete', actual))
+    if desired:
+        ops.append(('add-last', desired))
+    return ops
+
+
+def diff_network(desired: dict[str, Any],
+                 actual: dict[str, Any]) -> dict[str, Any]:
+    """
+    Compare a desired and an actual network state.
+
+    Args:
+        desired: from :func:`desired_state`
+        actual: from :func:`parse_network_xml`
+
+    Returns:
+        A plan dict with:
+
+        - ``action``: ``none``, ``live`` or ``recreate``
+        - ``structural``: human-readable descriptions of the changes that
+          require a destroy + redefine
+        - ``host_ops`` / ``range_ops``: the ``net-update`` operations that can
+          be applied to the running network
+    """
+    structural = []
+    for field, label in STRUCTURAL_FIELDS:
+        want = desired.get(field)
+        have = actual.get(field)
+
+        # boxman picks the bridge name unless the configuration pinned one, so
+        # only a pinned name can be said to have drifted
+        if field == 'bridge_name' and not want:
+            continue
+
+        if want is not None and str(want) != str(have):
+            structural.append(f"{label} {have!r} -> {want!r}")
+
+    host_ops = diff_dhcp_hosts(desired.get('dhcp_hosts') or [],
+                               actual.get('dhcp_hosts') or [])
+    range_ops = diff_dhcp_range(desired.get('dhcp_range'),
+                                actual.get('dhcp_range'))
+
+    if structural:
+        action = 'recreate'
+    elif host_ops or range_ops:
+        action = 'live'
+    else:
+        action = 'none'
+
+    return {
+        'action': action,
+        'structural': structural,
+        'host_ops': host_ops,
+        'range_ops': range_ops,
+    }
+
+
+def describe_plan(name: str, plan: dict[str, Any]) -> list[str]:
+    """Render a plan as log lines, one per change."""
+    lines = []
+    for change in plan['structural']:
+        lines.append(f"network {name}: {change} (needs recreate)")
+    for command, entry in plan['range_ops']:
+        verb = 'remove' if command == 'delete' else 'add'
+        lines.append(
+            f"network {name}: {verb} dhcp range "
+            f"{entry['start']}-{entry['end']}")
+    for command, entry in plan['host_ops']:
+        verb = {'add-last': 'add', 'modify': 'update', 'delete': 'remove'}[command]
+        name_part = f" ({entry['name']})" if entry.get('name') else ''
+        lines.append(
+            f"network {name}: {verb} reservation {entry['mac']} -> "
+            f"{entry.get('ip')}{name_part}")
+    return lines
+
+
+def host_element(entry: dict[str, Any]) -> str:
+    """Render a reservation as the ``<host>`` element ``net-update`` matches on."""
+    attrs = f"mac='{entry['mac']}'"
+    if entry.get('name'):
+        attrs += f" name='{entry['name']}'"
+    if entry.get('ip'):
+        attrs += f" ip='{entry['ip']}'"
+    return f"<host {attrs}/>"
+
+
+def range_element(entry: dict[str, Any]) -> str:
+    """Render a dhcp range as the ``<range>`` element ``net-update`` matches on."""
+    return f"<range start='{entry['start']}' end='{entry['end']}'/>"

--- a/src/boxman/providers/libvirt/net_reconcile.py
+++ b/src/boxman/providers/libvirt/net_reconcile.py
@@ -164,8 +164,24 @@ def diff_dhcp_hosts(desired: list, actual: list) -> list[tuple[str, dict]]:
         if mac not in desired_by_mac:
             deletes.append(('delete', actual_by_mac[mac]))
 
+    # an address moving between two reservations that both survive cannot be
+    # done with a modify: libvirt refuses to hand out an address another entry
+    # still holds, so the pair would fail on every run. Those entries are
+    # deleted first and added back in their new arrangement instead
+    surviving_ips = {
+        (entry.get('ip'), _host_key(entry)) for entry in actual
+        if _host_key(entry) in desired_by_mac}
+    contested = {
+        mac for mac, entry in desired_by_mac.items()
+        if mac in actual_by_mac
+        and any(ip == entry.get('ip') and holder != mac
+                for ip, holder in surviving_ips)}
+
     for mac, entry in desired_by_mac.items():
         if mac not in actual_by_mac:
+            adds.append(('add-last', entry))
+        elif mac in contested:
+            deletes.append(('delete', actual_by_mac[mac]))
             adds.append(('add-last', entry))
         elif entry != actual_by_mac[mac]:
             modifies.append(('modify', entry))

--- a/src/boxman/providers/libvirt/net_reconcile.py
+++ b/src/boxman/providers/libvirt/net_reconcile.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import ipaddress
 import xml.etree.ElementTree as ET
 from typing import Any
+from xml.sax.saxutils import escape
 
 #: fields that force a destroy + redefine because libvirt refuses to update
 #: them in place. ``bridge_name`` is only compared when the configuration
@@ -121,7 +122,11 @@ def desired_state(network) -> dict[str, Any]:
 
     return {
         'mode': network.forward_mode,
-        'bridge_name': network.bridge_name,
+        # the *configured* name, not the one in use: when the configuration
+        # does not pin one boxman assigned it and libvirt is authoritative, so
+        # leaving this None is what keeps an auto-assigned virbrX from reading
+        # as drift
+        'bridge_name': network.pinned_bridge_name,
         'bridge_stp': str(network.bridge_stp),
         'bridge_delay': str(network.bridge_delay),
         'mac': network.mac_address.lower() if network.mac_address else None,
@@ -151,20 +156,26 @@ def diff_dhcp_hosts(desired: list, actual: list) -> list[tuple[str, dict]]:
     desired_by_mac = {_host_key(entry): entry for entry in desired}
     actual_by_mac = {_host_key(entry): entry for entry in actual}
 
-    ops: list[tuple[str, dict]] = []
+    deletes: list[tuple[str, dict]] = []
+    modifies: list[tuple[str, dict]] = []
+    adds: list[tuple[str, dict]] = []
 
-    # deletions first: frees an address that a later addition may want to reuse
     for mac in actual_by_mac:
         if mac not in desired_by_mac:
-            ops.append(('delete', actual_by_mac[mac]))
+            deletes.append(('delete', actual_by_mac[mac]))
 
     for mac, entry in desired_by_mac.items():
         if mac not in actual_by_mac:
-            ops.append(('add-last', entry))
+            adds.append(('add-last', entry))
         elif entry != actual_by_mac[mac]:
-            ops.append(('modify', entry))
+            modifies.append(('modify', entry))
 
-    return ops
+    # delete, then modify, then add. libvirt rejects an entry whose address is
+    # still held by another reservation, so every operation that frees an
+    # address has to come before the one that claims it -- otherwise handing
+    # an address from one mac to another fails on the first run and only
+    # converges on the second
+    return deletes + modifies + adds
 
 
 def diff_dhcp_range(desired: dict | None,
@@ -257,16 +268,29 @@ def describe_plan(name: str, plan: dict[str, Any]) -> list[str]:
     return lines
 
 
+def _attr(value: Any) -> str:
+    """
+    Escape a value for use inside a single-quoted XML attribute.
+
+    The jinja template escapes with ``|e``, and these elements have to do the
+    same: a reservation name is free-form configuration text, so a name holding
+    an ``&`` or a quote would define happily through the template and then make
+    every later ``net-update`` on that network fail to parse.
+    """
+    return escape(str(value), {"'": '&apos;', '"': '&quot;'})
+
+
 def host_element(entry: dict[str, Any]) -> str:
     """Render a reservation as the ``<host>`` element ``net-update`` matches on."""
-    attrs = f"mac='{entry['mac']}'"
+    attrs = f"mac='{_attr(entry['mac'])}'"
     if entry.get('name'):
-        attrs += f" name='{entry['name']}'"
+        attrs += f" name='{_attr(entry['name'])}'"
     if entry.get('ip'):
-        attrs += f" ip='{entry['ip']}'"
+        attrs += f" ip='{_attr(entry['ip'])}'"
     return f"<host {attrs}/>"
 
 
 def range_element(entry: dict[str, Any]) -> str:
     """Render a dhcp range as the ``<range>`` element ``net-update`` matches on."""
-    return f"<range start='{entry['start']}' end='{entry['end']}'/>"
+    return (f"<range start='{_attr(entry['start'])}' "
+            f"end='{_attr(entry['end'])}'/>")

--- a/src/boxman/providers/libvirt/session.py
+++ b/src/boxman/providers/libvirt/session.py
@@ -235,12 +235,21 @@ class LibVirtSession:
 
         if 'paused' in state_text or 'pmsuspended' in state_text:
             # the qemu process outlived the bridge, so the tap is dead just as
-            # it is for a running guest -- resuming does not rebuild it. Resume
-            # so the guest can answer the shutdown request, then cycle it
+            # it is for a running guest -- resuming does not rebuild it. Wake
+            # the guest so it can answer the shutdown request, then cycle it
             log.info(
-                f"{domain}: is {state_text}, resuming it so it can be "
+                f"{domain}: is {state_text}, waking it so it can be "
                 f"power-cycled back onto {network_name}")
-            virsh.execute("resume", domain, hide=True, warn=True)
+
+            # a pmsuspended domain is asleep inside the guest OS; virsh resume
+            # only lifts a libvirt-level pause and does nothing for it
+            command = 'dompmwakeup' if 'pmsuspended' in state_text else 'resume'
+            woken = virsh.execute(command, domain, hide=True, warn=True)
+            if not woken.ok:
+                log.warning(
+                    f"{domain}: {command} failed ({woken.stderr.strip()}), "
+                    f"the power cycle will have to force it off")
+
             return 'cold' if self._power_cycle(virsh, domain) else 'failed'
 
         if 'running' not in state_text:

--- a/src/boxman/providers/libvirt/session.py
+++ b/src/boxman/providers/libvirt/session.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import time
 from multiprocessing import Process, Queue
 from typing import Any
@@ -14,6 +15,7 @@ from .disk import DiskManager
 from .disk_cleanup import remove_vm_disks
 from .import_image import ImageImporter
 from .iso_boot_vm import IsoBootVM
+from . import net_reconcile
 from .net import Network, NetworkInterface
 from .shared_folder import SharedFolderManager
 from .snapshot import SnapshotManager
@@ -175,6 +177,193 @@ class LibVirtSession:
         status = network.define_network(file_path=os.path.join(workdir, f'{name}_net_define.xml'))
 
         return status
+
+    def reattach_domain_network(self,
+                                domain: str,
+                                network_name: str) -> str:
+        """
+        Reconnect a domain's interfaces after its network was recreated.
+
+        Destroying a libvirt network deletes the bridge and libvirt does not
+        put the guests back when it returns -- the domain keeps running with a
+        tap that is attached to nothing. Two ways back:
+
+        - hot: detach and re-attach the interface. Free when it works, but it
+          needs pci hotplug support in the guest's machine type and an
+          operating system that answers the unplug request. It fails outright
+          with ``Bus 'pci.0' does not support hotplugging`` on machine types
+          without it.
+        - cold: power-cycle the domain. Always works, because the persistent
+          domain XML still names the network, so the interface is rebuilt from
+          scratch on boot.
+
+        Hot is tried first and cold is the fallback.
+
+        Args:
+            domain: the domain name
+            network_name: the fully qualified network name
+
+        Returns:
+            ``hot``, ``cold``, ``skipped`` (not running, or not attached) or
+            ``failed``.
+        """
+        virsh = VirshCommand(provider_config=self.provider_config)
+
+        iflist = virsh.execute("domiflist", domain, hide=True, warn=True)
+        if not iflist.ok:
+            return 'failed'
+
+        interfaces = []
+        for line in iflist.stdout.splitlines():
+            fields = line.split()
+            # columns: Interface Type Source Model MAC
+            if len(fields) >= 5 and fields[1] == 'network' and fields[2] == network_name:
+                interfaces.append({'model': fields[3], 'mac': fields[4]})
+
+        if not interfaces:
+            return 'skipped'
+
+        state = virsh.execute("domstate", domain, hide=True, warn=True)
+        if not state.ok or 'running' not in state.stdout:
+            # a stopped domain rebuilds its interfaces from the persistent
+            # config the next time it starts, so there is nothing to repair
+            return 'skipped'
+
+        if self._hot_replug(virsh, domain, network_name, interfaces):
+            log.info(f"{domain}: re-attached to {network_name} without a reboot")
+            return 'hot'
+
+        log.info(
+            f"{domain}: hot re-attach unavailable, power-cycling to restore "
+            f"the link to {network_name}")
+        return 'cold' if self._power_cycle(virsh, domain) else 'failed'
+
+    @staticmethod
+    def _hot_replug(virsh, domain: str, network_name: str,
+                    interfaces: list[dict]) -> bool:
+        """Detach and re-attach each interface. False if any step fails."""
+        for interface in interfaces:
+            element = (
+                f"<interface type='network'>"
+                f"<source network='{network_name}'/>"
+                f"<mac address='{interface['mac']}'/>"
+                f"<model type='{interface['model']}'/>"
+                f"</interface>")
+
+            temp = tempfile.NamedTemporaryFile(
+                mode='w', suffix='.xml', prefix='boxman-iface-', delete=False)
+            try:
+                temp.write(element)
+                temp.close()
+
+                detached = virsh.execute(
+                    "detach-device", domain, temp.name, "--live",
+                    hide=True, warn=True)
+                if not detached.ok:
+                    return False
+
+                attached = virsh.execute(
+                    "attach-device", domain, temp.name, "--live",
+                    hide=True, warn=True)
+                if not attached.ok:
+                    # the interface is gone now, so only a power cycle can
+                    # bring it back -- say so rather than reporting success
+                    log.warning(
+                        f"{domain}: interface {interface['mac']} was detached "
+                        f"but could not be re-attached")
+                    return False
+            finally:
+                if os.path.exists(temp.name):
+                    os.unlink(temp.name)
+
+        return True
+
+    @staticmethod
+    def _power_cycle(virsh, domain: str, timeout: int = 120) -> bool:
+        """Shut the domain down gracefully (force after *timeout*) and start it."""
+        virsh.execute("shutdown", domain, hide=True, warn=True)
+
+        waited = 0
+        while waited < timeout:
+            state = virsh.execute("domstate", domain, hide=True, warn=True)
+            if state.ok and 'shut off' in state.stdout:
+                break
+            time.sleep(2)
+            waited += 2
+        else:
+            log.warning(
+                f"{domain}: did not shut down within {timeout}s, forcing it off")
+            virsh.execute("destroy", domain, hide=True, warn=True)
+
+        return virsh.execute("start", domain, hide=True, warn=True).ok
+
+    def plan_network(self,
+                     name: str = None,
+                     info: dict[str, Any] | None = None) -> dict[str, Any]:
+        """
+        Compare a configured network against its live libvirt definition.
+
+        Args:
+            name: the fully qualified network name
+            info: the network block from the configuration
+
+        Returns:
+            A plan dict as described in
+            :func:`boxman.providers.libvirt.net_reconcile.diff_network`, with
+            an extra ``create`` action when the network does not exist yet and
+            an ``attached_vms`` list when it would have to be recreated.
+        """
+        # assign_new_bridge=False so that inspecting an existing network does
+        # not consume a fresh virbrX for a network that already has one
+        network = Network(
+            name=name,
+            info=info,
+            provider_config=self.provider_config,
+            assign_new_bridge=False,
+            manager=self.manager)
+
+        actual_xml = network.dump_xml()
+        if actual_xml is None:
+            return {'action': 'create', 'structural': [], 'host_ops': [],
+                    'range_ops': [], 'attached_vms': [], 'actual': {}}
+
+        actual = net_reconcile.parse_network_xml(actual_xml)
+        plan = net_reconcile.diff_network(
+            net_reconcile.desired_state(network), actual)
+
+        # the caller needs the state as it is on disk, not only the diff: a
+        # recreate has to tear down the iptables rules belonging to the network
+        # that is there now, which may be a different mode or subnet than the
+        # one being defined in its place
+        plan['actual'] = actual
+        plan['attached_vms'] = (
+            network.attached_domains() if plan['action'] == 'recreate' else [])
+
+        return plan
+
+    def apply_network_live_plan(self,
+                                name: str = None,
+                                info: dict[str, Any] | None = None,
+                                plan: dict[str, Any] | None = None) -> bool:
+        """
+        Apply the live half of a plan to an existing network.
+
+        Args:
+            name: the fully qualified network name
+            info: the network block from the configuration
+            plan: the plan returned by :meth:`plan_network`
+
+        Returns:
+            True when every ``net-update`` succeeded.
+        """
+        network = Network(
+            name=name,
+            info=info,
+            provider_config=self.provider_config,
+            assign_new_bridge=False,
+            manager=self.manager)
+
+        return network.apply_live_plan(plan or {})
 
     def destroy_network(self,
                         name: str = None,

--- a/src/boxman/providers/libvirt/session.py
+++ b/src/boxman/providers/libvirt/session.py
@@ -224,9 +224,26 @@ class LibVirtSession:
             return 'skipped'
 
         state = virsh.execute("domstate", domain, hide=True, warn=True)
-        if not state.ok or 'running' not in state.stdout:
+        if not state.ok:
+            return 'failed'
+        state_text = state.stdout.strip()
+
+        if 'shut off' in state_text:
             # a stopped domain rebuilds its interfaces from the persistent
             # config the next time it starts, so there is nothing to repair
+            return 'skipped'
+
+        if 'paused' in state_text or 'pmsuspended' in state_text:
+            # the qemu process outlived the bridge, so the tap is dead just as
+            # it is for a running guest -- resuming does not rebuild it. Resume
+            # so the guest can answer the shutdown request, then cycle it
+            log.info(
+                f"{domain}: is {state_text}, resuming it so it can be "
+                f"power-cycled back onto {network_name}")
+            virsh.execute("resume", domain, hide=True, warn=True)
+            return 'cold' if self._power_cycle(virsh, domain) else 'failed'
+
+        if 'running' not in state_text:
             return 'skipped'
 
         if self._hot_replug(virsh, domain, network_name, interfaces):
@@ -239,16 +256,41 @@ class LibVirtSession:
         return 'cold' if self._power_cycle(virsh, domain) else 'failed'
 
     @staticmethod
-    def _hot_replug(virsh, domain: str, network_name: str,
+    def _interface_element(virsh, domain: str, mac: str) -> str | None:
+        """
+        Return the domain's own ``<interface>`` element for *mac*.
+
+        Re-attaching a hand-built element would drop the pci address, mtu,
+        driver options and boot order, so the nic would come back in a
+        different slot and the guest's predictable interface name would change
+        under it. Round-tripping libvirt's own element keeps the slot.
+        """
+        dumped = virsh.execute("dumpxml", domain, hide=True, warn=True)
+        if not dumped.ok:
+            return None
+        try:
+            root = ET.fromstring(dumped.stdout)
+        except ET.ParseError:
+            return None
+
+        for interface in root.findall('./devices/interface'):
+            element_mac = interface.find('mac')
+            if element_mac is not None and \
+                    (element_mac.get('address') or '').lower() == mac.lower():
+                return ET.tostring(interface, encoding='unicode')
+        return None
+
+    @classmethod
+    def _hot_replug(cls, virsh, domain: str, network_name: str,
                     interfaces: list[dict]) -> bool:
         """Detach and re-attach each interface. False if any step fails."""
         for interface in interfaces:
-            element = (
-                f"<interface type='network'>"
-                f"<source network='{network_name}'/>"
-                f"<mac address='{interface['mac']}'/>"
-                f"<model type='{interface['model']}'/>"
-                f"</interface>")
+            element = cls._interface_element(virsh, domain, interface['mac'])
+            if element is None:
+                log.debug(
+                    f"{domain}: could not read the interface element for "
+                    f"{interface['mac']}")
+                return False
 
             temp = tempfile.NamedTemporaryFile(
                 mode='w', suffix='.xml', prefix='boxman-iface-', delete=False)
@@ -260,6 +302,17 @@ class LibVirtSession:
                     "detach-device", domain, temp.name, "--live",
                     hide=True, warn=True)
                 if not detached.ok:
+                    return False
+
+                # detach-device returns once the unplug has been *requested*;
+                # the guest still has to acknowledge it. Attaching the same mac
+                # before it is gone is rejected as a duplicate, which would
+                # send a guest that could have been fixed in place into a
+                # needless reboot
+                if not cls._wait_for_detach(virsh, domain, interface['mac']):
+                    log.debug(
+                        f"{domain}: interface {interface['mac']} did not go "
+                        f"away after the detach request")
                     return False
 
                 attached = virsh.execute(
@@ -277,6 +330,21 @@ class LibVirtSession:
                     os.unlink(temp.name)
 
         return True
+
+    @staticmethod
+    def _wait_for_detach(virsh, domain: str, mac: str,
+                         timeout: int = 10) -> bool:
+        """Poll until *mac* is no longer listed on the running domain."""
+        waited = 0
+        while waited < timeout:
+            iflist = virsh.execute("domiflist", domain, hide=True, warn=True)
+            if not iflist.ok:
+                return False
+            if mac.lower() not in iflist.stdout.lower():
+                return True
+            time.sleep(1)
+            waited += 1
+        return False
 
     @staticmethod
     def _power_cycle(virsh, domain: str, timeout: int = 120) -> bool:
@@ -322,10 +390,27 @@ class LibVirtSession:
             assign_new_bridge=False,
             manager=self.manager)
 
+        empty = {'structural': [], 'host_ops': [], 'range_ops': [],
+                 'attached_vms': [], 'actual': {}, 'inactive': False}
+
+        defined = network.exists()
+        if defined is None:
+            # libvirt could not be asked at all (daemon down, socket
+            # permissions, the runtime container stopped). That is emphatically
+            # not "the network is missing", and creating it would be wrong
+            log.error(
+                f"network {name}: libvirt could not be queried, skipping it")
+            return {'action': 'error', **empty}
+
+        if not defined:
+            return {'action': 'create', **empty}
+
         actual_xml = network.dump_xml()
         if actual_xml is None:
-            return {'action': 'create', 'structural': [], 'host_ops': [],
-                    'range_ops': [], 'attached_vms': [], 'actual': {}}
+            log.error(
+                f"network {name}: is defined but its XML could not be read, "
+                f"skipping it")
+            return {'action': 'error', **empty}
 
         actual = net_reconcile.parse_network_xml(actual_xml)
         plan = net_reconcile.diff_network(
@@ -339,7 +424,27 @@ class LibVirtSession:
         plan['attached_vms'] = (
             network.attached_domains() if plan['action'] == 'recreate' else [])
 
+        # a defined network that is not running is drift too, and the content
+        # diff cannot see it: a VM wired to it fails to start with "network is
+        # not active". Happens after a manual `virsh net-destroy` or a host
+        # reboot with autostart off
+        plan['inactive'] = not network.is_active()
+        if plan['inactive'] and plan['action'] == 'none':
+            plan['action'] = 'live'
+
         return plan
+
+    def start_network(self,
+                      name: str = None,
+                      info: dict[str, Any] | None = None) -> bool:
+        """Start a defined-but-stopped network."""
+        network = Network(
+            name=name,
+            info=info,
+            provider_config=self.provider_config,
+            assign_new_bridge=False,
+            manager=self.manager)
+        return network.start()
 
     def apply_network_live_plan(self,
                                 name: str = None,

--- a/src/boxman/scripts/cli_parser.py
+++ b/src/boxman/scripts/cli_parser.py
@@ -326,6 +326,22 @@ def parse_args():
         help='force-rebuild all templates (destroy and recreate) before provisioning',
         dest='rebuild_templates'
     )
+    parser_up.add_argument(
+        '--recreate-networks',
+        action='store_true',
+        default=False,
+        help=('apply network changes that libvirt cannot make in place (mode, '
+              'address, netmask, bridge) by destroying and redefining the '
+              'network; attached VMs are reconnected, by a reboot if needed'),
+        dest='recreate_networks'
+    )
+    parser_up.add_argument(
+        '--yes', '-y',
+        action='store_true',
+        default=False,
+        help='skip the confirmation prompt for recreating a network',
+        dest='yes'
+    )
 
     #
     # sub parser for the 'update' subcommand
@@ -354,6 +370,15 @@ def parse_args():
         default=False,
         help='skip confirmation prompt for VM removal',
         dest='yes'
+    )
+    parser_update.add_argument(
+        '--recreate-networks',
+        action='store_true',
+        default=False,
+        help=('apply network changes that libvirt cannot make in place (mode, '
+              'address, netmask, bridge) by destroying and redefining the '
+              'network; attached VMs are reconnected, by a reboot if needed'),
+        dest='recreate_networks'
     )
 
     #

--- a/src/boxman/scripts/cli_parser.py
+++ b/src/boxman/scripts/cli_parser.py
@@ -330,9 +330,10 @@ def parse_args():
         '--recreate-networks',
         action='store_true',
         default=False,
-        help=('apply network changes that libvirt cannot make in place (mode, '
-              'address, netmask, bridge) by destroying and redefining the '
-              'network; attached VMs are reconnected, by a reboot if needed'),
+        help=('apply network changes that libvirt cannot make in place '
+              '(forward mode, ip address, netmask, mac, bridge name/stp/delay) '
+              'by destroying and redefining the network; attached VMs are '
+              'reconnected, by a reboot if their machine type cannot hot-plug'),
         dest='recreate_networks'
     )
     parser_up.add_argument(
@@ -375,9 +376,10 @@ def parse_args():
         '--recreate-networks',
         action='store_true',
         default=False,
-        help=('apply network changes that libvirt cannot make in place (mode, '
-              'address, netmask, bridge) by destroying and redefining the '
-              'network; attached VMs are reconnected, by a reboot if needed'),
+        help=('apply network changes that libvirt cannot make in place '
+              '(forward mode, ip address, netmask, mac, bridge name/stp/delay) '
+              'by destroying and redefining the network; attached VMs are '
+              'reconnected, by a reboot if their machine type cannot hot-plug'),
         dest='recreate_networks'
     )
 

--- a/tests/test_libvirt_net.py
+++ b/tests/test_libvirt_net.py
@@ -184,16 +184,21 @@ class TestDhcpReservations:
         net = self._net([{"mac": "52:54:0:c:1:1", "ip": "10.5.3.15"}])
         assert net.dhcp_hosts[0]["mac"] == "52:54:0:c:1:1"
 
-    def test_name_with_xml_metacharacters_is_escaped(self):
-        # the jinja environment has no autoescape; an unescaped name would
-        # produce a document libvirt cannot parse
+    @pytest.mark.parametrize("name", ["a&b", "a<b", "a>b", "a'b", 'a"b'])
+    def test_names_with_xml_metacharacters_are_rejected(self, name):
+        # escaping is not enough: libvirt accepts the escaped form at
+        # net-define and then fails at net-start, because it writes the name
+        # back out unescaped ("EntityRef: expecting ';'"). Verified against
+        # libvirt 11.2.0, so the only safe answer is to refuse the name
+        with pytest.raises(ValueError, match="libvirt"):
+            self._net([{"mac": "52:54:00:0c:01:05", "ip": "10.5.3.16",
+                        "name": name}])
+
+    def test_an_ordinary_name_still_renders(self):
         net = self._net([{"mac": "52:54:00:0c:01:05", "ip": "10.5.3.16",
-                          "name": "a&b<c>'d\""}])
-        xml = net.generate_xml()
-        assert "&amp;" in xml
-        # round-trips back to the literal the user configured
-        host = ET.fromstring(xml).find("ip/dhcp/host")
-        assert host.get("name") == "a&b<c>'d\""
+                          "name": "node-01.lab"}])
+        host = ET.fromstring(net.generate_xml()).find("ip/dhcp/host")
+        assert host.get("name") == "node-01.lab"
 
     @pytest.mark.parametrize("dhcp", [None, {}, {"range": None, "hosts": None}])
     def test_null_dhcp_blocks_are_not_a_crash(self, dhcp):

--- a/tests/test_net_reconcile.py
+++ b/tests/test_net_reconcile.py
@@ -16,6 +16,7 @@ modified, only added or deleted").
 
 from __future__ import annotations
 
+import json
 import xml.etree.ElementTree as ET
 from unittest.mock import MagicMock, patch
 
@@ -161,6 +162,22 @@ class TestDiffDhcpHosts:
         assert [command for command, _ in ops] == ["delete", "add-last"]
 
 
+    def test_two_reservations_swapping_addresses_converge(self):
+        # a modify cannot claim an address another surviving entry still holds,
+        # so libvirt rejects it and the pair never converges; both have to be
+        # deleted before either is added back
+        ops = nr.diff_dhcp_hosts(
+            [{"mac": "aa", "ip": "1.1.1.2"}, {"mac": "bb", "ip": "1.1.1.1"}],
+            [{"mac": "aa", "ip": "1.1.1.1"}, {"mac": "bb", "ip": "1.1.1.2"}])
+        commands = [command for command, _ in ops]
+        assert commands == ["delete", "delete", "add-last", "add-last"]
+
+    def test_an_uncontested_move_is_still_a_modify(self):
+        ops = nr.diff_dhcp_hosts([{"mac": "aa", "ip": "1.1.1.9"}],
+                                 [{"mac": "aa", "ip": "1.1.1.1"}])
+        assert [command for command, _ in ops] == ["modify"]
+
+
 class TestDiffDhcpRange:
 
     def test_change_becomes_delete_then_add(self):
@@ -248,6 +265,48 @@ class TestPinnedBridgeAndStp:
             net = Network(name="demo", info=info, assign_new_bridge=False,
                           provider_config={"use_sudo": False})
         assert nr.desired_state(net)["bridge_name"] is None
+
+    def test_a_short_network_mac_does_not_read_as_drift(self):
+        # libvirt zero-pads the network's own mac when it stores it, so a
+        # short-form config would be permanent structural drift -- and with
+        # --recreate-networks that rebuilds the network, rebooting its guests,
+        # on every single run
+        info = {"mode": "nat", "mac": "52:54:0:a:b:c",
+                "ip": {"address": "10.5.3.1", "netmask": "255.255.255.0",
+                       "dhcp": {"range": {"start": "10.5.3.50",
+                                          "end": "10.5.3.100"},
+                                "hosts": [{"mac": "52:54:00:00:00:01",
+                                           "ip": "10.5.3.10",
+                                           "name": "one"}]}}}
+        with patch.object(Network, "find_available_bridge_name",
+                          return_value="virbr9"):
+            net = Network(name="demo", info=info, assign_new_bridge=True,
+                          provider_config={"use_sudo": False})
+        assert net.mac_address == "52:54:00:0a:0b:0c"
+        plan = nr.diff_network(nr.desired_state(net),
+                               nr.parse_network_xml(LIVE_XML))
+        assert plan["action"] == "none", plan["structural"]
+
+    def test_a_short_reservation_mac_is_left_alone(self):
+        # the opposite of the network mac: libvirt stores reservation macs
+        # verbatim, so padding one here would create the mismatch
+        with patch.object(Network, "find_available_bridge_name",
+                          return_value="virbr9"):
+            net = Network(
+                name="demo", assign_new_bridge=True,
+                provider_config={"use_sudo": False},
+                info={"mode": "nat",
+                      "ip": {"address": "10.5.3.1", "netmask": "255.255.255.0",
+                             "dhcp": {"hosts": [{"mac": "52:54:0:c:1:1",
+                                                 "ip": "10.5.3.10"}]}}})
+        assert net.dhcp_hosts[0]["mac"] == "52:54:0:c:1:1"
+
+    def test_an_unrecognised_stp_value_is_rejected(self):
+        # quietly turning `stp: enabled` into 'off' would disable stp silently
+        with pytest.raises(ValueError, match="stp must be on or off"):
+            Network(name="demo", info={"bridge": {"stp": "enabled"}},
+                    assign_new_bridge=False,
+                    provider_config={"use_sudo": False})
 
     @pytest.mark.parametrize("configured, expected", [
         (True, "on"), (False, "off"),          # yaml reads unquoted on/off as bool
@@ -432,6 +491,83 @@ class TestRecreateSequence:
                 dry_run=False, allow_recreate=True, auto_accept=False)
         assert outcome == 'skipped'
         assert calls == []
+
+
+class TestCacheSelfConflict:
+    """
+    The wedge: a network must not conflict with its own cache entry.
+
+    ``define_network`` used to write the cache entry *before* ``net-define``,
+    so a define that failed left the cache claiming a network that does not
+    exist; ``check_network_exists`` then refused to create it on every later
+    run, by name and by address, against itself. These drive the real
+    ``BoxmanCache`` against a temporary cache file rather than a mock, because
+    the mocked-provider tests cannot see inside ``define_network`` at all.
+    """
+
+    @staticmethod
+    def _net_with_cache(tmp_path, cached: dict | None):
+        from boxman.config_cache import BoxmanCache
+
+        cache = BoxmanCache.__new__(BoxmanCache)
+        cache.cache_dir = str(tmp_path)
+        cache.projects_cache_file = str(tmp_path / 'projects.json')
+        cache.projects = None
+        if cached is not None:
+            (tmp_path / 'projects.json').write_text(json.dumps(cached))
+
+        manager = MagicMock()
+        manager.cache = cache
+        manager.config = {'project': 'p1'}
+        manager._runtime_name = 'local'
+
+        info = {"mode": "nat", "bridge": {"name": "virbr9"},
+                "ip": {"address": "10.5.3.1", "netmask": "255.255.255.0"}}
+        net = Network(name="bprj__p1__bprj__clstr__c1__clstr__nat", info=info,
+                      assign_new_bridge=True,
+                      provider_config={"use_sudo": False}, manager=manager)
+        return net, cache
+
+    def test_a_networks_own_entry_is_not_a_conflict(self, tmp_path):
+        # exactly the state a failed define, or a recreate, leaves behind
+        net, _ = self._net_with_cache(tmp_path, {
+            'p1': {'runtime': 'local', 'networks': {
+                'bprj__p1__bprj__clstr__c1__clstr__nat': {
+                    'ip_address': '10.5.3.1', 'bridge_name': 'virbr9'}}}})
+        net.check_network_exists()      # must not raise
+
+    def test_another_project_with_the_same_address_still_conflicts(self, tmp_path):
+        net, _ = self._net_with_cache(tmp_path, {
+            'p2': {'runtime': 'local', 'networks': {
+                'bprj__p2__bprj__clstr__c1__clstr__nat': {
+                    'ip_address': '10.5.3.1', 'bridge_name': 'virbr9'}}}})
+        with pytest.raises(RuntimeError, match="conflict"):
+            net.check_network_exists()
+
+    def test_the_cache_is_written_only_after_the_define_succeeds(self, tmp_path):
+        # a failed net-define must not leave an entry behind
+        net, cache = self._net_with_cache(tmp_path, {'p1': {'runtime': 'local'}})
+
+        def fake_execute(*args, **kwargs):
+            if args[0] == "net-define":
+                raise RuntimeError("boom")
+            return _result()
+
+        net.execute = fake_execute
+        net._get_libvirt_bridges = lambda: set()
+        assert net.define_network(str(tmp_path / 'net.xml')) is False
+
+        cache.read_projects_cache()
+        assert not cache.projects['p1'].get('networks')
+
+    def test_a_bridge_already_in_use_raises_instead_of_exiting(self, tmp_path):
+        # SystemExit would take the whole reconcile down, after a recreate has
+        # already destroyed the previous network
+        net, _ = self._net_with_cache(tmp_path, {'p1': {'runtime': 'local'}})
+        net._get_libvirt_bridges = lambda: {"virbr9"}
+        net._log_bridge_usage = lambda _: None
+        with pytest.raises(RuntimeError, match="already in use"):
+            net.define_network(str(tmp_path / 'net.xml'))
 
 
 class TestElementRendering:

--- a/tests/test_net_reconcile.py
+++ b/tests/test_net_reconcile.py
@@ -16,6 +16,7 @@ modified, only added or deleted").
 
 from __future__ import annotations
 
+import xml.etree.ElementTree as ET
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -223,6 +224,73 @@ class TestDiffNetwork:
         assert nr.diff_network(desired, actual)["action"] == "recreate"
 
 
+class TestPinnedBridgeAndStp:
+    """Fields whose configured form differs from what libvirt echoes back."""
+
+    def test_pinned_bridge_name_reaches_the_diff(self, ):
+        # the plan builds its Network with assign_new_bridge=False, which reads
+        # the bridge from libvirt; the *configured* name has to survive that or
+        # the pinned-name drift check can never fire
+        info = {"mode": "nat", "bridge": {"name": "virbr42"},
+                "ip": {"address": "10.5.3.1", "netmask": "255.255.255.0"}}
+        with patch.object(Network, "get_bridge_from_network",
+                          return_value="virbr9"):
+            net = Network(name="demo", info=info, assign_new_bridge=False,
+                          provider_config={"use_sudo": False})
+        assert net.bridge_name == "virbr9"          # what is in use
+        assert nr.desired_state(net)["bridge_name"] == "virbr42"   # what was asked for
+
+    def test_unpinned_bridge_name_is_not_reported_as_desired(self):
+        info = {"mode": "nat",
+                "ip": {"address": "10.5.3.1", "netmask": "255.255.255.0"}}
+        with patch.object(Network, "get_bridge_from_network",
+                          return_value="virbr9"):
+            net = Network(name="demo", info=info, assign_new_bridge=False,
+                          provider_config={"use_sudo": False})
+        assert nr.desired_state(net)["bridge_name"] is None
+
+    @pytest.mark.parametrize("configured, expected", [
+        (True, "on"), (False, "off"),          # yaml reads unquoted on/off as bool
+        ("on", "on"), ("off", "off"),
+        ("true", "on"), ("yes", "on"), (1, "on"), (0, "off"),
+    ])
+    def test_stp_is_normalised(self, configured, expected):
+        assert Network._normalise_stp(configured) == expected
+
+    def test_yaml_boolean_stp_does_not_read_as_drift(self):
+        # `stp: on` unquoted is True in yaml; libvirt accepts stp='True' and
+        # stores it as 'on'. Without normalising, that mismatch is permanent
+        # drift and --recreate-networks would rebuild the network on every run
+        info = {"mode": "nat", "bridge": {"stp": True, "delay": 0},
+                "mac": "52:54:00:0a:0b:0c",
+                "ip": {"address": "10.5.3.1", "netmask": "255.255.255.0",
+                       "dhcp": {"range": {"start": "10.5.3.50",
+                                          "end": "10.5.3.100"},
+                                "hosts": [{"mac": "52:54:00:00:00:01",
+                                           "ip": "10.5.3.10",
+                                           "name": "one"}]}}}
+        with patch.object(Network, "find_available_bridge_name",
+                          return_value="virbr9"):
+            net = Network(name="demo", info=info, assign_new_bridge=True,
+                          provider_config={"use_sudo": False})
+        plan = nr.diff_network(nr.desired_state(net),
+                               nr.parse_network_xml(LIVE_XML))
+        assert plan["action"] == "none", plan["structural"]
+
+    def test_numeric_reservation_name_does_not_read_as_drift(self):
+        # `name: 101` is an int in yaml and would never equal the '101' read
+        # back from the network XML
+        info = {"mode": "nat",
+                "ip": {"address": "10.5.3.1", "netmask": "255.255.255.0",
+                       "dhcp": {"hosts": [{"mac": "52:54:00:00:00:01",
+                                           "ip": "10.5.3.10", "name": 101}]}}}
+        with patch.object(Network, "find_available_bridge_name",
+                          return_value="virbr9"):
+            net = Network(name="demo", info=info, assign_new_bridge=True,
+                          provider_config={"use_sudo": False})
+        assert net.dhcp_hosts[0]["name"] == "101"
+
+
 class TestTeardownInfo:
     """A recreate must withdraw the rules of the network that is there now."""
 
@@ -256,6 +324,116 @@ class TestTeardownInfo:
         assert self._teardown({}, network_info) is network_info
 
 
+class TestRecreateSequence:
+    """
+    The destructive path, with the provider and the cache stubbed.
+
+    The ordering here is not cosmetic: ``define_network`` starts with
+    ``check_network_exists()``, which walks every cached project *including
+    this one*. A network's own leftover cache entry therefore collides with
+    itself and the redefine raises -- after the network has already been
+    destroyed, which wedges the project until the cache is edited by hand.
+    """
+
+    @staticmethod
+    def _manager(remove=True, define=True, reattach='hot'):
+        from boxman.manager import BoxmanManager
+
+        mgr = BoxmanManager.__new__(BoxmanManager)
+        mgr.config = {'project': 'p1', 'clusters': {}}
+        mgr.logger = MagicMock()
+
+        calls = []
+
+        mgr.cache = MagicMock()
+        mgr.cache.projects = {'p1': {'networks': {'full-net': {'ip_address': '10.5.3.1'}}}}
+        mgr.cache.read_projects_cache.side_effect = lambda: calls.append('cache-read')
+        mgr.cache.write_projects_cache.side_effect = lambda: calls.append('cache-write')
+
+        provider = MagicMock()
+        provider.remove_network.side_effect = lambda **kw: (
+            calls.append('remove') or remove)
+        provider.define_network.side_effect = lambda **kw: (
+            calls.append('define') or define)
+        provider.reattach_domain_network.side_effect = lambda *a: (
+            calls.append('reattach') or reattach)
+        mgr.provider = provider
+
+        return mgr, calls
+
+    def _recreate(self, mgr, plan=None):
+        return mgr._recreate_network(
+            cluster={'workdir': '/tmp/wd'},
+            network_name='cluster_1/mgmt',
+            full_name='full-net',
+            network_info={'mode': 'route'},
+            plan=plan if plan is not None else {
+                'structural': ["ip address '10.5.3.1' -> '10.9.9.1'"],
+                'attached_vms': ['vm1'],
+                'actual': {'mode': 'nat', 'ip_address': '10.5.3.1',
+                           'netmask': '255.255.255.0'}},
+            dry_run=False, allow_recreate=True, auto_accept=True)
+
+    def test_cache_entry_is_dropped_before_the_redefine(self):
+        mgr, calls = self._manager()
+        assert self._recreate(mgr) == 'recreated'
+        assert 'full-net' not in mgr.cache.projects['p1']['networks']
+        assert calls.index('cache-write') < calls.index('define')
+        assert calls.index('remove') < calls.index('define')
+
+    def test_a_failed_removal_does_not_redefine_on_top(self):
+        mgr, calls = self._manager(remove=False)
+        assert self._recreate(mgr) == 'failed'
+        assert 'define' not in calls
+
+    def test_a_conflict_on_redefine_is_a_result_not_a_traceback(self):
+        mgr, calls = self._manager()
+        mgr.provider.define_network.side_effect = RuntimeError(
+            "found 2 conflicts for network full-net")
+        assert self._recreate(mgr) == 'failed'
+
+    def test_a_vm_that_cannot_be_reconnected_is_not_reported_as_success(self):
+        mgr, _ = self._manager(reattach='failed')
+        assert self._recreate(mgr) == 'partial'
+
+    def test_teardown_uses_the_actual_mode(self):
+        mgr, _ = self._manager()
+        self._recreate(mgr)
+        info = mgr.provider.remove_network.call_args.kwargs['info']
+        assert info['mode'] == 'nat'          # what is there, not the new 'route'
+
+    def test_nothing_is_touched_without_the_flag(self):
+        mgr, calls = self._manager()
+        outcome = mgr._recreate_network(
+            cluster={'workdir': '/tmp/wd'}, network_name='cluster_1/mgmt',
+            full_name='full-net', network_info={'mode': 'route'},
+            plan={'structural': ['x'], 'attached_vms': ['vm1'], 'actual': {}},
+            dry_run=False, allow_recreate=False, auto_accept=True)
+        assert outcome == 'skipped'
+        assert calls == []
+
+    def test_dry_run_touches_nothing(self):
+        mgr, calls = self._manager()
+        outcome = mgr._recreate_network(
+            cluster={'workdir': '/tmp/wd'}, network_name='cluster_1/mgmt',
+            full_name='full-net', network_info={'mode': 'route'},
+            plan={'structural': ['x'], 'attached_vms': ['vm1'], 'actual': {}},
+            dry_run=True, allow_recreate=True, auto_accept=True)
+        assert outcome == 'skipped'
+        assert calls == []
+
+    def test_no_stdin_aborts_instead_of_raising(self):
+        mgr, calls = self._manager()
+        with patch('builtins.input', side_effect=EOFError):
+            outcome = mgr._recreate_network(
+                cluster={'workdir': '/tmp/wd'}, network_name='cluster_1/mgmt',
+                full_name='full-net', network_info={'mode': 'route'},
+                plan={'structural': ['x'], 'attached_vms': [], 'actual': {}},
+                dry_run=False, allow_recreate=True, auto_accept=False)
+        assert outcome == 'skipped'
+        assert calls == []
+
+
 class TestElementRendering:
 
     def test_host_element_includes_the_optional_name(self):
@@ -269,6 +447,18 @@ class TestElementRendering:
     def test_range_element(self):
         assert nr.range_element({"start": "1.1.1.1", "end": "1.1.1.9"}) == \
             "<range start='1.1.1.1' end='1.1.1.9'/>"
+
+    def test_name_is_escaped(self):
+        # the template escapes with |e, and this path has to match: a name
+        # holding an & defines fine and would then break every net-update
+        element = nr.host_element(
+            {"mac": "aa", "ip": "1.1.1.1", "name": "a&b'c"})
+        assert "a&amp;b&apos;c" in element
+        ET.fromstring(element)   # parses, which is the whole point
+
+    def test_a_numeric_value_is_rendered(self):
+        assert nr.host_element({"mac": "aa", "ip": "1.1.1.1", "name": 101}) == \
+            "<host mac='aa' name='101' ip='1.1.1.1'/>"
 
 
 class TestApplyLivePlan:
@@ -315,7 +505,7 @@ class TestApplyLivePlan:
         # element would fail to match an entry whose ip already moved
         net, _ = self._net_with_exec()
         seen = []
-        net.apply_net_update = lambda command, section, element: (
+        net.apply_net_update = lambda command, section, element, live=None: (
             seen.append((command, section, element)) or True)
 
         net.apply_live_plan({
@@ -326,7 +516,7 @@ class TestApplyLivePlan:
     def test_add_and_modify_send_the_whole_element(self):
         net, _ = self._net_with_exec()
         seen = []
-        net.apply_net_update = lambda command, section, element: (
+        net.apply_net_update = lambda command, section, element, live=None: (
             seen.append(element) or True)
 
         net.apply_live_plan({"host_ops": [
@@ -335,6 +525,29 @@ class TestApplyLivePlan:
 
         assert seen == ["<host mac='aa' name='n' ip='1.1.1.2'/>",
                         "<host mac='bb' ip='1.1.1.3'/>"]
+
+    def test_a_failed_range_delete_stops_the_add(self):
+        # otherwise the network ends up with two ranges, and the diff only
+        # reads the first -- so every later run tries to add the second again
+        net, _ = self._net_with_exec()
+        seen = []
+        net.apply_net_update = lambda command, section, element, live=None: (
+            seen.append(command) or command != 'delete')
+
+        ok = net.apply_live_plan({"range_ops": [
+            ("delete", {"start": "1.1.1.1", "end": "1.1.1.9"}),
+            ("add-last", {"start": "1.1.1.10", "end": "1.1.1.20"})]})
+
+        assert seen == ["delete"]
+        assert ok is False
+
+    def test_active_state_is_looked_up_once_per_plan(self):
+        net, calls = self._net_with_exec()
+        net.apply_live_plan({"host_ops": [
+            ("add-last", {"mac": "aa", "ip": "1.1.1.1"}),
+            ("add-last", {"mac": "bb", "ip": "1.1.1.2"}),
+            ("add-last", {"mac": "cc", "ip": "1.1.1.3"})]})
+        assert len([args for args in calls if args[0] == "net-list"]) == 1
 
     def test_a_failing_update_is_reported(self):
         net = _network({"mode": "nat",

--- a/tests/test_net_reconcile.py
+++ b/tests/test_net_reconcile.py
@@ -1,0 +1,346 @@
+"""
+Unit tests for network reconciliation.
+
+Two halves:
+
+1. ``net_reconcile`` -- the pure diff between the configured network and the
+   XML libvirt reports. No virsh involved.
+2. ``Network.apply_live_plan`` / ``apply_net_update`` -- the command building
+   for ``virsh net-update``, with the executor mocked.
+
+The behaviour being encoded here was checked against libvirt 11.2.0: dhcp
+hosts and ranges can be changed on a running network, the ip and bridge
+sections cannot, and ``modify`` is refused for a range ("dhcp ranges cannot be
+modified, only added or deleted").
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from boxman.providers.libvirt import net_reconcile as nr
+from boxman.providers.libvirt.net import Network
+
+
+pytestmark = pytest.mark.unit
+
+
+LIVE_XML = """
+<network>
+  <name>demo</name>
+  <uuid>9f8e7d6c-0000-0000-0000-000000000000</uuid>
+  <forward mode='nat'/>
+  <bridge name='virbr9' stp='on' delay='0'/>
+  <mac address='52:54:00:0A:0B:0C'/>
+  <ip address='10.5.3.1' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='10.5.3.50' end='10.5.3.100'/>
+      <host mac='52:54:00:00:00:01' name='one' ip='10.5.3.10'/>
+    </dhcp>
+  </ip>
+</network>
+"""
+
+
+def _result(stdout: str = "", ok: bool = True, stderr: str = "") -> MagicMock:
+    r = MagicMock(name="invoke.Result")
+    r.stdout = stdout
+    r.stderr = stderr
+    r.ok = ok
+    r.failed = not ok
+    return r
+
+
+def _network(info: dict) -> Network:
+    with patch.object(Network, "find_available_bridge_name",
+                      return_value="virbr9"):
+        return Network(name="demo", info=info, assign_new_bridge=True,
+                       provider_config={"use_sudo": False})
+
+
+class TestParseNetworkXml:
+
+    def test_reads_every_compared_field(self):
+        state = nr.parse_network_xml(LIVE_XML)
+        assert state["mode"] == "nat"
+        assert state["bridge_name"] == "virbr9"
+        assert state["bridge_stp"] == "on"
+        assert state["ip_address"] == "10.5.3.1"
+        assert state["netmask"] == "255.255.255.0"
+        assert state["dhcp_range"] == {"start": "10.5.3.50", "end": "10.5.3.100"}
+        assert state["dhcp_hosts"] == [
+            {"mac": "52:54:00:00:00:01", "ip": "10.5.3.10", "name": "one"}]
+
+    def test_mac_is_lowercased(self):
+        # libvirt echoes back whatever case it was given, boxman stores lower
+        assert nr.parse_network_xml(LIVE_XML)["mac"] == "52:54:00:0a:0b:0c"
+
+    def test_uuid_is_not_part_of_the_state(self):
+        # it is regenerated on every definition and would read as permanent drift
+        assert "uuid" not in nr.parse_network_xml(LIVE_XML)
+
+    def test_prefix_is_normalised_to_a_netmask(self):
+        xml = ("<network><name>d</name><forward mode='nat'/>"
+               "<ip address='10.5.3.1' prefix='24'/></network>")
+        assert nr.parse_network_xml(xml)["netmask"] == "255.255.255.0"
+
+    def test_network_without_dhcp_or_ip(self):
+        xml = "<network><name>d</name><forward mode='open'/></network>"
+        state = nr.parse_network_xml(xml)
+        assert state["dhcp_hosts"] == []
+        assert state["dhcp_range"] is None
+        assert state["ip_address"] is None
+
+
+class TestDesiredState:
+
+    def test_built_from_the_network_object(self):
+        net = _network({
+            "mode": "nat",
+            "ip": {"address": "10.5.3.1", "netmask": "255.255.255.0",
+                   "dhcp": {"range": {"start": "10.5.3.50", "end": "10.5.3.100"},
+                            "hosts": [{"mac": "52:54:00:00:00:01",
+                                       "ip": "10.5.3.10", "name": "one"}]}},
+        })
+        state = nr.desired_state(net)
+        assert state["mode"] == "nat"
+        assert state["ip_address"] == "10.5.3.1"
+        assert state["dhcp_range"] == {"start": "10.5.3.50", "end": "10.5.3.100"}
+        assert state["dhcp_hosts"][0]["name"] == "one"
+
+    def test_matches_what_libvirt_reports_for_the_same_config(self):
+        # the round trip must be drift-free, otherwise every reconcile would
+        # think the network had changed
+        net = _network({
+            "mode": "nat",
+            "mac": "52:54:00:0a:0b:0c",
+            "ip": {"address": "10.5.3.1", "netmask": "255.255.255.0",
+                   "dhcp": {"range": {"start": "10.5.3.50", "end": "10.5.3.100"},
+                            "hosts": [{"mac": "52:54:00:00:00:01",
+                                       "ip": "10.5.3.10", "name": "one"}]}},
+        })
+        plan = nr.diff_network(nr.desired_state(net),
+                               nr.parse_network_xml(LIVE_XML))
+        assert plan["action"] == "none"
+        assert plan["structural"] == []
+
+
+class TestDiffDhcpHosts:
+
+    def test_added_reservation(self):
+        ops = nr.diff_dhcp_hosts([{"mac": "aa", "ip": "1.1.1.1"}], [])
+        assert ops == [("add-last", {"mac": "aa", "ip": "1.1.1.1"})]
+
+    def test_removed_reservation(self):
+        ops = nr.diff_dhcp_hosts([], [{"mac": "aa", "ip": "1.1.1.1"}])
+        assert ops == [("delete", {"mac": "aa", "ip": "1.1.1.1"})]
+
+    def test_moved_address_is_a_modify_not_a_remove_and_add(self):
+        # libvirt keys on the mac, so this is one operation
+        ops = nr.diff_dhcp_hosts([{"mac": "aa", "ip": "1.1.1.2"}],
+                                 [{"mac": "aa", "ip": "1.1.1.1"}])
+        assert ops == [("modify", {"mac": "aa", "ip": "1.1.1.2"})]
+
+    def test_added_name_is_a_modify(self):
+        ops = nr.diff_dhcp_hosts([{"mac": "aa", "ip": "1.1.1.1", "name": "n"}],
+                                 [{"mac": "aa", "ip": "1.1.1.1"}])
+        assert ops[0][0] == "modify"
+
+    def test_identical_lists_produce_nothing(self):
+        entries = [{"mac": "aa", "ip": "1.1.1.1", "name": "n"}]
+        assert nr.diff_dhcp_hosts(entries, list(entries)) == []
+
+    def test_deletions_are_ordered_before_additions(self):
+        # so that an address being handed from one mac to another is free by
+        # the time the new reservation asks for it
+        ops = nr.diff_dhcp_hosts([{"mac": "bb", "ip": "1.1.1.1"}],
+                                 [{"mac": "aa", "ip": "1.1.1.1"}])
+        assert [command for command, _ in ops] == ["delete", "add-last"]
+
+
+class TestDiffDhcpRange:
+
+    def test_change_becomes_delete_then_add(self):
+        # libvirt: "dhcp ranges cannot be modified, only added or deleted"
+        ops = nr.diff_dhcp_range({"start": "1.1.1.10", "end": "1.1.1.20"},
+                                 {"start": "1.1.1.1", "end": "1.1.1.9"})
+        assert [command for command, _ in ops] == ["delete", "add-last"]
+
+    def test_unchanged_range_produces_nothing(self):
+        same = {"start": "1.1.1.1", "end": "1.1.1.9"}
+        assert nr.diff_dhcp_range(same, dict(same)) == []
+
+    def test_range_added_to_a_reservations_only_network(self):
+        ops = nr.diff_dhcp_range({"start": "1.1.1.1", "end": "1.1.1.9"}, None)
+        assert [command for command, _ in ops] == ["add-last"]
+
+
+class TestDiffNetwork:
+
+    def test_dhcp_only_changes_stay_live(self):
+        actual = nr.parse_network_xml(LIVE_XML)
+        desired = dict(actual)
+        desired["dhcp_hosts"] = [{"mac": "52:54:00:00:00:09", "ip": "10.5.3.30"}]
+        assert nr.diff_network(desired, actual)["action"] == "live"
+
+    @pytest.mark.parametrize("field, value", [
+        ("mode", "route"),
+        ("ip_address", "10.9.9.1"),
+        ("netmask", "255.255.0.0"),
+        ("bridge_stp", "off"),
+        ("mac", "52:54:00:ff:ff:ff"),
+    ])
+    def test_structural_changes_force_a_recreate(self, field, value):
+        actual = nr.parse_network_xml(LIVE_XML)
+        desired = dict(actual)
+        desired[field] = value
+        plan = nr.diff_network(desired, actual)
+        assert plan["action"] == "recreate"
+        assert len(plan["structural"]) == 1
+
+    def test_an_unpinned_bridge_name_is_not_drift(self):
+        # boxman assigns virbrX when the config does not pin one, so libvirt is
+        # authoritative and a difference here must not trigger a recreate
+        actual = nr.parse_network_xml(LIVE_XML)
+        desired = dict(actual)
+        desired["bridge_name"] = None
+        assert nr.diff_network(desired, actual)["action"] == "none"
+
+    def test_a_pinned_bridge_name_is_drift(self):
+        actual = nr.parse_network_xml(LIVE_XML)
+        desired = dict(actual)
+        desired["bridge_name"] = "virbr42"
+        assert nr.diff_network(desired, actual)["action"] == "recreate"
+
+    def test_structural_wins_over_live(self):
+        # no point updating dnsmasq on a network about to be destroyed
+        actual = nr.parse_network_xml(LIVE_XML)
+        desired = dict(actual)
+        desired["ip_address"] = "10.9.9.1"
+        desired["dhcp_hosts"] = [{"mac": "52:54:00:00:00:09", "ip": "10.9.9.5"}]
+        assert nr.diff_network(desired, actual)["action"] == "recreate"
+
+
+class TestTeardownInfo:
+    """A recreate must withdraw the rules of the network that is there now."""
+
+    @staticmethod
+    def _teardown(actual, network_info):
+        from boxman.manager import BoxmanManager
+        return BoxmanManager._teardown_info({'actual': actual}, network_info)
+
+    def test_uses_the_actual_mode_not_the_desired_one(self):
+        # nat -> route: withdrawing route rules would leave the nat rules in
+        # place and remove rules that were never added
+        info = self._teardown(
+            {'mode': 'nat', 'bridge_name': 'virbr9', 'ip_address': '10.5.3.1',
+             'netmask': '255.255.255.0'},
+            {'mode': 'route', 'ip': {'address': '10.9.9.1'}})
+        assert info['mode'] == 'nat'
+        assert info['ip']['address'] == '10.5.3.1'
+        assert info['bridge']['name'] == 'virbr9'
+
+    def test_no_dhcp_block_is_carried_over(self):
+        # reservations validated against the new subnet would be rejected when
+        # paired with the old address
+        info = self._teardown(
+            {'mode': 'nat', 'ip_address': '10.5.3.1', 'netmask': '255.255.255.0'},
+            {'mode': 'nat', 'ip': {'address': '10.9.9.1', 'dhcp': {
+                'hosts': [{'mac': '52:54:00:00:00:01', 'ip': '10.9.9.10'}]}}})
+        assert 'dhcp' not in info['ip']
+
+    def test_falls_back_to_the_configuration_when_nothing_is_known(self):
+        network_info = {'mode': 'nat'}
+        assert self._teardown({}, network_info) is network_info
+
+
+class TestElementRendering:
+
+    def test_host_element_includes_the_optional_name(self):
+        assert nr.host_element({"mac": "aa", "ip": "1.1.1.1", "name": "n"}) == \
+            "<host mac='aa' name='n' ip='1.1.1.1'/>"
+
+    def test_host_element_without_a_name(self):
+        assert nr.host_element({"mac": "aa", "ip": "1.1.1.1"}) == \
+            "<host mac='aa' ip='1.1.1.1'/>"
+
+    def test_range_element(self):
+        assert nr.range_element({"start": "1.1.1.1", "end": "1.1.1.9"}) == \
+            "<range start='1.1.1.1' end='1.1.1.9'/>"
+
+
+class TestApplyLivePlan:
+    """The virsh net-update calls, with the executor mocked."""
+
+    @staticmethod
+    def _net_with_exec(active: bool = True):
+        net = _network({"mode": "nat",
+                        "ip": {"address": "10.5.3.1", "netmask": "255.255.255.0"}})
+        calls = []
+
+        def fake_execute(*args, **kwargs):
+            calls.append(args)
+            if args[0] == "net-list":
+                return _result(stdout="demo\n" if active else "")
+            return _result()
+
+        net.execute = fake_execute
+        return net, calls
+
+    def test_range_is_applied_before_the_reservations(self):
+        net, calls = self._net_with_exec()
+        net.apply_live_plan({
+            "range_ops": [("add-last", {"start": "1.1.1.1", "end": "1.1.1.9"})],
+            "host_ops": [("add-last", {"mac": "aa", "ip": "1.1.1.2"})],
+        })
+        sections = [args[3] for args in calls if args[0] == "net-update"]
+        assert sections == ["ip-dhcp-range", "ip-dhcp-host"]
+
+    def test_live_flag_only_when_the_network_is_running(self):
+        net, calls = self._net_with_exec(active=True)
+        net.apply_live_plan({"host_ops": [("add-last", {"mac": "aa", "ip": "1.1.1.2"})]})
+        update = [args for args in calls if args[0] == "net-update"][0]
+        assert "--config" in update and "--live" in update
+
+    def test_a_stopped_network_is_only_updated_in_config(self):
+        net, calls = self._net_with_exec(active=False)
+        net.apply_live_plan({"host_ops": [("add-last", {"mac": "aa", "ip": "1.1.1.2"})]})
+        update = [args for args in calls if args[0] == "net-update"][0]
+        assert "--config" in update and "--live" not in update
+
+    def test_delete_matches_on_the_mac_alone(self):
+        # net-update matches every attribute it is given, so passing the whole
+        # element would fail to match an entry whose ip already moved
+        net, _ = self._net_with_exec()
+        seen = []
+        net.apply_net_update = lambda command, section, element: (
+            seen.append((command, section, element)) or True)
+
+        net.apply_live_plan({
+            "host_ops": [("delete", {"mac": "aa", "ip": "1.1.1.2", "name": "n"})]})
+
+        assert seen == [("delete", "ip-dhcp-host", "<host mac='aa'/>")]
+
+    def test_add_and_modify_send_the_whole_element(self):
+        net, _ = self._net_with_exec()
+        seen = []
+        net.apply_net_update = lambda command, section, element: (
+            seen.append(element) or True)
+
+        net.apply_live_plan({"host_ops": [
+            ("add-last", {"mac": "aa", "ip": "1.1.1.2", "name": "n"}),
+            ("modify", {"mac": "bb", "ip": "1.1.1.3"})]})
+
+        assert seen == ["<host mac='aa' name='n' ip='1.1.1.2'/>",
+                        "<host mac='bb' ip='1.1.1.3'/>"]
+
+    def test_a_failing_update_is_reported(self):
+        net = _network({"mode": "nat",
+                        "ip": {"address": "10.5.3.1", "netmask": "255.255.255.0"}})
+        net.execute = lambda *a, **k: (
+            _result(stdout="demo\n") if a[0] == "net-list"
+            else _result(ok=False, stderr="boom"))
+        assert net.apply_live_plan(
+            {"host_ops": [("add-last", {"mac": "aa", "ip": "1.1.1.2"})]}) is False

--- a/tests/test_network_reconcile_integration.py
+++ b/tests/test_network_reconcile_integration.py
@@ -1,0 +1,347 @@
+"""
+Network reconciliation against a real libvirt.
+
+The reconcile logic is unit-tested with virsh mocked out, which is enough for
+the diff but not for the part that has actually broken twice: what
+``define_network`` does with the real projects cache, and whether a guest whose
+network was destroyed underneath it comes back. Both bugs were invisible to a
+mocked provider. These tests drive the real thing.
+
+**These tests create, destroy and redefine libvirt networks, and power-cycle a
+guest they created.** They are therefore opt-in twice over: the ``integration``
+marker keeps them out of the default run, and they skip unless
+``BOXMAN_INTEGRATION_LIBVIRT=1`` says the host is disposable. Point them at a
+throwaway machine -- a nested VM is ideal -- never at a host carrying work.
+
+Environment:
+
+``BOXMAN_INTEGRATION_LIBVIRT=1``
+    Required. Confirms this host may have networks destroyed on it.
+``BOXMAN_IT_URI``
+    libvirt URI, default ``qemu:///system``.
+``BOXMAN_IT_SUBNET_A`` / ``BOXMAN_IT_SUBNET_B``
+    The two /24 prefixes to move the network between, default ``10.77.1`` and
+    ``10.77.2``. Both must be unused on the host or the test skips.
+``BOXMAN_IT_BASE_IMAGE``
+    Optional qcow2 for the guest, readable **by the qemu user** (a file under a
+    0750 home is not). With it the guest runs an OS and answers the shutdown
+    request, so the reconnect is quick. Without it the guest is a disk-less
+    domain that boots nothing: still enough to hold a tap on the bridge, but
+    the power cycle has to wait out the graceful-shutdown timeout, which adds
+    about two minutes.
+
+The host also needs passwordless sudo for ``iptables``: boxman's NAT setup
+shells out to it when a network is defined.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+import xml.etree.ElementTree as ET
+
+import pytest
+import yaml
+
+from boxman.manager import BoxmanManager
+from boxman.providers.libvirt.session import LibVirtSession
+
+
+pytestmark = pytest.mark.integration
+
+URI = os.environ.get("BOXMAN_IT_URI", "qemu:///system")
+SUBNET_A = os.environ.get("BOXMAN_IT_SUBNET_A", "10.77.1")
+SUBNET_B = os.environ.get("BOXMAN_IT_SUBNET_B", "10.77.2")
+BASE_IMAGE = os.environ.get("BOXMAN_IT_BASE_IMAGE")
+
+PROJECT = "boxman_it_reconcile"
+CLUSTER = "c1"
+NETWORK = "lab"
+FULL_NET = f"bprj__{PROJECT}__bprj__clstr__{CLUSTER}__clstr__{NETWORK}"
+GUEST = "boxman-it-guest"
+GUEST_MAC = "52:54:00:17:17:01"
+
+
+def virsh(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["virsh", "--connect", URI, *args],
+                          capture_output=True, text=True)
+
+
+def _ip_bin() -> str:
+    return shutil.which("ip") or "/usr/sbin/ip"
+
+
+def taps_on(bridge: str) -> list[str]:
+    """The vnet interfaces enslaved to *bridge* right now."""
+    out = subprocess.run([_ip_bin(), "link", "show", "master", bridge],
+                         capture_output=True, text=True)
+    return [line.split(":")[1].strip()
+            for line in out.stdout.splitlines() if ": vnet" in line]
+
+
+def reservations(network: str) -> dict[str, str]:
+    """mac -> ip for the network's dhcp reservations, parsed rather than grepped.
+
+    Substring checks are not safe here: an address like ``10.77.1.10`` is a
+    prefix of the range end ``10.77.1.100``, which makes a naive ``in`` assert
+    pass and a ``not in`` assert fail for the wrong reason.
+    """
+    root = ET.fromstring(virsh("net-dumpxml", network).stdout)
+    return {host.get("mac"): host.get("ip")
+            for host in root.findall("./ip/dhcp/host")}
+
+
+def network_address(network: str) -> str | None:
+    root = ET.fromstring(virsh("net-dumpxml", network).stdout)
+    element = root.find("ip")
+    return element.get("address") if element is not None else None
+
+
+def bridge_of(network: str) -> str | None:
+    for line in virsh("net-dumpxml", network).stdout.splitlines():
+        if "<bridge" in line and "name='" in line:
+            return line.split("name='")[1].split("'")[0]
+    return None
+
+
+def network_config(subnet: str, reservation_host: str = "10") -> dict:
+    return {
+        "mode": "nat",
+        "ip": {
+            "address": f"{subnet}.1",
+            "netmask": "255.255.255.0",
+            "dhcp": {
+                "range": {"start": f"{subnet}.50", "end": f"{subnet}.100"},
+                "hosts": [{"mac": GUEST_MAC, "name": "pinned",
+                           "ip": f"{subnet}.{reservation_host}"}],
+            },
+        },
+    }
+
+
+def _preflight() -> str | None:
+    """Return the reason this host must be left alone, or None if it is fine."""
+    if os.environ.get("BOXMAN_INTEGRATION_LIBVIRT") != "1":
+        return ("set BOXMAN_INTEGRATION_LIBVIRT=1 to run this on a disposable "
+                "host: it destroys and redefines libvirt networks")
+
+    listed = virsh("net-list", "--all", "--name")
+    if listed.returncode != 0:
+        return f"libvirt is not reachable at {URI}"
+
+    if FULL_NET in listed.stdout:
+        return f"{FULL_NET} is left over from an earlier run, remove it first"
+
+    # refuse to touch a host already using either subnet
+    for name in [n.strip() for n in listed.stdout.splitlines() if n.strip()]:
+        xml = virsh("net-dumpxml", name).stdout
+        for subnet in (SUBNET_A, SUBNET_B):
+            if f"address='{subnet}.1'" in xml:
+                return (f"{subnet}.0/24 is already used by network {name}; "
+                        f"set BOXMAN_IT_SUBNET_A/B to free prefixes")
+
+    if BASE_IMAGE and not os.path.exists(BASE_IMAGE):
+        return f"BOXMAN_IT_BASE_IMAGE does not exist: {BASE_IMAGE}"
+
+    return None
+
+
+@pytest.fixture(scope="module", autouse=True)
+def disposable_host():
+    reason = _preflight()
+    if reason:
+        pytest.skip(reason)
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    """
+    A boxman project on a private HOME, so the real projects cache is untouched.
+
+    Yields a factory that builds a manager for a given subnet. Everything it
+    created is torn down afterwards even if the test fails.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+
+    def build(subnet: str, reservation_host: str = "10") -> BoxmanManager:
+        conf = {
+            "project": PROJECT,
+            "provider": {"libvirt": {"uri": URI, "virsh_cmd": "/usr/bin/virsh",
+                                     "use_sudo": True}},
+            "clusters": {CLUSTER: {
+                "workdir": str(workdir / CLUSTER),
+                "networks": {NETWORK: network_config(subnet, reservation_host)},
+                "vms": {},
+            }},
+        }
+        path = tmp_path / "conf.yml"
+        path.write_text(yaml.safe_dump(conf))
+
+        manager = BoxmanManager(config=str(path))
+        manager.load_app_config({})
+        manager.runtime = "local"
+        session = LibVirtSession(manager.config)
+        session.manager = manager
+        manager.provider = session
+        try:
+            manager.register_project_in_cache()
+        except RuntimeError:
+            pass                      # a previous build in the same test
+        return manager
+
+    try:
+        yield build
+    finally:
+        virsh("destroy", GUEST)
+        virsh("undefine", GUEST)
+        virsh("net-destroy", FULL_NET)
+        virsh("net-undefine", FULL_NET)
+
+
+def define_guest(network: str) -> None:
+    """Define and start a guest holding a nic on *network*."""
+    disk = ""
+    if BASE_IMAGE:
+        disk = (f"<disk type='file' device='disk'>"
+                f"<driver name='qemu' type='qcow2'/>"
+                f"<source file='{BASE_IMAGE}'/>"
+                f"<target dev='vda' bus='virtio'/>"
+                f"<readonly/></disk>")
+
+    domain_type = "kvm" if os.path.exists("/dev/kvm") else "qemu"
+    xml = (
+        f"<domain type='{domain_type}'>"
+        f"<name>{GUEST}</name>"
+        f"<memory unit='MiB'>512</memory><vcpu>1</vcpu>"
+        f"<os><type arch='x86_64'>hvm</type></os>"
+        f"<devices>{disk}"
+        f"<interface type='network'>"
+        f"<source network='{network}'/>"
+        f"<mac address='{GUEST_MAC}'/>"
+        f"<model type='virtio'/>"
+        f"</interface></devices></domain>"
+    )
+
+    import tempfile
+    with tempfile.NamedTemporaryFile("w", suffix=".xml", delete=False) as handle:
+        handle.write(xml)
+        path = handle.name
+    try:
+        assert virsh("define", path).returncode == 0, "could not define the guest"
+        assert virsh("start", GUEST).returncode == 0, "could not start the guest"
+    finally:
+        os.unlink(path)
+
+    for _ in range(30):
+        if "running" in virsh("domstate", GUEST).stdout:
+            return
+        time.sleep(2)
+    pytest.fail("the guest never reached the running state")
+
+
+def wait_for_tap(bridge: str, timeout: int = 60) -> list[str]:
+    for _ in range(timeout // 2):
+        taps = taps_on(bridge)
+        if taps:
+            return taps
+        time.sleep(2)
+    return []
+
+
+class TestLiveTier:
+    """Reservations change on a running network without disturbing it."""
+
+    def test_a_reservation_change_leaves_the_bridge_alone(self, project):
+        manager = project(SUBNET_A, reservation_host="10")
+        manager.define_networks()
+        bridge = bridge_of(FULL_NET)
+        assert bridge, "the network was not defined"
+        assert reservations(FULL_NET) == {GUEST_MAC: f"{SUBNET_A}.10"}
+
+        # same network, the reservation moved to another address
+        moved = project(SUBNET_A, reservation_host="20")
+        results = moved.reconcile_networks()
+
+        assert results.get(FULL_NET) == "updated", results
+        assert reservations(FULL_NET) == {GUEST_MAC: f"{SUBNET_A}.20"}
+        # the whole point of the live tier: the bridge never went away
+        assert bridge_of(FULL_NET) == bridge
+
+    def test_reconciling_twice_is_a_no_op(self, project):
+        manager = project(SUBNET_A)
+        manager.define_networks()
+
+        again = project(SUBNET_A)
+        assert again.reconcile_networks() == {}
+
+    def test_a_stopped_network_is_started_again(self, project):
+        manager = project(SUBNET_A)
+        manager.define_networks()
+        assert virsh("net-destroy", FULL_NET).returncode == 0
+
+        restarted = project(SUBNET_A)
+        results = restarted.reconcile_networks()
+
+        assert results.get(FULL_NET) == "updated", results
+        assert FULL_NET in virsh("net-list", "--name").stdout
+
+
+class TestRecreateTier:
+    """
+    Structural drift: destroy, redefine, and put the guest back.
+
+    Without BOXMAN_IT_BASE_IMAGE the guest cannot answer a shutdown request, so
+    the reconnect falls through to a forced power cycle and this takes a couple
+    of minutes.
+    """
+
+    def test_drift_is_reported_but_not_applied_without_the_flag(self, project):
+        manager = project(SUBNET_A)
+        manager.define_networks()
+        before = virsh("net-dumpxml", FULL_NET).stdout
+
+        moved = project(SUBNET_B)
+        results = moved.reconcile_networks(allow_recreate=False)
+
+        assert results.get(FULL_NET) == "skipped", results
+        assert virsh("net-dumpxml", FULL_NET).stdout == before
+
+    def test_recreate_moves_the_network_and_reconnects_the_guest(self, project):
+        manager = project(SUBNET_A)
+        manager.define_networks()
+        original_bridge = bridge_of(FULL_NET)
+
+        define_guest(FULL_NET)
+        assert wait_for_tap(original_bridge), "the guest never got a tap"
+
+        moved = project(SUBNET_B)
+        plan = moved.provider.plan_network(
+            name=FULL_NET, info=network_config(SUBNET_B))
+        assert plan["action"] == "recreate", plan
+        assert GUEST in plan["attached_vms"], plan["attached_vms"]
+
+        results = moved.reconcile_networks(allow_recreate=True, auto_accept=True)
+        assert results.get(FULL_NET) == "recreated", results
+
+        assert FULL_NET in virsh("net-list", "--name").stdout
+        assert network_address(FULL_NET) == f"{SUBNET_B}.1"
+        assert reservations(FULL_NET) == {GUEST_MAC: f"{SUBNET_B}.10"}, \
+            "the reservation was not carried over"
+
+        # the cache has to agree, or the next run refuses the network as a
+        # conflict with itself -- the failure this whole path regressed on
+        moved.cache.read_projects_cache()
+        cached = moved.cache.projects[PROJECT]["networks"][FULL_NET]
+        assert cached["ip_address"] == f"{SUBNET_B}.1", cached
+
+        assert "running" in virsh("domstate", GUEST).stdout
+        assert wait_for_tap(bridge_of(FULL_NET)), "the guest was left disconnected"
+
+        # and it converges: nothing left to do on the next pass
+        settled = project(SUBNET_B)
+        assert settled.reconcile_networks(allow_recreate=True,
+                                          auto_accept=True) == {}


### PR DESCRIPTION
## what

Network changes in `conf.yml` used to be inert. `define_networks()` only ran
from the provision path, so a reservation, a range, or a whole new network
added to an already-provisioned project did nothing at all until a
deprovision/provision cycle — silently, with no message saying so.

`boxman up` and `boxman update` now diff each configured network against
`virsh net-dumpxml` and act on the difference:

| changed | applied how | disruptive |
|---|---|---|
| `ip.dhcp.hosts` (reservations) | `virsh net-update … --live --config` | no |
| `ip.dhcp.range` | same, as delete + add | no |
| network missing from libvirt | defined and started | no |
| `mode`, `ip.address`, `ip.netmask`, `bridge.*`, `mac` | destroy + define again | **yes**, opt-in |

## why the two tiers

libvirt draws a hard line through the possible changes, and the design just
follows it. Checked against libvirt 11.2.0:

- `ip-dhcp-host` takes `add-last`, `modify` and `delete` on a running network.
  dnsmasq reloads, the bridge stays up, no guest is disturbed.
- `ip-dhcp-range` takes add and delete but **not** modify — *"dhcp ranges
  cannot be modified, only added or deleted"* — so a range change is emitted
  as a delete followed by an add.
- everything else is refused outright: *"can't update 'ip' section of
  network"*, *"can't update 'bridge' section of network"*. The only way to
  apply those is to destroy the network and define it again.

That last one is not a small thing. Destroying a network deletes the bridge,
and **libvirt does not reconnect the guests when it comes back** — verified
with a running domain: the tap is gone, the VM keeps running, and its NIC is
attached to nothing.

So the disruptive tier is opt-in behind `--recreate-networks` (on both `up`
and `update`), prints the VMs it is about to interrupt, and asks for the
network name to be typed back (skip with `-y`). Afterwards each affected VM is
reconnected: a hot detach/attach where the machine type allows it, and a
graceful power cycle where it does not — PCI hotplug is not always available
(*"Bus 'pci.0' does not support hotplugging"*), so the cold path is the
fallback rather than the exception.

## notes

- The diff is a pure function over (desired dict, actual XML) in
  `net_reconcile.py`, so the interesting logic is testable without libvirt.
- **A config round trip must report no drift**, otherwise every `up` would
  think the network had changed. The uuid is excluded from the comparison
  (regenerated on every definition) and an unpinned bridge name is not drift
  (boxman assigns it, libvirt is authoritative). Verified end to end by
  defining a network from boxman's own template and reading it back.
- Teardown before a recreate is described from the **actual** state, not the
  desired one. Handing `remove_network()` the new config would, on a
  `nat` → `route` change, withdraw route rules that were never added and leave
  the nat rules behind.
- `net-update` elements go via a temp file rather than inline. They are full of
  spaces and quotes, and the container runtime re-wraps commands as strings.
- `--live` is only added when the network is actually running; `--config`
  alone is correct for a defined-but-stopped one.
- The network pass in `update` runs **before** the "no VMs to add, update, or
  remove" early return, so a change that only touches networks is not a silent
  no-op.
- A network whose config does not validate is reported against its own name
  and skipped, rather than aborting the run for the networks and VMs that are
  fine.
- A guest holding a lease keeps its address until renewal; a new reservation
  takes hold at the next renewal, not instantly.

## tests

37 new tests in `tests/test_net_reconcile.py` — XML parsing, the desired/actual
round trip, each diff case, the structural/live split, the teardown descriptor,
and the `net-update` command building with the executor mocked.

Full suite: 1198 passed, 108 deselected.

Every path was also exercised against real libvirt 11.2.0 on throwaway
networks (round trip, live apply, idempotent re-diff, structural detection,
guest disconnection and recovery); all probe networks, domains and bridges
were cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
