### PR TITLE
feat(templates): make the cloud-init verification timeouts configurable

### DIFF
--- a/boxes/tiny-libvirt-rocky-9-cloudinit/conf.yml
+++ b/boxes/tiny-libvirt-rocky-9-cloudinit/conf.yml
@@ -23,6 +23,15 @@ templates:
     vcpus: 2
     cloudinit_network_config: disabled
     cloudinit_done_marker: /var/log/hello-cloudinit.log
+    # Caps on the post-virt-install verification phase, in seconds (defaults
+    # shown). Rocky/RHEL ship a guest agent that blacklists guest-exec until
+    # cloud-init reconfigures it, so this is the family where
+    # cloudinit_guest_exec_timeout matters — if guest-exec never becomes
+    # usable boxman falls back to a blind cloudinit_fallback_timeout wait.
+    #cloudinit_agent_timeout: 300        # wait for the qemu guest agent
+    #cloudinit_guest_exec_timeout: 120   # wait for guest-exec to be usable
+    #cloudinit_done_timeout: 120         # wait for cloudinit_done_marker
+    #cloudinit_fallback_timeout: 180     # blind wait when the guest can't be polled
     cloudinit: |
       #cloud-config
       hostname: hello-cloudinit

--- a/boxes/tiny-libvirt-ubuntu-24.04-cloudinit/conf.yml
+++ b/boxes/tiny-libvirt-ubuntu-24.04-cloudinit/conf.yml
@@ -21,6 +21,15 @@ templates:
     memory: 4096
     vcpus: 2
     cloudinit_done_marker: /var/log/hello-cloudinit.log
+    # Caps on the post-virt-install verification phase, in seconds. The
+    # defaults below are what boxman uses when these are omitted; raise
+    # cloudinit_done_timeout for templates that install a lot of packages,
+    # otherwise the done marker poll gives up before cloud-init finishes and
+    # the template is reported as unusable.
+    #cloudinit_agent_timeout: 300        # wait for the qemu guest agent
+    #cloudinit_guest_exec_timeout: 120   # wait for guest-exec to be usable
+    #cloudinit_done_timeout: 120         # wait for cloudinit_done_marker
+    #cloudinit_fallback_timeout: 180     # blind wait when the guest can't be polled
     cloudinit: |
       #cloud-config
       hostname: hello-cloudinit

--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -1142,6 +1142,10 @@ class BoxmanManager:
             cloudinit_metadata = tpl_conf.get('cloudinit_metadata', None)
             cloudinit_network_config = tpl_conf.get('cloudinit_network_config', None)
             cloudinit_done_marker = tpl_conf.get('cloudinit_done_marker', None)
+            cloudinit_agent_timeout = tpl_conf.get('cloudinit_agent_timeout', 300)
+            cloudinit_guest_exec_timeout = tpl_conf.get('cloudinit_guest_exec_timeout', 120)
+            cloudinit_done_timeout = tpl_conf.get('cloudinit_done_timeout', 120)
+            cloudinit_fallback_timeout = tpl_conf.get('cloudinit_fallback_timeout', 180)
             tpl_memory = tpl_conf.get('memory', 2048)
             tpl_vcpus = tpl_conf.get('vcpus', 2)
             tpl_os_variant = tpl_conf.get('os_variant', 'generic')
@@ -1170,6 +1174,10 @@ class BoxmanManager:
                 cloudinit_metadata=cloudinit_metadata,
                 cloudinit_network_config=cloudinit_network_config,
                 cloudinit_done_marker=cloudinit_done_marker,
+                cloudinit_agent_timeout=cloudinit_agent_timeout,
+                cloudinit_guest_exec_timeout=cloudinit_guest_exec_timeout,
+                cloudinit_done_timeout=cloudinit_done_timeout,
+                cloudinit_fallback_timeout=cloudinit_fallback_timeout,
                 workdir=tpl_workdir,
                 provider_config=provider_config,
                 memory=tpl_memory,

--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -1036,11 +1036,21 @@ class BoxmanManager:
 
         force = getattr(cli_args, 'force', False) if cli_args is not None else False
 
-        cls._create_templates_impl(requested=requested, force=force)
+        failed = cls._create_templates_impl(requested=requested, force=force)
+        if failed:
+            cls.logger.error(
+                f"{len(failed)} template(s) could not be created: "
+                f"{', '.join(failed)}")
+            raise SystemExit(1)
 
-    def _create_templates_impl(self, requested=None, force=False) -> None:
+    def _create_templates_impl(self, requested=None, force=False) -> list[str]:
         """
         Internal implementation for creating template VMs.
+
+        Returns:
+            The keys of the templates that could not be built. Empty when they
+            all succeeded. A caller that ignores this will happily clone from a
+            template whose cloud-init never finished.
 
         Args:
             requested: Optional list of template keys to create (None = all).
@@ -1057,7 +1067,10 @@ class BoxmanManager:
 
         if not templates:
             self.logger.warning("no templates defined in configuration")
-            return
+            return []
+
+        #: keys of the templates whose build failed, reported to the caller
+        failed: list[str] = []
 
         # determine provider config
         provider_type = list(config.get('provider', {}).keys())[0] if 'provider' in config else 'libvirt'
@@ -1113,7 +1126,7 @@ class BoxmanManager:
                 f"the following template(s) already exist: {names}. "
                 f"Use --force to delete and recreate them."
             )
-            return
+            return list(existing_templates)
 
         # Merge both lists (existing ones will be force-recreated)
         all_keys = existing_templates + templates_to_create
@@ -1191,11 +1204,20 @@ class BoxmanManager:
                 image_cache=image_cache,
             )
 
-            success = ct.create_template(force=force)
+            try:
+                success = ct.create_template(force=force)
+            except ValueError as exc:
+                # a bad timeout or marker in the template block
+                self.logger.error(f"template '{tpl_key}': {exc}")
+                success = False
+
             if success:
                 self.logger.info(f"template '{tpl_key}' created successfully")
             else:
                 self.logger.error(f"failed to create template '{tpl_key}'")
+                failed.append(tpl_key)
+
+        return failed
 
     def _ensure_writable_dir(self, path: str) -> None:
         """
@@ -1801,14 +1823,25 @@ class BoxmanManager:
         if not missing_keys and not broken_keys:
             return True
 
+        failed: list[str] = []
         if missing_keys:
             self.logger.info(
                 f"auto-creating {len(missing_keys)} missing template(s): {missing_keys}")
-            self._create_templates_impl(requested=missing_keys, force=False)
+            failed += self._create_templates_impl(
+                requested=missing_keys, force=False)
         if broken_keys:
             self.logger.info(
                 f"auto-rebuilding {len(broken_keys)} broken template(s): {broken_keys}")
-            self._create_templates_impl(requested=broken_keys, force=True)
+            failed += self._create_templates_impl(
+                requested=broken_keys, force=True)
+
+        if failed:
+            # returning True here would let provisioning carry on and clone
+            # from a template whose cloud-init never finished
+            self.logger.error(
+                f"template(s) {', '.join(failed)} could not be built, so the "
+                f"VMs that use them cannot be cloned")
+            return False
 
         return True
 
@@ -3219,11 +3252,17 @@ class BoxmanManager:
                 "rebuilding all templates (--rebuild-templates implies --force "
                 "for create-templates)..."
             )
-            cls._create_templates_impl(requested=None, force=True)
+            if cls._create_templates_impl(requested=None, force=True):
+                cls.logger.error(
+                    "aborting: not every template could be rebuilt")
+                return
         else:
             # Auto-create any template VMs that are referenced as base_image
             # but do not yet exist.
-            cls.ensure_templates_exist()
+            if not cls.ensure_templates_exist():
+                cls.logger.error(
+                    "aborting: not every template could be created")
+                return
 
         try:
             cls.validate_base_images()
@@ -5266,8 +5305,12 @@ class BoxmanManager:
                 # expand any `base_image: oci://…` into implicit templates
                 # before resolving/cloning (the clone path needs a VM name).
                 cls._expand_oci_base_images()
-                # ensure templates exist
-                cls.ensure_templates_exist()
+                # ensure templates exist -- cloning from one that failed to
+                # build produces VMs whose cloud-init never ran
+                if not cls.ensure_templates_exist():
+                    cls.logger.error(
+                        "aborting: not every template could be created")
+                    return
                 try:
                     cls.validate_base_images()
                 except ValueError as exc:

--- a/src/boxman/providers/libvirt/cloudinit.py
+++ b/src/boxman/providers/libvirt/cloudinit.py
@@ -32,6 +32,7 @@ from boxman.image_cache import ImageCache
 from boxman.utils.shell import run as _shell_run
 
 from .cloudinit_presets import (  # noqa: F401 — re-exported for back-compat
+    DEFAULT_DONE_MARKER,
     DEFAULT_META_DATA,
     DEFAULT_NETWORK_CONFIG,
     DEFAULT_USER_DATA,
@@ -74,19 +75,30 @@ class CloudInitTemplate:
         self.cloudinit_userdata = cloudinit_userdata
         self.cloudinit_metadata = cloudinit_metadata
         self.cloudinit_network_config = cloudinit_network_config
+        # when the stock user-data is used, boxman knows what marks the end of
+        # it: DEFAULT_USER_DATA writes this file. That makes the completion of
+        # an implicit template -- one synthesised from `base_image: oci://…`,
+        # which has nowhere to declare a marker -- verifiable like any other
+        if cloudinit_done_marker is None and cloudinit_userdata is None:
+            cloudinit_done_marker = DEFAULT_DONE_MARKER
+
         self.cloudinit_done_marker = cloudinit_done_marker
 
         # Timeouts for the cloud-init verification phase, all in seconds and
         # all overridable per template from conf.yml. Templates that install a
         # lot of packages routinely blow past the defaults.
         #: wait for the qemu guest agent to answer guest-ping
-        self.cloudinit_agent_timeout = cloudinit_agent_timeout
+        self.cloudinit_agent_timeout = self._timeout(
+            cloudinit_agent_timeout, 'cloudinit_agent_timeout')
         #: wait for guest-exec to stop being blacklisted by the agent
-        self.cloudinit_guest_exec_timeout = cloudinit_guest_exec_timeout
+        self.cloudinit_guest_exec_timeout = self._timeout(
+            cloudinit_guest_exec_timeout, 'cloudinit_guest_exec_timeout')
         #: wait for ``cloudinit_done_marker`` to appear in the guest
-        self.cloudinit_done_timeout = cloudinit_done_timeout
+        self.cloudinit_done_timeout = self._timeout(
+            cloudinit_done_timeout, 'cloudinit_done_timeout')
         #: blind wait used when the guest cannot be polled at all
-        self.cloudinit_fallback_timeout = cloudinit_fallback_timeout
+        self.cloudinit_fallback_timeout = self._timeout(
+            cloudinit_fallback_timeout, 'cloudinit_fallback_timeout')
 
         self.workdir = os.path.expanduser(workdir) if workdir else tempfile.mkdtemp(prefix="boxman-cloudinit-")
         self.provider_config = provider_config or {}
@@ -107,6 +119,31 @@ class CloudInitTemplate:
         self.virt_install = VirtInstallCommand(provider_config=provider_config)
         self.logger.info(f"using virt-install command: {self.virt_install.command_path}")
         self.logger.info(f"using virsh command: {self.virsh.command_path}")
+
+    @staticmethod
+    def _timeout(value: Any, key: str) -> int:
+        """
+        Coerce a configured timeout to a whole number of seconds.
+
+        yaml hands back whatever was written: `"300"` if it was quoted, a float
+        if it had a decimal point, None for a key left empty. All three reach
+        the ``//`` in the wait loops and raise TypeError there -- long after
+        virt-install has booted the VM. Fail here instead, with the key name.
+
+        Raises:
+            ValueError: on anything that is not a positive whole number
+        """
+        try:
+            seconds = int(value)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"{key} must be a whole number of seconds, got {value!r}") from None
+
+        if seconds < 0:
+            raise ValueError(
+                f"{key} must not be negative, got {seconds}")
+
+        return seconds
 
     @staticmethod
     def _resolve_image_path(image_path: str) -> str:
@@ -760,19 +797,27 @@ class CloudInitTemplate:
                 # remaining runcmd entries to finish.
                 if self.cloudinit_done_marker:
                     found = self._poll_done_marker(self.cloudinit_done_marker)
+                    # fetched either way: on failure this is the log that says
+                    # *why*, guest-exec still works, and the VM is still up --
+                    # exactly when it is both retrievable and wanted
+                    self._fetch_cloudinit_log()
                     if not found:
                         self.logger.error(
                             f"cloud-init done marker '{self.cloudinit_done_marker}' "
                             f"was not found — cloud-init may have failed")
+                        self._shutdown_template()
                         return False
-                    self._fetch_cloudinit_log()
                 else:
-                    self.logger.error(
+                    # without a marker there is nothing to check against, so
+                    # fall back to a blind wait rather than failing a template
+                    # that may be perfectly good. Only a marker that was asked
+                    # for and never appeared is a hard failure
+                    self.logger.warning(
                         "cloudinit_done_marker is not configured in the "
-                        "template config — cannot verify cloud-init completion. "
-                        "Set cloudinit_done_marker to a file path created by "
-                        "the last runcmd entry.")
-                    return False
+                        "template config — cloud-init completion cannot be "
+                        "verified. Set it to a file path created by the last "
+                        "runcmd entry to have boxman check it.")
+                    self._wait_cloudinit_fallback()
             else:
                 self.logger.warning(
                     "guest-exec unavailable after retries (some distros "
@@ -781,6 +826,17 @@ class CloudInitTemplate:
                     "via cloud-init write_files and restart the agent.")
                 self._wait_cloudinit_fallback()
 
+        self._shutdown_template()
+        return True
+
+    def _shutdown_template(self) -> None:
+        """
+        Shut the template VM down, forcing it off if it will not go quietly.
+
+        Called on the failure paths too. A template left *running* is worse
+        than a failed one: ``create-templates`` then reports "already exists",
+        and ``up`` skips creation and virt-clones a running domain.
+        """
         self.logger.info("shutting down the template VM...")
         self.virsh.execute("shutdown", self.template_name, hide=True, warn=True)
 
@@ -789,12 +845,11 @@ class CloudInitTemplate:
             result = self.virsh.execute("domstate", self.template_name, hide=True, warn=True)
             if result.ok and "shut off" in result.stdout.strip():
                 self.logger.info("VM is successfully shut off.")
-                return True
+                return
             time.sleep(2)
 
         self.logger.warning("VM did not shut off gracefully. Forcing destroy...")
         self.virsh.execute("destroy", self.template_name, hide=True, warn=True)
-        return True
 
     def _verify_dhcp_on_network(self) -> bool:
         """

--- a/src/boxman/providers/libvirt/cloudinit.py
+++ b/src/boxman/providers/libvirt/cloudinit.py
@@ -53,6 +53,10 @@ class CloudInitTemplate:
         cloudinit_metadata: str | None = None,
         cloudinit_network_config: str | None = None,
         cloudinit_done_marker: str | None = None,
+        cloudinit_agent_timeout: int = 300,
+        cloudinit_guest_exec_timeout: int = 120,
+        cloudinit_done_timeout: int = 120,
+        cloudinit_fallback_timeout: int = 180,
         workdir: str | None = None,
         provider_config: dict[str, Any] | None = None,
         memory: int = 2048,
@@ -71,6 +75,19 @@ class CloudInitTemplate:
         self.cloudinit_metadata = cloudinit_metadata
         self.cloudinit_network_config = cloudinit_network_config
         self.cloudinit_done_marker = cloudinit_done_marker
+
+        # Timeouts for the cloud-init verification phase, all in seconds and
+        # all overridable per template from conf.yml. Templates that install a
+        # lot of packages routinely blow past the defaults.
+        #: wait for the qemu guest agent to answer guest-ping
+        self.cloudinit_agent_timeout = cloudinit_agent_timeout
+        #: wait for guest-exec to stop being blacklisted by the agent
+        self.cloudinit_guest_exec_timeout = cloudinit_guest_exec_timeout
+        #: wait for ``cloudinit_done_marker`` to appear in the guest
+        self.cloudinit_done_timeout = cloudinit_done_timeout
+        #: blind wait used when the guest cannot be polled at all
+        self.cloudinit_fallback_timeout = cloudinit_fallback_timeout
+
         self.workdir = os.path.expanduser(workdir) if workdir else tempfile.mkdtemp(prefix="boxman-cloudinit-")
         self.provider_config = provider_config or {}
         self.memory = memory
@@ -528,15 +545,19 @@ class CloudInitTemplate:
         finally:
             shutil.rmtree(tmp_dir, ignore_errors=True)
 
-    def _wait_cloudinit_fallback(self, seconds: int = 180) -> None:
+    def _wait_cloudinit_fallback(self, seconds: int | None = None) -> None:
         """
         Time-based fallback: wait *seconds* for cloud-init to finish when
         we cannot poll via ``guest-exec`` (e.g. Rocky/RHEL where the
         guest agent blacklists ``guest-exec``).
 
+        *seconds* defaults to ``cloudinit_fallback_timeout``.
+
         While waiting, periodically ping the guest agent to confirm the VM
         is still alive.
         """
+        if seconds is None:
+            seconds = self.cloudinit_fallback_timeout
         self.logger.info(
             f"waiting {seconds}s for cloud-init to finish "
             f"(guest-exec unavailable, using time-based fallback)...")
@@ -558,13 +579,18 @@ class CloudInitTemplate:
                     f"still waiting for cloud-init... ({elapsed}s / {seconds}s)")
         self.logger.info("fallback wait complete")
 
-    def _poll_done_marker(self, marker_path: str, max_wait: int = 120) -> bool:
+    def _poll_done_marker(self, marker_path: str, max_wait: int | None = None) -> bool:
         """
         Poll for *marker_path* inside the guest via ``guest-exec`` with
         exponential back-off.
 
+        *max_wait* defaults to ``cloudinit_done_timeout``.
+
         Returns True if the marker was found, False on timeout.
         """
+        if max_wait is None:
+            max_wait = self.cloudinit_done_timeout
+
         self.logger.info(
             f"polling for done marker: {marker_path} "
             f"(exponential back-off, max {max_wait}s)...")
@@ -662,8 +688,10 @@ class CloudInitTemplate:
         self.logger.info("verifying VM health: waiting for QEMU guest agent (this may take a few minutes while cloud-init installs it)...")
         agent_up = False
 
-        # Wait up to 300 seconds (5 minutes) for the guest agent
-        for i in range(150):
+        # Wait up to cloudinit_agent_timeout seconds for the guest agent
+        agent_poll_interval = 2
+        agent_attempts = max(1, self.cloudinit_agent_timeout // agent_poll_interval)
+        for i in range(agent_attempts):
             result = self.virsh.execute_shell(
                 f"virsh qemu-agent-command {self.template_name} '{{\"execute\":\"guest-ping\"}}'",
                 hide=True, warn=True)
@@ -672,14 +700,16 @@ class CloudInitTemplate:
                 break
 
             if i > 0 and i % 15 == 0:
-                self.logger.info(f"still waiting for QEMU guest agent... ({i * 2}s elapsed)")
+                self.logger.info(
+                    f"still waiting for QEMU guest agent... "
+                    f"({i * agent_poll_interval}s / {self.cloudinit_agent_timeout}s)")
 
-            time.sleep(2)
+            time.sleep(agent_poll_interval)
 
         if not agent_up:
             self.logger.warning("QEMU guest agent did not respond in time. OS might not be healthy or agent is not installed.")
             # Even without the agent we should give cloud-init a chance
-            self._wait_cloudinit_fallback(seconds=180)
+            self._wait_cloudinit_fallback()
         else:
             self.logger.info("QEMU guest agent is responding. OS is healthy.")
 
@@ -698,7 +728,10 @@ class CloudInitTemplate:
                 "waiting for guest-exec to become available "
                 "(cloud-init must reconfigure the agent first)...")
 
-            for attempt in range(24):  # up to ~120s (24 * 5s)
+            exec_poll_interval = 5
+            exec_attempts = max(
+                1, self.cloudinit_guest_exec_timeout // exec_poll_interval)
+            for attempt in range(exec_attempts):
                 exec_cmd = (
                     '{"execute":"guest-exec","arguments":'
                     '{"path":"/bin/sh","arg":["-c","echo ok"],'
@@ -717,8 +750,9 @@ class CloudInitTemplate:
                 if attempt > 0 and attempt % 6 == 0:
                     self.logger.info(
                         f"still waiting for guest-exec... "
-                        f"({attempt * 5}s elapsed)")
-                time.sleep(5)
+                        f"({attempt * exec_poll_interval}s / "
+                        f"{self.cloudinit_guest_exec_timeout}s)")
+                time.sleep(exec_poll_interval)
 
             if guest_exec_ok:
                 # guest-exec availability means cloud-init has already
@@ -745,7 +779,7 @@ class CloudInitTemplate:
                     "like Rocky/RHEL blacklist it by default). "
                     "To fix: add BLOCK_RPCS= to /etc/sysconfig/qemu-ga "
                     "via cloud-init write_files and restart the agent.")
-                self._wait_cloudinit_fallback(seconds=120)
+                self._wait_cloudinit_fallback()
 
         self.logger.info("shutting down the template VM...")
         self.virsh.execute("shutdown", self.template_name, hide=True, warn=True)
@@ -901,7 +935,10 @@ class CloudInitTemplate:
             return False
 
         # Verify the VM is up and healthy, then shut it down
-        self.verify_and_shutdown()
+        if not self.verify_and_shutdown():
+            self.logger.error(
+                "cloud-init did not complete — template is not usable")
+            return False
 
         # Eject the seed ISO from the template's persistent config.
         # The VM is now shut off, so cloud-init has finished and the cdrom

--- a/src/boxman/providers/libvirt/cloudinit_presets.py
+++ b/src/boxman/providers/libvirt/cloudinit_presets.py
@@ -25,10 +25,14 @@ from __future__ import annotations
 from passlib.hash import sha512_crypt
 
 
-#: file written by DEFAULT_USER_DATA once cloud-init has run to the end.
-#: Used as the completion marker for templates that do not bring their own
-#: cloudinit block, so their build can be verified like any other.
-DEFAULT_DONE_MARKER = "/etc/boxman-template-marker"
+#: completion marker for templates that bring no cloudinit block of their own.
+#: This is the file the LAST ``runcmd`` entry of DEFAULT_USER_DATA appends to,
+#: which is the only thing in the stock user-data that means "finished".
+#: Deliberately not /etc/boxman-template-marker: that one is written by
+#: ``write_files``, which cloud-init runs in the config stage -- long before
+#: runcmd -- so polling for it would report success while the template was
+#: still being built.
+DEFAULT_DONE_MARKER = "/var/log/boxman-cloudinit.log"
 
 DEFAULT_META_DATA = """\
 instance-id: {instance_id}

--- a/src/boxman/providers/libvirt/cloudinit_presets.py
+++ b/src/boxman/providers/libvirt/cloudinit_presets.py
@@ -25,6 +25,11 @@ from __future__ import annotations
 from passlib.hash import sha512_crypt
 
 
+#: file written by DEFAULT_USER_DATA once cloud-init has run to the end.
+#: Used as the completion marker for templates that do not bring their own
+#: cloudinit block, so their build can be verified like any other.
+DEFAULT_DONE_MARKER = "/etc/boxman-template-marker"
+
 DEFAULT_META_DATA = """\
 instance-id: {instance_id}
 local-hostname: {hostname}

--- a/tests/test_libvirt_cloudinit.py
+++ b/tests/test_libvirt_cloudinit.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from boxman.providers.libvirt.cloudinit import (
-    CloudInitTemplate, DEFAULT_USER_DATA, DEFAULT_META_DATA,
+    CloudInitTemplate, DEFAULT_USER_DATA, DEFAULT_META_DATA, DEFAULT_DONE_MARKER,
 )
 
 
@@ -236,6 +236,22 @@ class TestCloudinitTimeouts:
         assert t.cloudinit_done_timeout == 900
         assert t.cloudinit_guest_exec_timeout == 180
 
+    def test_a_quoted_timeout_is_coerced(self, tmp_path: Path):
+        # yaml hands back "900" for a quoted value; left alone it reaches the
+        # // in the wait loops and raises TypeError, long after virt-install
+        # has already booted the VM
+        t = _make_template(tmp_path, cloudinit_done_timeout="900")
+        assert t.cloudinit_done_timeout == 900
+
+    @pytest.mark.parametrize("value", [None, "abc", "", -5, [300]])
+    def test_a_nonsense_timeout_is_rejected_up_front(self, tmp_path: Path, value):
+        with pytest.raises(ValueError, match="cloudinit_done_timeout"):
+            _make_template(tmp_path, cloudinit_done_timeout=value)
+
+    def test_zero_means_skip_the_wait(self, tmp_path: Path):
+        t = _make_template(tmp_path, cloudinit_fallback_timeout=0)
+        assert t.cloudinit_fallback_timeout == 0
+
     def test_poll_done_marker_honours_configured_timeout(self, tmp_path: Path):
         t = _make_template(tmp_path, cloudinit_done_timeout=7)
         with patch.object(t.virsh, "execute_shell", return_value=_result(ok=False)), \
@@ -289,3 +305,65 @@ class TestCloudinitTimeouts:
                 patch(self.SLEEP):
             assert t.verify_and_shutdown() is True
         assert sum("guest-exec" in c for c in calls) == 4
+
+
+class TestVerificationFailureLeavesCleanState:
+    """
+    What is left behind when cloud-init cannot be verified.
+
+    A template VM left *running* is worse than a failed one: the next
+    ``create-templates`` reports "already exists", and ``up`` sees the domain,
+    skips creation and virt-clones a running guest.
+    """
+
+    SLEEP = "boxman.providers.libvirt.cloudinit.time.sleep"
+
+    @staticmethod
+    def _template(tmp_path: Path, **overrides):
+        t = _make_template(tmp_path, cloudinit_userdata="#cloud-config\n",
+                           cloudinit_done_marker="/var/log/done", **overrides)
+        calls: list = []
+
+        def fake_execute(*args, **kwargs):
+            calls.append(args)
+            # domstate is asked whether the VM went down
+            if args and args[0] == "domstate":
+                return _result(stdout="shut off")
+            return _result()
+
+        def fake_shell(cmd, **kwargs):
+            calls.append(("shell", cmd))
+            # the agent answers, guest-exec works, the marker never appears
+            return _result(ok=("guest-ping" in cmd or "guest-exec" in cmd),
+                           stdout='{"return": {"pid": 1}}')
+
+        t.virsh.execute = fake_execute
+        t.virsh.execute_shell = fake_shell
+        return t, calls
+
+    def test_a_missing_marker_still_shuts_the_vm_down(self, tmp_path: Path):
+        t, calls = self._template(tmp_path, cloudinit_done_timeout=1)
+        with patch(self.SLEEP):
+            assert t.verify_and_shutdown() is False
+        assert any(args[0] == "shutdown" for args in calls if args and args[0] != "shell"), \
+            "the template VM was left running"
+
+    def test_no_marker_configured_is_not_a_hard_failure(self, tmp_path: Path):
+        # nothing to check against is not the same as a failed check: falling
+        # back to a blind wait keeps templates that predate the marker working
+        t = _make_template(tmp_path, cloudinit_userdata="#cloud-config\n",
+                           cloudinit_fallback_timeout=0)
+        assert t.cloudinit_done_marker is None
+        t.virsh.execute = lambda *a, **k: _result(stdout="shut off")
+        t.virsh.execute_shell = lambda cmd, **k: _result(
+            ok=("guest-ping" in cmd or "guest-exec" in cmd),
+            stdout='{"return": {"pid": 1}}')
+        with patch(self.SLEEP):
+            assert t.verify_and_shutdown() is True
+
+    def test_a_template_without_its_own_cloudinit_gets_the_default_marker(self, tmp_path: Path):
+        # an implicit template synthesised from `base_image: oci://…` has
+        # nowhere to declare one, but it runs DEFAULT_USER_DATA, which writes
+        # this file at the end
+        t = _make_template(tmp_path)
+        assert t.cloudinit_done_marker == DEFAULT_DONE_MARKER

--- a/tests/test_libvirt_cloudinit.py
+++ b/tests/test_libvirt_cloudinit.py
@@ -363,7 +363,15 @@ class TestVerificationFailureLeavesCleanState:
 
     def test_a_template_without_its_own_cloudinit_gets_the_default_marker(self, tmp_path: Path):
         # an implicit template synthesised from `base_image: oci://…` has
-        # nowhere to declare one, but it runs DEFAULT_USER_DATA, which writes
-        # this file at the end
+        # nowhere to declare one, but it runs DEFAULT_USER_DATA, whose last
+        # runcmd entry appends to this file
         t = _make_template(tmp_path)
         assert t.cloudinit_done_marker == DEFAULT_DONE_MARKER
+
+    def test_the_default_marker_is_written_last_not_early(self):
+        # write_files runs in the config stage, before runcmd: a marker from
+        # there would be found while the template was still being built
+        from boxman.providers.libvirt.cloudinit_presets import DEFAULT_USER_DATA
+        assert DEFAULT_DONE_MARKER not in DEFAULT_USER_DATA.split("runcmd:")[0]
+        last_runcmd = DEFAULT_USER_DATA.rstrip().splitlines()[-1]
+        assert DEFAULT_DONE_MARKER in last_runcmd, last_runcmd

--- a/tests/test_libvirt_cloudinit.py
+++ b/tests/test_libvirt_cloudinit.py
@@ -213,3 +213,79 @@ class TestDefaultTemplates:
         rendered = DEFAULT_META_DATA.format(instance_id="abc", hostname="demo")
         assert "instance-id: abc" in rendered
         assert "local-hostname: demo" in rendered
+
+
+class TestCloudinitTimeouts:
+    """The cloud-init verification caps are per-template knobs (conf.yml)."""
+
+    SLEEP = "boxman.providers.libvirt.cloudinit.time.sleep"
+
+    def test_defaults_match_previous_hardcoded_values(self, tmp_path: Path):
+        t = _make_template(tmp_path)
+        assert t.cloudinit_agent_timeout == 300
+        assert t.cloudinit_guest_exec_timeout == 120
+        assert t.cloudinit_done_timeout == 120
+        assert t.cloudinit_fallback_timeout == 180
+
+    def test_overrides_are_stored(self, tmp_path: Path):
+        t = _make_template(
+            tmp_path,
+            cloudinit_done_timeout=900,
+            cloudinit_guest_exec_timeout=180,
+        )
+        assert t.cloudinit_done_timeout == 900
+        assert t.cloudinit_guest_exec_timeout == 180
+
+    def test_poll_done_marker_honours_configured_timeout(self, tmp_path: Path):
+        t = _make_template(tmp_path, cloudinit_done_timeout=7)
+        with patch.object(t.virsh, "execute_shell", return_value=_result(ok=False)), \
+                patch(self.SLEEP) as sleep:
+            assert t._poll_done_marker("/var/log/done") is False
+        # back-off 1 + 2 + 4 == the 7s cap
+        assert sum(c.args[0] for c in sleep.call_args_list) == 7
+
+    def test_explicit_max_wait_still_wins(self, tmp_path: Path):
+        t = _make_template(tmp_path, cloudinit_done_timeout=900)
+        with patch.object(t.virsh, "execute_shell", return_value=_result(ok=False)), \
+                patch(self.SLEEP) as sleep:
+            assert t._poll_done_marker("/var/log/done", max_wait=3) is False
+        assert sum(c.args[0] for c in sleep.call_args_list) == 3
+
+    def test_fallback_wait_honours_configured_timeout(self, tmp_path: Path):
+        t = _make_template(tmp_path, cloudinit_fallback_timeout=30)
+        with patch.object(t.virsh, "execute_shell", return_value=_result(ok=True)), \
+                patch(self.SLEEP) as sleep:
+            t._wait_cloudinit_fallback()
+        assert sleep.call_count == 3          # range(0, 30, 10)
+
+    def test_agent_wait_loop_scales_with_timeout(self, tmp_path: Path):
+        # agent never answers: 10s cap / 2s per probe == 5 guest-ping attempts,
+        # then a zero-length blind wait, then the shutdown path
+        t = _make_template(
+            tmp_path, cloudinit_agent_timeout=10, cloudinit_fallback_timeout=0)
+        with patch.object(t.virsh, "execute_shell",
+                          return_value=_result(ok=False)) as shell, \
+                patch.object(t.virsh, "execute",
+                             return_value=_result(stdout="shut off")), \
+                patch(self.SLEEP):
+            assert t.verify_and_shutdown() is True
+        assert shell.call_count == 5
+
+    def test_guest_exec_loop_scales_with_timeout(self, tmp_path: Path):
+        # agent answers guest-ping but guest-exec stays blacklisted:
+        # 1 ping + (20s / 5s) == 4 guest-exec probes
+        t = _make_template(
+            tmp_path, cloudinit_guest_exec_timeout=20,
+            cloudinit_fallback_timeout=0)
+        calls: list[str] = []
+
+        def fake_shell(cmd, **kwargs):
+            calls.append(cmd)
+            return _result(ok="guest-ping" in cmd)
+
+        with patch.object(t.virsh, "execute_shell", side_effect=fake_shell), \
+                patch.object(t.virsh, "execute",
+                             return_value=_result(stdout="shut off")), \
+                patch(self.SLEEP):
+            assert t.verify_and_shutdown() is True
+        assert sum("guest-exec" in c for c in calls) == 4

--- a/tests/test_manager_core.py
+++ b/tests/test_manager_core.py
@@ -320,6 +320,7 @@ class TestCheckTemplatesForClusters:
 
         def fake_impl(*args, **kwargs):
             captured.append((args, kwargs))
+            return []          # no template failed to build
 
         with _patch.object(m, '_create_templates_impl', side_effect=fake_impl):
             ok = m.ensure_templates_exist()
@@ -347,7 +348,7 @@ class TestCheckTemplatesForClusters:
         m._provider.vm_exists.return_value = False  # not registered
         captured: list = []
         with _patch.object(m, '_create_templates_impl',
-                           side_effect=lambda *a, **kw: captured.append(kw)):
+                           side_effect=lambda *a, **kw: (captured.append(kw), [])[1]):
             ok = m.ensure_templates_exist()
         assert ok is True
         assert len(captured) == 1


### PR DESCRIPTION
## what

Two related changes to the cloud-init template path.

**1. The four hardcoded caps in the post-virt-install verification phase are now
per-template keys in `conf.yml`.** They default to exactly the values that were
previously hardcoded, so nothing changes for existing boxes that do not set them:

| key | default | what it caps |
| --- | --- | --- |
| `cloudinit_agent_timeout` | `300` | wait for the qemu guest agent to answer `guest-ping` |
| `cloudinit_guest_exec_timeout` | `120` | wait for `guest-exec` to become usable |
| `cloudinit_done_timeout` | `120` | wait for `cloudinit_done_marker` to appear |
| `cloudinit_fallback_timeout` | `180` | blind wait when the guest cannot be polled at all |

The two counted loops (`guest-ping` and `guest-exec`) now derive their bounds from
the timeout and the poll interval instead of a magic iteration count
(`range(150)`, `range(24)`), and their progress lines report `elapsed / total`
rather than just elapsed.

**2. `create_template()` now acts on the verification result.** It called
`verify_and_shutdown()` and threw the return value away, so a template whose
cloud-init never finished was reported as created and then happily cloned from.
It now logs `cloud-init did not complete - template is not usable` and returns
`False`. The VM is shut down and left defined with the seed ISO still attached so
the failure can be inspected, and the cloud-init output log is dumped.

**Correction:** an earlier revision of this description claimed the VM was left
shut off. It was not — both failure paths returned before the shutdown block, so
the template was left *running*, which wedged the next run (`create-templates`
reports "already exists"; `up` skips creation and virt-clones a running domain).
Fixed in 282b405.

## why

Templates that install a large package set routinely blow past the 120s
done-marker poll. There was no way to raise that short of editing
`src/boxman/providers/libvirt/cloudinit.py`, and the failure was silent: the poll
gave up, the template was still reported as created, and the first sign of
trouble was a clone missing everything cloud-init was supposed to have installed.

## notes

**Behaviour change worth flagging:** the guest-exec-blacklisted branch used to
blind-wait `120s` while the no-agent branch waited `180s` — two different
hardcoded numbers for the same "we cannot poll the guest" situation. Both now use
`cloudinit_fallback_timeout`, so **the blacklisted branch defaults to 180s
instead of 120s**. Set `cloudinit_fallback_timeout: 120` to restore the old
value.

Commented-out sample knobs were added to
`boxes/tiny-libvirt-ubuntu-24.04-cloudinit/conf.yml` and
`boxes/tiny-libvirt-rocky-9-cloudinit/conf.yml`. Rocky/RHEL is the family whose
guest agent blacklists `guest-exec` until cloud-init reconfigures it, so that box
is where `cloudinit_guest_exec_timeout` and the fallback actually matter, and its
comment says so.

### not addressed

Two gaps this PR does not close:

1. **The guest-exec-blacklisted branch still returns `True` after its blind
   wait.** It never observes the done marker, it just sleeps and declares
   success. A template built on such a distro is therefore still not truly
   verified — raising `cloudinit_fallback_timeout` makes it more likely to be
   correct, not guaranteed.
2. **`create_templates()` in `manager.py` only logs `failed to create template`
   and continues to the next template.** So even though `create_template()` now
   returns `False`, provisioning can still proceed and clone from a template that
   failed verification. Making the caller fail hard (or refuse to clone from an
   unverified template) is a separate change.

## tests

7 new tests in `tests/test_libvirt_cloudinit.py` (`TestCloudinitTimeouts`),
covering: the defaults matching the previously hardcoded values, overrides being
stored, `_poll_done_marker` honouring the configured cap, an explicit `max_wait=`
argument still winning over the configured cap, `_wait_cloudinit_fallback`
honouring its cap, and both counted loops scaling their attempt count with the
configured timeout.

Full unit suite:

```
$ PYTHONPATH=$PWD/src python3 -m pytest tests/ -q -m "not integration"
1227 passed, 108 deselected in 2.66s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

