### PR TITLE
feat(doctor): detect docker wiping libvirt's forwarding rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,10 +582,11 @@ restart takes them), and offers these commands as a guided fix.
 
 **Three things worth internalising:**
 
-1. **This is not an iptables-vs-nftables problem.** On any modern distro
-   `iptables` is `iptables-nft` — docker's "iptables filter table" *is*
-   `table ip filter` in nftables. The fix is a **private table instead of a
-   shared one**, not a change of framework.
+1. **This is not an iptables-vs-nftables problem.** On most current distros
+   `iptables` is `iptables-nft` (check with `iptables --version`, which then
+   reports `(nf_tables)`) — docker's "iptables filter table" *is* `table ip
+   filter` in nftables. The fix is a **private table instead of a shared
+   one**, not a change of framework.
 2. **Rule order does not save you.** Being first in your own chain is
    irrelevant when a different base chain at the same hook drops the packet.
 3. **firewalld is not the answer.** It does not relocate libvirt's rules and

--- a/README.md
+++ b/README.md
@@ -553,17 +553,29 @@ one alone leaves the host broken in a different way.
                                     └──────────────────────────┘
 ```
 
+Do them **in this order**. Step 2 restarts docker, which is the event that
+wipes the shared table — so move libvirt out first. Stopping halfway then
+costs you nothing you did not already have.
+
 ```bash
-# 1. /etc/docker/daemon.json  ->  "ip-forward-no-drop": true
+# 1. /etc/libvirt/network.conf  ->  firewall_backend = "nftables"
+sudo systemctl restart virtnetworkd     # or libvirtd on monolithic builds
+
+# 2. /etc/docker/daemon.json  ->  "ip-forward-no-drop": true
+#    Check the engine knows it first -- dockerd refuses to start on an
+#    unknown directive:  dockerd --help | grep ip-forward-no-drop
 sudo systemctl restart docker
 
-# 2. the flag stops docker *setting* DROP; it does not clear one it already
+# 3. the flag stops docker *setting* DROP; it does not clear one it already
 #    set. This one-off reset is the step everyone misses:
 sudo iptables -P FORWARD ACCEPT
-
-# 3. /etc/libvirt/network.conf  ->  firewall_backend = "nftables"
-sudo systemctl restart virtnetworkd     # or libvirtd on monolithic builds
+sudo ip6tables -P FORWARD ACCEPT        # docker manages v6 too
 ```
+
+If your libvirt is too old for `firewall_backend` (before 10.10), step 1 is
+unavailable: do steps 2–3 and then `sudo systemctl restart virtnetworkd` to
+put libvirt's rules back, and accept that a docker restart will keep removing
+them.
 
 Verify:
 

--- a/README.md
+++ b/README.md
@@ -499,6 +499,113 @@ the host before the first `compact` / `compress-snapshots`.
 Full reference, flag matrix, and troubleshooting:
 [doc/storage.md](doc/storage.md).
 
+## Advanced
+
+### Docker and libvirt fight over the same firewall table
+
+**Symptom.** Guests get an address and can reach the host, but nothing past it.
+Usually after a `systemctl restart docker`, a docker upgrade, or a reboot where
+docker happened to start last. It presents as a slow or flaky network rather
+than a firewall fault, because NAT keeps working and only forwarding is dead.
+
+**Cause.** Docker and libvirt both write the `filter` table. Docker rebuilds
+that table on every restart and leaves the FORWARD policy at `DROP`. libvirt's
+rules — and boxman's own routed-network `FORWARD` rules — are collateral
+damage, and nothing re-applies them.
+
+Every base chain on the forward hook is evaluated, and **a drop or reject in
+any one of them is final**; an accept only ends its own chain. libvirt's
+ACCEPTs therefore cannot rescue a packet that docker's policy drops:
+
+```text
+  guest ──▶ [ FORWARD HOOK ] ──▶ internet
+                   │
+                   ├─ ip filter FORWARD .............. policy DROP   ◀ docker
+                   │    -j DOCKER-USER      (empty)
+                   │    -j DOCKER-FORWARD
+                   │    LIBVIRT_FWI/FWO/FWX  ▓ empty, no jumps ▓  ◀ wiped
+                   │
+                   └─ ip6 filter FORWARD ............. policy accept
+
+                        verdict = DROP
+```
+
+The nat table usually survives, so `LIBVIRT_PRT` still MASQUERADEs happily.
+That mismatch is the tell.
+
+**Fix — stop sharing the table.** Two settings; both are required, and either
+one alone leaves the host broken in a different way.
+
+```text
+                   ├─ ip filter FORWARD .............. policy ACCEPT ◀ ip-forward-no-drop
+                   ├─ ip6 filter FORWARD ............. policy accept
+                   └─ ip libvirt_network forward ..... accept virbr* ◀ firewall_backend=nftables
+                        verdict = ACCEPT
+```
+
+```text
+  BEFORE                            AFTER
+  ┌ table ip filter ─────────┐      ┌ table ip filter ─────────┐
+  │  docker   ── rebuilds ───┼──╮   │  docker   ── rebuilds    │ harmless
+  │  libvirt  ── collateral ◀┼──╯   └──────────────────────────┘
+  └──────────────────────────┘      ┌ table ip libvirt_network ┐
+                                    │  libvirt  ── untouchable │
+                                    └──────────────────────────┘
+```
+
+```bash
+# 1. /etc/docker/daemon.json  ->  "ip-forward-no-drop": true
+sudo systemctl restart docker
+
+# 2. the flag stops docker *setting* DROP; it does not clear one it already
+#    set. This one-off reset is the step everyone misses:
+sudo iptables -P FORWARD ACCEPT
+
+# 3. /etc/libvirt/network.conf  ->  firewall_backend = "nftables"
+sudo systemctl restart virtnetworkd     # or libvirtd on monolithic builds
+```
+
+Verify:
+
+```bash
+nft list tables | grep libvirt          # libvirt now owns a private table
+sudo iptables -S FORWARD | head -1      # -P FORWARD ACCEPT
+sudo virsh net-destroy default && sudo virsh net-start default
+```
+
+Then the real test: a guest reaches the internet, and `systemctl restart
+docker` leaves it reachable.
+
+`python3 scripts/installer/check_prerequisites.py` detects both the acute case
+(rules already gone) and the latent one (still fine, but the next docker
+restart takes them), and offers these commands as a guided fix.
+
+**Three things worth internalising:**
+
+1. **This is not an iptables-vs-nftables problem.** On any modern distro
+   `iptables` is `iptables-nft` — docker's "iptables filter table" *is*
+   `table ip filter` in nftables. The fix is a **private table instead of a
+   shared one**, not a change of framework.
+2. **Rule order does not save you.** Being first in your own chain is
+   irrelevant when a different base chain at the same hook drops the packet.
+3. **firewalld is not the answer.** It does not relocate libvirt's rules and
+   does not touch docker's FORWARD policy, so it fixes neither half. libvirt
+   *does* re-apply its rules on firewalld's reload signal — but a docker
+   restart never emits one, so that recovery hook never fires. Enabling it
+   only adds a third forward-hook chain that ends in `reject`, which
+   everything then has to be zoned past.
+
+**Caveats.**
+
+- `ip-forward-no-drop` makes host-wide forwarding default-accept. On a box
+  routing guest subnets that is a deliberate posture change, not a free win.
+- Once libvirt's own rules are protected, boxman's routed-network `FORWARD`
+  rules are duplication. They are also what masks this fault — which is why
+  the breakage tends to look partial.
+- **This applies to the local runtime only.** Under `--runtime docker` the
+  libvirt container has its own network namespace, so its tables are already
+  isolated from the host's docker.
+
 ## Development
 
 ### Run boxman in development mode

--- a/scripts/installer/README.md
+++ b/scripts/installer/README.md
@@ -51,12 +51,19 @@ afterwards to confirm.
 
 A few fixes restart running services — the docker/libvirt forwarding fix
 restarts `docker` and `virtnetworkd`, briefly interrupting running containers
-and guest connectivity. Those are marked **disruptive**: they always ask for
-confirmation, **even under `--yes`**, so an unattended run can never bounce a
-container host. Decline one and it is reported in the summary as a manual step.
+and guest connectivity. Those are marked **disruptive** and require a human at
+a terminal:
 
-Disruptive fixes write a `.boxman-bak` copy of every file they edit before
-changing it.
+- `--yes` does not cover them.
+- Neither does a piped answer (`yes | check_prerequisites.py --yes`) — without
+  a tty they are declined outright, not prompted.
+- If one of their commands fails, the remaining commands are **not** run, so a
+  failed config edit is never followed by the service restart it was meant to
+  accompany.
+
+Decline one and it is reported in the summary as a manual step. Disruptive
+fixes write a `.boxman-bak` copy of every file they edit, and never overwrite
+an existing backup.
 
 ## What it checks
 

--- a/scripts/installer/README.md
+++ b/scripts/installer/README.md
@@ -47,6 +47,17 @@ as usual. Fixes that add you to a group (e.g. `libvirt`, `kvm`, `docker`) are
 flagged as needing a logout/login before they take effect — re-run the checker
 afterwards to confirm.
 
+## Disruptive fixes
+
+A few fixes restart running services — the docker/libvirt forwarding fix
+restarts `docker` and `virtnetworkd`, briefly interrupting running containers
+and guest connectivity. Those are marked **disruptive**: they always ask for
+confirmation, **even under `--yes`**, so an unattended run can never bounce a
+container host. Decline one and it is reported in the summary as a manual step.
+
+Disruptive fixes write a `.boxman-bak` copy of every file they edit before
+changing it.
+
 ## What it checks
 
 - **Environment** — Python ≥ 3.10, `boxman` on PATH (+ active conda/venv), and
@@ -60,6 +71,13 @@ afterwards to confirm.
   tool, `sshpass`, `rsync`, the OpenSSH client, and your **sudo rights**
   (including the footgun where cleanup silently no-ops if `sudo qemu-img`/`rm`
   aren't passwordless).
+- **Host forwarding (docker/libvirt)** — whether docker has rebuilt the
+  iptables `filter` table out from under libvirt (and boxman's own
+  routed-network `FORWARD` rules), leaving guests that NAT but never forward.
+  Catches both the acute case (rules already gone) and the latent one (still
+  present, but the next `systemctl restart docker` takes them). The guided fix
+  gives libvirt its own nftables table and stops docker forcing `FORWARD` to
+  `DROP`. Background and diagrams: the **Advanced** section of the main README.
 - **Docker runtime** (when selected) — Docker Engine + Compose v2 reachable and
   `/dev/kvm` on the host.
 - **Optional features** — `ansible`, `zstd`, `virt-sparsify`, `oras`,

--- a/scripts/installer/check_prerequisites.py
+++ b/scripts/installer/check_prerequisites.py
@@ -164,7 +164,10 @@ def parse_firewall_backend(text):
     is a reliable signal that this build understands it.
     """
     match = re.search(r'^\s*firewall_backend\s*=\s*"?([a-z]+)"?', text, re.M)
-    return (match.group(1) if match else ""), ("firewall_backend" in text)
+    # anchored on a real declaration, set or commented out -- the bare word
+    # could appear in unrelated prose and would then claim false support
+    supported = re.search(r"^\s*#?\s*firewall_backend\s*=", text, re.M) is not None
+    return (match.group(1) if match else ""), supported
 
 
 def iptables_forward_facts(text):
@@ -932,15 +935,18 @@ class Doctor(object):
                 return True
         return False
 
-    def _forwarding_fix(self, backend):
+    def _forwarding_fix(self, backend, docker_manages):
         """Commands that take libvirt out of the table docker rebuilds.
 
         ``backend`` is the *effective* backend, so a host that already keeps
         libvirt in its own table is only offered the docker half.
+        ``docker_manages`` is the same signal the verdict used: offering to
+        edit /etc/docker/daemon.json and restart docker just because the
+        binary exists would contradict the reason we stopped trusting it.
         """
         configured, supported = self._libvirt_fw_backend()
         commands = []
-        if have("docker"):
+        if docker_manages:
             commands += [
                 "sudo cp -an /etc/docker/daemon.json "
                 "/etc/docker/daemon.json.boxman-bak 2>/dev/null || true",
@@ -1054,11 +1060,13 @@ class Doctor(object):
             # only a fallback, since libvirt >= 11 defaults to nftables with
             # the setting left unset.
             backend = "nftables" if libvirt_table else self._libvirt_fw_backend()[0]
+            docker_manages = self._docker_manages_firewall(evidence)
             status, detail, needs_fix = forwarding_verdict(
-                networks, evidence, self._docker_manages_firewall(evidence),
-                backend, policy_drop, complete_view)
-            return status, detail, (self._forwarding_fix(backend)
-                                    if needs_fix else None)
+                networks, evidence, docker_manages, backend, policy_drop,
+                complete_view)
+            return status, detail, (
+                self._forwarding_fix(backend, docker_manages)
+                if needs_fix else None)
 
         self.check("Host forwarding (docker/libvirt)", forwarding)
 

--- a/scripts/installer/check_prerequisites.py
+++ b/scripts/installer/check_prerequisites.py
@@ -173,7 +173,8 @@ def parse_firewall_backend(text):
 def iptables_forward_facts(text):
     """Forward-relevant facts from ``iptables -S`` (filter table) output.
 
-    Returns ``(rules_text, policy_drop)``.  Only ``-A FORWARD`` lines count as
+    Returns ``(rules_text, drop_closures, policy_drop)``.  Only ``-A FORWARD``
+    lines count as
     evidence, plus libvirt's own ``LIBVIRT_FW*`` chains -- and those only when
     FORWARD still jumps into them, because a populated chain nothing jumps to
     is inert.  Docker's rebuild removes the jumps, which is exactly the state
@@ -192,7 +193,7 @@ def iptables_forward_facts(text):
     # When FORWARD drops by default, its own rules are what can still rescue a
     # packet before the policy applies -- so they decide which bridges are
     # actually at risk.
-    return rules, (rules if policy_drop else ""), policy_drop
+    return rules, ([rules] if policy_drop else []), policy_drop
 
 
 def _jump_targets(rule):
@@ -211,10 +212,9 @@ def _jump_targets(rule):
 def nft_forward_facts(json_text):
     """Forward-hook facts from ``nft -j list ruleset`` output.
 
-    Returns ``(rules_text, drop_rules_text, policy_drop, libvirt_table,
-    parsed)``: the serialised rules reachable from the forward hook, the subset
-    of those reachable from chains that *drop by default*, whether any such
-    chain exists, whether libvirt owns a table (proof that it is using the
+    Returns ``(rules_text, drop_closures, policy_drop, libvirt_table,
+    parsed)``: the serialised rules reachable from the forward hook, one
+    closure per chain that *drops by default*, whether any such chain exists, whether libvirt owns a table (proof that it is using the
     nftables backend instead of sharing docker's), and whether the output was
     understood at all.
 
@@ -236,11 +236,11 @@ def nft_forward_facts(json_text):
     try:
         doc = json.loads(json_text)
     except (ValueError, TypeError):
-        return "", "", False, False, False
+        return "", [], False, False, False
 
     items = doc.get("nftables", []) if isinstance(doc, dict) else []
     if not isinstance(items, list) or not items:
-        return "", "", False, False, False
+        return "", [], False, False, False
 
     reachable, dropping, policy_drop, libvirt_table = set(), set(), False, False
     for item in items:
@@ -291,7 +291,11 @@ def nft_forward_facts(json_text):
                 out.append(json.dumps(rule, sort_keys=True))
         return "\n".join(out)
 
-    return (serialise(close_over(reachable)), serialise(close_over(dropping)),
+    # one closure per dropping chain, not a merged blob: each such chain kills
+    # independently, so a bridge must be accepted in every one of them
+    drop_closures = [serialise(close_over([key])) for key in
+                     sorted(dropping, key=lambda k: [str(part) for part in k])]
+    return (serialise(close_over(reachable)), drop_closures,
             policy_drop, libvirt_table, True)
 
 
@@ -330,8 +334,12 @@ def forwarding_verdict(networks, evidence, docker_present, backend,
 
     # Word-anchored, not a substring test: plain containment would let
     # virbr10's rules vouch for virbr1 and hide a genuinely wiped network.
-    def named(bridge):
-        return re.search(r"\b%s\b" % re.escape(bridge), evidence) is not None
+    # One entry per chain that drops by default, holding the rules that chain
+    # can still rescue a packet with. Merging them would let an accept in one
+    # dropping chain vouch for a bridge that a second dropping chain kills.
+    if isinstance(drop_evidence, str):
+        drop_evidence = [drop_evidence] if drop_evidence else []
+    closures = list(drop_evidence) or ([""] if policy_drop else [])
 
     wiped = wiped_networks(networks, evidence)
     # A default drop only kills what its own chain did not already accept, so
@@ -340,8 +348,8 @@ def forwarding_verdict(networks, evidence, docker_present, backend,
     # those libvirt writes nothing by design, which is exactly why a drop is
     # fatal to them.
     at_risk = [name for name, bridge, _ in networks
-               if policy_drop
-               and not re.search(r"\b%s\b" % re.escape(bridge), drop_evidence)]
+               if any(not re.search(r"\b%s\b" % re.escape(bridge), closure)
+                      for closure in closures)]
 
     if wiped and not complete_view:
         return INFO, ("part of the ruleset was unreadable, so the rules for %s "
@@ -1019,6 +1027,19 @@ class Doctor(object):
                 return True
         return False
 
+    def _docker_supports_no_drop(self):
+        """Does this engine understand ``ip-forward-no-drop``?
+
+        Distro engines from the 24.x/26.x era do not, and dockerd refuses to
+        start on an unknown daemon.json directive -- so writing the key and
+        restarting would leave docker down. That is the worst outcome this
+        script can produce, so anything short of proof counts as "no".
+        """
+        if not have("dockerd"):
+            return False
+        rc, out = run_capture(["dockerd", "--help"])
+        return rc == 0 and "ip-forward-no-drop" in out
+
     def _forwarding_fix(self, backend, docker_manages, wiped=False):
         """Commands that take libvirt out of the table docker rebuilds.
 
@@ -1051,8 +1072,16 @@ class Doctor(object):
                 "sudo systemctl restart %s" % unit,
             ]
 
-        docker_cmds = []
-        if docker_manages:
+        # the flag stops docker *setting* the policy; it does not clear one
+        # docker already set, so this one-off reset is required. Both families:
+        # docker manages ip6tables too, and leaving the v6 policy at DROP makes
+        # the check warn forever after an otherwise successful fix.
+        policy_reset = ["sudo iptables -P FORWARD ACCEPT"]
+        if have("ip6tables"):
+            policy_reset.append("sudo ip6tables -P FORWARD ACCEPT")
+
+        docker_cmds, stale_engine = [], False
+        if docker_manages and self._docker_supports_no_drop():
             docker_cmds = [
                 "sudo sh -c '[ ! -f /etc/docker/daemon.json ] || "
                 "cp -an /etc/docker/daemon.json "
@@ -1066,20 +1095,23 @@ class Doctor(object):
                 "p.parent.mkdir(parents=True,exist_ok=True);"
                 "p.write_text(json.dumps(d,indent=2))\""
                 " && sudo systemctl restart docker",
-                # the flag stops docker *setting* the policy; it does not clear
-                # one docker already set, so this one-off reset is required
-                "sudo iptables -P FORWARD ACCEPT",
-            ]
+            ] + policy_reset
+        elif docker_manages:
+            # Engine too old for the directive: clearing the policy still
+            # restores connectivity now, but docker will set it again on its
+            # next restart. Editing daemon.json here would stop dockerd dead.
+            docker_cmds, stale_engine = list(policy_reset), True
 
         commands = libvirt_cmds + docker_cmds
-        if wiped and not libvirt_cmds and commands:
-            # Nothing above re-applies libvirt's rules, and they are gone.
-            # Without this the guided fix "succeeds" and the re-probe still
-            # reports the network as wiped.
+
+        # Re-apply libvirt's rules when nothing above will and they are either
+        # already gone or about to be: a docker restart against the shared
+        # table takes them with it. Gating this on `wiped` alone left a merely
+        # at-risk host actually broken, with the fix reporting success.
+        restarts_docker = any("restart docker" in cmd for cmd in docker_cmds)
+        if not libvirt_cmds and (
+                wiped or (restarts_docker and backend != "nftables")):
             commands.append("sudo systemctl restart %s" % unit)
-        description = ("give libvirt its own nftables table and stop docker "
-                       "forcing FORWARD to DROP (a .boxman-bak backup is "
-                       "written next to each file)")
         if backend == "nftables" and docker_manages:
             description = ("stop docker forcing FORWARD to DROP -- libvirt "
                            "already has its own table")
@@ -1091,16 +1123,29 @@ class Doctor(object):
                            "the FORWARD policy to DROP -- `iptables -S FORWARD "
                            "| head -1` and `nft list ruleset | grep -B5 'hook "
                            "forward'` -- and let that owner accept the bridge")
-        elif not supported:
-            description += ("; this libvirt build has no firewall_backend "
-                            "option, so only the docker half can be automated")
+        elif libvirt_cmds:
+            description = ("give libvirt its own nftables table and stop "
+                           "docker forcing FORWARD to DROP (a .boxman-bak "
+                           "backup is written next to each file)")
+        elif docker_manages:
+            description = ("clear the FORWARD policy and re-apply libvirt's "
+                           "rules; this libvirt build has no firewall_backend "
+                           "option, so it cannot be moved out of docker's "
+                           "table")
+        else:
+            description = "re-apply libvirt's network rules"
+        if stale_engine:
+            description += ("; this docker engine predates "
+                            "`ip-forward-no-drop`, so daemon.json is left "
+                            "alone -- upgrade docker or the policy returns on "
+                            "its next restart")
         return Fix(description, commands, needs_sudo=True,
                    disruptive=bool(commands))
 
     def _forward_evidence(self):
         """Gather forward-scoped rules from both firewall views.
 
-        Returns ``(evidence, drop_evidence, policy_drop, libvirt_table,
+        Returns ``(evidence, drop_closures, policy_drop, libvirt_table,
         complete_view)``.  Only rules on the forward hook are collected:
         scanning a whole ruleset would let nat and mangle -- which survive a
         docker rebuild -- vouch for filter rules that are long gone.
@@ -1113,7 +1158,7 @@ class Doctor(object):
             if rc == 0:
                 rules, drop_rules, drop = iptables_forward_facts(out)
                 evidence.append(rules)
-                drops.append(drop_rules)
+                drops.extend(drop_rules)
                 policy_drop = policy_drop or drop
             else:
                 complete_view = False
@@ -1123,10 +1168,10 @@ class Doctor(object):
         if have("nft"):
             rc, out = self._root_capture(["nft", "-j", "list", "ruleset"])
             rules, drop_rules, drop, libvirt_table, parsed = \
-                nft_forward_facts(out) if rc == 0 else ("", "", False, False, False)
+                nft_forward_facts(out) if rc == 0 else ("", [], False, False, False)
             if parsed:
                 evidence.append(rules)
-                drops.append(drop_rules)
+                drops.extend(drop_rules)
                 policy_drop = policy_drop or drop
             else:
                 # ran but told us nothing we understood -- same standing as
@@ -1135,7 +1180,7 @@ class Doctor(object):
         else:
             complete_view = False
 
-        return ("\n".join(evidence), "\n".join(drops), policy_drop,
+        return ("\n".join(evidence), drops, policy_drop,
                 libvirt_table, complete_view)
 
     def _check_host_forwarding(self):

--- a/scripts/installer/check_prerequisites.py
+++ b/scripts/installer/check_prerequisites.py
@@ -26,6 +26,7 @@ Exit code: 0 when no blocking FAIL remains, 1 otherwise.
 """
 
 import argparse
+import json
 import os
 import platform
 import re
@@ -166,18 +167,82 @@ def parse_firewall_backend(text):
     return (match.group(1) if match else ""), ("firewall_backend" in text)
 
 
-def forwarding_verdict(networks, rules, docker_present, backend,
-                       complete_view=True):
+def iptables_forward_facts(text):
+    """Forward-relevant facts from ``iptables -S`` (filter table) output.
+
+    Returns ``(rules_text, policy_drop)``.  Only ``-A FORWARD`` lines count as
+    evidence, plus libvirt's own ``LIBVIRT_FW*`` chains -- and those only when
+    FORWARD still jumps into them, because a populated chain nothing jumps to
+    is inert.  Docker's rebuild removes the jumps, which is exactly the state
+    we must not mistake for a healthy one.
+    """
+    lines = [line.strip() for line in text.splitlines()]
+    jumped = any(re.match(r"-A FORWARD .*-j LIBVIRT_", line) for line in lines)
+    keep = []
+    for line in lines:
+        if re.match(r"-A FORWARD\b", line):
+            keep.append(line)
+        elif jumped and re.match(r"-A LIBVIRT_FW", line):
+            keep.append(line)
+    policy_drop = any(re.match(r"-P FORWARD DROP\b", line) for line in lines)
+    return "\n".join(keep), policy_drop
+
+
+def nft_forward_facts(json_text):
+    """Forward-hook facts from ``nft -j list ruleset`` output.
+
+    Returns ``(rules_text, policy_drop, libvirt_table)``: the serialised rules
+    of every base chain on the forward hook, whether any such chain drops by
+    default, and whether libvirt owns a table (proof that it is using the
+    nftables backend instead of sharing docker's).
+
+    The JSON form is used rather than the human-readable listing because the
+    latter cannot be scanned safely: it also contains nat and mangle, which
+    survive the very wipe we are looking for.  libvirt's mangle CHECKSUM rule
+    names the bridge, so a naive scan finds it and reports a dead network as
+    healthy.
+    """
+    try:
+        doc = json.loads(json_text)
+    except (ValueError, TypeError):
+        return "", False, False
+
+    items = doc.get("nftables", []) if isinstance(doc, dict) else []
+    forward, policy_drop, libvirt_table = set(), False, False
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        table = item.get("table")
+        if isinstance(table, dict) and str(table.get("name", "")).startswith("libvirt"):
+            libvirt_table = True
+        chain = item.get("chain")
+        if isinstance(chain, dict) and chain.get("hook") == "forward":
+            forward.add((chain.get("family"), chain.get("table"), chain.get("name")))
+            if chain.get("policy") == "drop":
+                policy_drop = True
+
+    rules = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        rule = item.get("rule")
+        if isinstance(rule, dict) and (
+                rule.get("family"), rule.get("table"), rule.get("chain")) in forward:
+            rules.append(json.dumps(rule, sort_keys=True))
+    return "\n".join(rules), policy_drop, libvirt_table
+
+
+def forwarding_verdict(networks, evidence, docker_present, backend,
+                       policy_drop=False, complete_view=True):
     """Grade the host forward path from facts already gathered.
 
-    ``networks`` is ``[(network_name, bridge_name), ...]`` for the active
-    NAT/routed libvirt networks; ``rules`` is the concatenated text of every
-    ruleset we managed to read (``iptables -S`` *and* ``nft list ruleset``).
-    ``complete_view`` is False when one of those could not be read -- a bridge
-    we then fail to find is reported as unconfirmed rather than wiped, because
-    libvirt's nftables backend keeps its rules in a private table and a checker
-    that could not look there must not claim they are gone.
-    Returns ``(status, detail, needs_fix)``.
+    ``networks`` is ``[(name, bridge, expects_rules), ...]`` for the active
+    libvirt networks that care about forwarding; ``expects_rules`` is False for
+    modes libvirt deliberately writes no rules for (``open``), which must not
+    be reported as wiped.  ``evidence`` is the forward-scoped rule text --
+    never a whole ruleset.  ``complete_view`` is False when part of the ruleset
+    could not be read, in which case a bridge we fail to find is reported as
+    unconfirmed rather than wiped.  Returns ``(status, detail, needs_fix)``.
 
     Docker and libvirt both write the ``filter`` table.  Docker rebuilds it on
     every restart and leaves the FORWARD policy at DROP; libvirt's rules -- and
@@ -188,12 +253,12 @@ def forwarding_verdict(networks, rules, docker_present, backend,
     forwarding is dead: it reads as a slow network, not a firewall fault.
     """
     if not networks:
-        return SKIP, "no active NAT/routed libvirt networks", False
+        return SKIP, "no active forwarding libvirt networks", False
 
     # Word-anchored, not a substring test: plain containment would let
     # virbr10's rules vouch for virbr1 and hide a genuinely wiped network.
-    wiped = [name for name, bridge in networks
-             if not re.search(r"\b%s\b" % re.escape(bridge), rules)]
+    wiped = [name for name, bridge, expects in networks
+             if expects and not re.search(r"\b%s\b" % re.escape(bridge), evidence)]
 
     if wiped and not complete_view:
         return INFO, ("part of the ruleset was unreadable, so the rules for %s "
@@ -206,16 +271,28 @@ def forwarding_verdict(networks, rules, docker_present, backend,
             detail += "\ndocker shares this table and rebuilds it on restart"
         return WARN, detail, True
 
+    # libvirt is safely in its own table, but a foreign DROP at the same hook
+    # still kills the packet. This is the half-fixed state: protecting the
+    # rules without clearing the policy changes nothing for the guest.
+    if backend == "nftables" and policy_drop:
+        return WARN, ("libvirt has its own table, but the FORWARD policy is "
+                      "DROP -- a drop in any table at the hook is final, so "
+                      "guests still cannot forward"), True
+
     if docker_present and backend != "nftables":
         detail = ("forwarding works now, but libvirt shares the filter table "
                   "with docker -- the next `systemctl restart docker` wipes "
                   "these rules")
-        if re.search(r"^-P FORWARD DROP", rules, re.M):
+        if policy_drop:
             detail += "\nFORWARD policy is DROP, so nothing survives the wipe"
         return WARN, detail, True
 
+    if not backend and not complete_view:
+        return INFO, ("rules are in place, but libvirt's firewall backend "
+                      "could not be determined from here"), False
+
     return OK, "forwarding rules present for: %s" % ", ".join(
-        name for name, _ in networks), False
+        name for name, _, _ in networks), False
 
 
 # --------------------------------------------------------------------------- #
@@ -357,8 +434,15 @@ class Doctor(object):
             self._remember_manual(result)
             return
 
-        # --yes deliberately does not cover disruptive fixes: bouncing a
-        # container host is not something an unattended run may decide.
+        # A disruptive fix needs a human at a terminal: --yes does not cover
+        # it, and neither does a piped "y" (`yes | check_prerequisites.py`).
+        # Bouncing a container host is not something an unattended run may
+        # decide for itself.
+        if fix.disruptive and not sys.stdin.isatty():
+            self._remember_manual(
+                result, note="needs a terminal to confirm; not run")
+            return
+
         auto = self.opts.yes and not fix.disruptive
         if not (auto or self._ask("       -> run the above now?")):
             self._remember_manual(result)
@@ -411,6 +495,14 @@ class Doctor(object):
             if rc != 0:
                 ok = False
                 print("       " + self.c("command exited with status %d" % rc, "yellow"))
+                if fix.disruptive:
+                    # Later commands restart services. Carrying on past a
+                    # failed edit would apply the disruption without the
+                    # change it was meant to accompany.
+                    print("       " + self.c(
+                        "stopping here; the remaining commands were not run",
+                        "yellow"))
+                    return False
         return ok
 
     # -- environment discovery --------------------------------------------- #
@@ -789,25 +881,28 @@ class Doctor(object):
     def _root_capture(self, args):
         """Run a root-only inspection command without ever prompting.
 
-        Returns ``(rc, text)``; rc 126 means "we were not allowed to look",
-        which callers surface as INFO -- a checker that cannot see must say so
-        rather than guess.
+        Returns ``(rc, text)``.  Any non-zero rc means "we did not get a
+        reliable answer" -- the caller must treat that as reduced visibility
+        rather than as evidence of absence.  No attempt is made to classify
+        sudo's refusal message: it is localised, so matching English text would
+        silently misbehave under any other locale.
         """
         if getattr(os, "geteuid", lambda: 1)() == 0:
             return run_capture(args)
         if not have("sudo"):
-            return 126, ""
-        rc, out = run_capture(["sudo", "-n"] + args)
-        if rc != 0 and re.search(r"password is required|terminal is required",
-                                 out, re.I):
-            return 126, ""
-        return rc, out
+            return 1, ""
+        return run_capture(["sudo", "-n"] + args)
 
     def _libvirt_net_unit(self):
         """The systemd unit that owns libvirt's network rules on this host."""
         for unit in ("virtnetworkd", "libvirtd"):
             if run_capture(["systemctl", "is-active", unit])[1].strip() == "active":
                 return unit
+        # a socket-activated virtnetworkd is idle, not absent; restarting
+        # libvirtd instead would fail outright on a modular install
+        if run_capture(["systemctl", "is-active",
+                        "virtnetworkd.socket"])[1].strip() == "active":
+            return "virtnetworkd"
         return "libvirtd"
 
     def _libvirt_fw_backend(self):
@@ -818,40 +913,53 @@ class Doctor(object):
         except OSError:
             return "", False
 
-    def _effective_fw_backend(self, rules):
-        """What libvirt is actually doing, not merely what is configured.
+    def _docker_manages_firewall(self, evidence):
+        """Is a docker daemon actually writing firewall rules here?
 
-        A libvirt-owned nft table is proof.  The config file is only a
-        fallback: libvirt >= 11 defaults to the nftables backend with the
-        setting left unset, so an empty ``firewall_backend`` means nothing on
-        its own.
+        The ``docker`` binary alone proves nothing -- it is also present as a
+        remote-only client and as podman's compatibility shim, neither of which
+        touches this host's tables.  Warning those hosts about "the next
+        `systemctl restart docker`" and offering to edit /etc/docker/daemon.json
+        is pure noise.
         """
-        if re.search(r"^table (?:ip|ip6|inet) libvirt", rules, re.M):
-            return "nftables"
-        return self._libvirt_fw_backend()[0]
+        if "DOCKER-USER" in evidence or "DOCKER-FORWARD" in evidence:
+            return True
+        if not have("docker"):
+            return False
+        for query in ("is-active", "is-enabled"):
+            if run_capture(["systemctl", query, "docker"])[1].strip() in (
+                    "active", "enabled"):
+                return True
+        return False
 
-    def _forwarding_fix(self):
-        """Commands that take libvirt out of the table docker rebuilds."""
-        backend, supported = self._libvirt_fw_backend()
+    def _forwarding_fix(self, backend):
+        """Commands that take libvirt out of the table docker rebuilds.
+
+        ``backend`` is the *effective* backend, so a host that already keeps
+        libvirt in its own table is only offered the docker half.
+        """
+        configured, supported = self._libvirt_fw_backend()
         commands = []
         if have("docker"):
             commands += [
-                "sudo cp -a /etc/docker/daemon.json "
+                "sudo cp -an /etc/docker/daemon.json "
                 "/etc/docker/daemon.json.boxman-bak 2>/dev/null || true",
+                # merge and restart are chained: if the merge fails, restarting
+                # docker would perform the very wipe this fix exists to prevent
                 "sudo python3 -c \"import json,pathlib;"
                 "p=pathlib.Path('/etc/docker/daemon.json');"
-                "d=json.loads(p.read_text() or '{}') if p.exists() else {};"
+                "d=json.loads(p.read_text().strip() or '{}') if p.exists() else {};"
                 "d['ip-forward-no-drop']=True;"
                 "p.parent.mkdir(parents=True,exist_ok=True);"
-                "p.write_text(json.dumps(d,indent=2))\"",
-                "sudo systemctl restart docker",
+                "p.write_text(json.dumps(d,indent=2))\""
+                " && sudo systemctl restart docker",
                 # the flag stops docker *setting* the policy; it does not clear
                 # one docker already set, so this one-off reset is required
                 "sudo iptables -P FORWARD ACCEPT",
             ]
         if supported and backend != "nftables":
             commands += [
-                "sudo cp -a /etc/libvirt/network.conf "
+                "sudo cp -an /etc/libvirt/network.conf "
                 "/etc/libvirt/network.conf.boxman-bak 2>/dev/null || true",
                 "sudo sh -c 'sed -i "
                 "\"/^[[:space:]]*firewall_backend[[:space:]]*=/d\" "
@@ -863,11 +971,48 @@ class Doctor(object):
         description = ("give libvirt its own nftables table and stop docker "
                        "forcing FORWARD to DROP (a .boxman-bak backup is "
                        "written next to each file)")
-        if not supported:
+        if backend == "nftables":
+            description = ("stop docker forcing FORWARD to DROP -- libvirt "
+                           "already has its own table")
+        elif not supported:
             description += ("; this libvirt build has no firewall_backend "
                             "option, so only the docker half can be automated")
         return Fix(description, commands, needs_sudo=True,
                    disruptive=bool(commands))
+
+    def _forward_evidence(self):
+        """Gather forward-scoped rules from both firewall views.
+
+        Returns ``(evidence, policy_drop, libvirt_table, complete_view)``.
+        Only rules on the forward hook are collected: scanning a whole ruleset
+        would let nat and mangle -- which survive a docker rebuild -- vouch for
+        filter rules that are long gone.
+        """
+        evidence, policy_drop, libvirt_table, complete_view = [], False, False, True
+
+        if have("iptables"):
+            rc, out = self._root_capture(["iptables", "-S"])
+            if rc == 0:
+                rules, drop = iptables_forward_facts(out)
+                evidence.append(rules)
+                policy_drop = policy_drop or drop
+            else:
+                complete_view = False
+        else:
+            complete_view = False
+
+        if have("nft"):
+            rc, out = self._root_capture(["nft", "-j", "list", "ruleset"])
+            if rc == 0:
+                rules, drop, libvirt_table = nft_forward_facts(out)
+                evidence.append(rules)
+                policy_drop = policy_drop or drop
+            else:
+                complete_view = False
+        else:
+            complete_view = False
+
+        return "\n".join(evidence), policy_drop, libvirt_table, complete_view
 
     def _check_host_forwarding(self):
         """Report whether libvirt's forwarding rules are intact -- see
@@ -885,38 +1030,35 @@ class Doctor(object):
             for name in [n.strip() for n in out.splitlines() if n.strip()]:
                 rc, xml = run_capture(
                     ["virsh", "-c", "qemu:///system", "net-dumpxml", name])
-                if rc != 0 or not re.search(
-                        r"<forward[^>]*mode=['\"](nat|route)", xml):
+                if rc != 0:
                     continue
+                mode = re.search(r"<forward[^>]*mode=['\"](nat|route|open)", xml)
                 bridge = re.search(r"<bridge[^>]*name=['\"]([^'\"]+)", xml)
-                if bridge:
-                    networks.append((name, bridge.group(1)))
+                if mode and bridge:
+                    # 'open' means libvirt deliberately writes no rules, so its
+                    # bridge must not be judged against the ruleset -- but the
+                    # host's forward policy still decides whether it works
+                    networks.append((name, bridge.group(1),
+                                     mode.group(1) != "open"))
             if not networks:
-                return SKIP, "no active NAT/routed libvirt networks", None
+                return SKIP, "no active forwarding libvirt networks", None
 
-            # Both must be consulted: docker and boxman write the iptables
-            # filter table, while libvirt's nftables backend keeps its rules in
-            # a private table that `iptables -S` cannot see.
-            texts, complete_view = [], True
-            for args in (["iptables", "-S"], ["nft", "list", "ruleset"]):
-                if not have(args[0]):
-                    complete_view = False
-                    continue
-                rc, out = self._root_capture(args)
-                if rc == 0:
-                    texts.append(out)
-                else:
-                    complete_view = False
-            if not texts:
+            evidence, policy_drop, libvirt_table, complete_view = \
+                self._forward_evidence()
+            if not evidence and not complete_view:
                 return INFO, ("cannot read the firewall ruleset without "
                               "passwordless sudo; re-run as root to include "
                               "this check"), None
 
-            rules = "\n".join(texts)
+            # A live libvirt table is proof of the backend; the config file is
+            # only a fallback, since libvirt >= 11 defaults to nftables with
+            # the setting left unset.
+            backend = "nftables" if libvirt_table else self._libvirt_fw_backend()[0]
             status, detail, needs_fix = forwarding_verdict(
-                networks, rules, "DOCKER-USER" in rules or have("docker"),
-                self._effective_fw_backend(rules), complete_view)
-            return status, detail, (self._forwarding_fix() if needs_fix else None)
+                networks, evidence, self._docker_manages_firewall(evidence),
+                backend, policy_drop, complete_view)
+            return status, detail, (self._forwarding_fix(backend)
+                                    if needs_fix else None)
 
         self.check("Host forwarding (docker/libvirt)", forwarding)
 

--- a/scripts/installer/check_prerequisites.py
+++ b/scripts/installer/check_prerequisites.py
@@ -155,15 +155,82 @@ def worst_status(statuses):
     return OK
 
 
+def parse_firewall_backend(text):
+    """Return ``(configured_backend, option_supported)`` from network.conf text.
+
+    libvirt's shipped network.conf documents ``firewall_backend`` even when the
+    setting itself is commented out, so the option's mere presence in the file
+    is a reliable signal that this build understands it.
+    """
+    match = re.search(r'^\s*firewall_backend\s*=\s*"?([a-z]+)"?', text, re.M)
+    return (match.group(1) if match else ""), ("firewall_backend" in text)
+
+
+def forwarding_verdict(networks, rules, docker_present, backend,
+                       complete_view=True):
+    """Grade the host forward path from facts already gathered.
+
+    ``networks`` is ``[(network_name, bridge_name), ...]`` for the active
+    NAT/routed libvirt networks; ``rules`` is the concatenated text of every
+    ruleset we managed to read (``iptables -S`` *and* ``nft list ruleset``).
+    ``complete_view`` is False when one of those could not be read -- a bridge
+    we then fail to find is reported as unconfirmed rather than wiped, because
+    libvirt's nftables backend keeps its rules in a private table and a checker
+    that could not look there must not claim they are gone.
+    Returns ``(status, detail, needs_fix)``.
+
+    Docker and libvirt both write the ``filter`` table.  Docker rebuilds it on
+    every restart and leaves the FORWARD policy at DROP; libvirt's rules -- and
+    boxman's own routed-network FORWARD rules -- are collateral damage, and
+    nothing re-applies them.  Every base chain on the forward hook is evaluated
+    and a drop in any of them is final, so libvirt's ACCEPTs cannot rescue the
+    packet.  The nat table usually survives, so guests keep NATing while
+    forwarding is dead: it reads as a slow network, not a firewall fault.
+    """
+    if not networks:
+        return SKIP, "no active NAT/routed libvirt networks", False
+
+    # Word-anchored, not a substring test: plain containment would let
+    # virbr10's rules vouch for virbr1 and hide a genuinely wiped network.
+    wiped = [name for name, bridge in networks
+             if not re.search(r"\b%s\b" % re.escape(bridge), rules)]
+
+    if wiped and not complete_view:
+        return INFO, ("part of the ruleset was unreadable, so the rules for %s "
+                      "could not be confirmed either way" % ", ".join(wiped)), False
+
+    if wiped:
+        detail = ("no forwarding rules for active network(s): %s\n"
+                  "guests will NAT but never forward" % ", ".join(wiped))
+        if docker_present:
+            detail += "\ndocker shares this table and rebuilds it on restart"
+        return WARN, detail, True
+
+    if docker_present and backend != "nftables":
+        detail = ("forwarding works now, but libvirt shares the filter table "
+                  "with docker -- the next `systemctl restart docker` wipes "
+                  "these rules")
+        if re.search(r"^-P FORWARD DROP", rules, re.M):
+            detail += "\nFORWARD policy is DROP, so nothing survives the wipe"
+        return WARN, detail, True
+
+    return OK, "forwarding rules present for: %s" % ", ".join(
+        name for name, _ in networks), False
+
+
 # --------------------------------------------------------------------------- #
 # Small result containers                                                      #
 # --------------------------------------------------------------------------- #
 class Fix(object):
-    def __init__(self, description, commands=None, needs_sudo=False, needs_relogin=False):
+    def __init__(self, description, commands=None, needs_sudo=False,
+                 needs_relogin=False, disruptive=False):
         self.description = description
         self.commands = list(commands or [])
         self.needs_sudo = needs_sudo
         self.needs_relogin = needs_relogin
+        # Restarts a running service. Always confirmed interactively, even
+        # under --yes, so an unattended run can never bounce a container host.
+        self.disruptive = disruptive
 
     @property
     def runnable(self):
@@ -279,6 +346,10 @@ class Doctor(object):
     def _handle_fix(self, result, probe):
         fix = result.fix
         self._show_fix(fix)
+        if fix.disruptive:
+            print("       " + self.c(
+                "(disruptive: restarts services -- running containers and guest "
+                "connectivity are interrupted)", "yellow"))
 
         # Advisory-only situations: read-only mode, no runnable commands, or a
         # non-interactive session the user hasn't pre-approved with --yes.
@@ -286,7 +357,10 @@ class Doctor(object):
             self._remember_manual(result)
             return
 
-        if not (self.opts.yes or self._ask("       -> run the above now?")):
+        # --yes deliberately does not cover disruptive fixes: bouncing a
+        # container host is not something an unattended run may decide.
+        auto = self.opts.yes and not fix.disruptive
+        if not (auto or self._ask("       -> run the above now?")):
             self._remember_manual(result)
             return
 
@@ -637,6 +711,7 @@ class Doctor(object):
                 return WARN, "'default' network exists but is inactive", fix
 
             self.check("Default libvirt network", default_net)
+            self._check_host_forwarding()
 
         def seed_tool():
             tools = ["cloud-localds", "genisoimage", "mkisofs", "xorrisofs", "xorriso"]
@@ -709,6 +784,141 @@ class Doctor(object):
             return WARN, "passwordless sudo present but missing: " + "; ".join(gaps), fix
 
         self.check("sudo rights", sudo_rights)
+
+    # -- host packet forwarding (docker vs libvirt) ------------------------- #
+    def _root_capture(self, args):
+        """Run a root-only inspection command without ever prompting.
+
+        Returns ``(rc, text)``; rc 126 means "we were not allowed to look",
+        which callers surface as INFO -- a checker that cannot see must say so
+        rather than guess.
+        """
+        if getattr(os, "geteuid", lambda: 1)() == 0:
+            return run_capture(args)
+        if not have("sudo"):
+            return 126, ""
+        rc, out = run_capture(["sudo", "-n"] + args)
+        if rc != 0 and re.search(r"password is required|terminal is required",
+                                 out, re.I):
+            return 126, ""
+        return rc, out
+
+    def _libvirt_net_unit(self):
+        """The systemd unit that owns libvirt's network rules on this host."""
+        for unit in ("virtnetworkd", "libvirtd"):
+            if run_capture(["systemctl", "is-active", unit])[1].strip() == "active":
+                return unit
+        return "libvirtd"
+
+    def _libvirt_fw_backend(self):
+        """``(configured_backend, option_supported)`` for this libvirt."""
+        try:
+            with open("/etc/libvirt/network.conf") as handle:
+                return parse_firewall_backend(handle.read())
+        except OSError:
+            return "", False
+
+    def _effective_fw_backend(self, rules):
+        """What libvirt is actually doing, not merely what is configured.
+
+        A libvirt-owned nft table is proof.  The config file is only a
+        fallback: libvirt >= 11 defaults to the nftables backend with the
+        setting left unset, so an empty ``firewall_backend`` means nothing on
+        its own.
+        """
+        if re.search(r"^table (?:ip|ip6|inet) libvirt", rules, re.M):
+            return "nftables"
+        return self._libvirt_fw_backend()[0]
+
+    def _forwarding_fix(self):
+        """Commands that take libvirt out of the table docker rebuilds."""
+        backend, supported = self._libvirt_fw_backend()
+        commands = []
+        if have("docker"):
+            commands += [
+                "sudo cp -a /etc/docker/daemon.json "
+                "/etc/docker/daemon.json.boxman-bak 2>/dev/null || true",
+                "sudo python3 -c \"import json,pathlib;"
+                "p=pathlib.Path('/etc/docker/daemon.json');"
+                "d=json.loads(p.read_text() or '{}') if p.exists() else {};"
+                "d['ip-forward-no-drop']=True;"
+                "p.parent.mkdir(parents=True,exist_ok=True);"
+                "p.write_text(json.dumps(d,indent=2))\"",
+                "sudo systemctl restart docker",
+                # the flag stops docker *setting* the policy; it does not clear
+                # one docker already set, so this one-off reset is required
+                "sudo iptables -P FORWARD ACCEPT",
+            ]
+        if supported and backend != "nftables":
+            commands += [
+                "sudo cp -a /etc/libvirt/network.conf "
+                "/etc/libvirt/network.conf.boxman-bak 2>/dev/null || true",
+                "sudo sh -c 'sed -i "
+                "\"/^[[:space:]]*firewall_backend[[:space:]]*=/d\" "
+                "/etc/libvirt/network.conf && printf "
+                "\"firewall_backend = \\\"nftables\\\"\\n\" "
+                ">> /etc/libvirt/network.conf'",
+                "sudo systemctl restart %s" % self._libvirt_net_unit(),
+            ]
+        description = ("give libvirt its own nftables table and stop docker "
+                       "forcing FORWARD to DROP (a .boxman-bak backup is "
+                       "written next to each file)")
+        if not supported:
+            description += ("; this libvirt build has no firewall_backend "
+                            "option, so only the docker half can be automated")
+        return Fix(description, commands, needs_sudo=True,
+                   disruptive=bool(commands))
+
+    def _check_host_forwarding(self):
+        """Report whether libvirt's forwarding rules are intact -- see
+        :func:`forwarding_verdict` for why docker keeps removing them."""
+        def forwarding():
+            if not have("virsh"):
+                return SKIP, "needs virsh to inspect", None
+
+            rc, out = run_capture(
+                ["virsh", "-c", "qemu:///system", "net-list", "--name"])
+            if rc != 0:
+                return SKIP, "cannot list libvirt networks", None
+
+            networks = []
+            for name in [n.strip() for n in out.splitlines() if n.strip()]:
+                rc, xml = run_capture(
+                    ["virsh", "-c", "qemu:///system", "net-dumpxml", name])
+                if rc != 0 or not re.search(
+                        r"<forward[^>]*mode=['\"](nat|route)", xml):
+                    continue
+                bridge = re.search(r"<bridge[^>]*name=['\"]([^'\"]+)", xml)
+                if bridge:
+                    networks.append((name, bridge.group(1)))
+            if not networks:
+                return SKIP, "no active NAT/routed libvirt networks", None
+
+            # Both must be consulted: docker and boxman write the iptables
+            # filter table, while libvirt's nftables backend keeps its rules in
+            # a private table that `iptables -S` cannot see.
+            texts, complete_view = [], True
+            for args in (["iptables", "-S"], ["nft", "list", "ruleset"]):
+                if not have(args[0]):
+                    complete_view = False
+                    continue
+                rc, out = self._root_capture(args)
+                if rc == 0:
+                    texts.append(out)
+                else:
+                    complete_view = False
+            if not texts:
+                return INFO, ("cannot read the firewall ruleset without "
+                              "passwordless sudo; re-run as root to include "
+                              "this check"), None
+
+            rules = "\n".join(texts)
+            status, detail, needs_fix = forwarding_verdict(
+                networks, rules, "DOCKER-USER" in rules or have("docker"),
+                self._effective_fw_backend(rules), complete_view)
+            return status, detail, (self._forwarding_fix() if needs_fix else None)
+
+        self.check("Host forwarding (docker/libvirt)", forwarding)
 
     def _check_optional_tools(self):
         self.section("Optional features (not required for basic `boxman up`)")

--- a/scripts/installer/check_prerequisites.py
+++ b/scripts/installer/check_prerequisites.py
@@ -194,10 +194,17 @@ def iptables_forward_facts(text):
 def nft_forward_facts(json_text):
     """Forward-hook facts from ``nft -j list ruleset`` output.
 
-    Returns ``(rules_text, policy_drop, libvirt_table)``: the serialised rules
-    of every base chain on the forward hook, whether any such chain drops by
-    default, and whether libvirt owns a table (proof that it is using the
-    nftables backend instead of sharing docker's).
+    Returns ``(rules_text, policy_drop, libvirt_table, parsed)``: the
+    serialised rules of every base chain on the forward hook, whether any such
+    chain drops by default, whether libvirt owns a table (proof that it is
+    using the nftables backend instead of sharing docker's), and whether the
+    output was understood at all.
+
+    ``parsed`` guards against schema drift.  If a future nft speaks a shape
+    this function does not recognise, every fact above comes back empty and
+    silently absent -- which would read as "libvirt is not using nftables" and
+    warn a perfectly healthy host.  Saying "I did not understand this" instead
+    keeps that failure honest.
 
     The JSON form is used rather than the human-readable listing because the
     latter cannot be scanned safely: it also contains nat and mangle, which
@@ -208,9 +215,11 @@ def nft_forward_facts(json_text):
     try:
         doc = json.loads(json_text)
     except (ValueError, TypeError):
-        return "", False, False
+        return "", False, False, False
 
     items = doc.get("nftables", []) if isinstance(doc, dict) else []
+    if not isinstance(items, list) or not items:
+        return "", False, False, False
     forward, policy_drop, libvirt_table = set(), False, False
     for item in items:
         if not isinstance(item, dict):
@@ -232,7 +241,7 @@ def nft_forward_facts(json_text):
         if isinstance(rule, dict) and (
                 rule.get("family"), rule.get("table"), rule.get("chain")) in forward:
             rules.append(json.dumps(rule, sort_keys=True))
-    return "\n".join(rules), policy_drop, libvirt_table
+    return "\n".join(rules), policy_drop, libvirt_table, True
 
 
 def forwarding_verdict(networks, evidence, docker_present, backend,
@@ -1009,11 +1018,14 @@ class Doctor(object):
 
         if have("nft"):
             rc, out = self._root_capture(["nft", "-j", "list", "ruleset"])
-            if rc == 0:
-                rules, drop, libvirt_table = nft_forward_facts(out)
+            rules, drop, libvirt_table, parsed = nft_forward_facts(out) \
+                if rc == 0 else ("", False, False, False)
+            if parsed:
                 evidence.append(rules)
                 policy_drop = policy_drop or drop
             else:
+                # ran but told us nothing we understood -- same standing as
+                # not having been allowed to look
                 complete_view = False
         else:
             complete_view = False

--- a/scripts/installer/check_prerequisites.py
+++ b/scripts/installer/check_prerequisites.py
@@ -986,9 +986,17 @@ class Doctor(object):
         description = ("give libvirt its own nftables table and stop docker "
                        "forcing FORWARD to DROP (a .boxman-bak backup is "
                        "written next to each file)")
-        if backend == "nftables":
+        if backend == "nftables" and docker_manages:
             description = ("stop docker forcing FORWARD to DROP -- libvirt "
                            "already has its own table")
+        elif backend == "nftables":
+            # nothing here to automate: docker is not the one dropping, so
+            # whatever set the policy (firewalld, a hand-rolled ruleset, an
+            # admin) has to be found before anything can be recommended
+            description = ("libvirt already has its own table; find what set "
+                           "the FORWARD policy to DROP -- `iptables -S FORWARD "
+                           "| head -1` and `nft list ruleset | grep -B5 'hook "
+                           "forward'` -- and let that owner accept the bridge")
         elif not supported:
             description += ("; this libvirt build has no firewall_backend "
                             "option, so only the docker half can be automated")

--- a/scripts/installer/check_prerequisites.py
+++ b/scripts/installer/check_prerequisites.py
@@ -188,17 +188,38 @@ def iptables_forward_facts(text):
         elif jumped and re.match(r"-A LIBVIRT_FW", line):
             keep.append(line)
     policy_drop = any(re.match(r"-P FORWARD DROP\b", line) for line in lines)
-    return "\n".join(keep), policy_drop
+    rules = "\n".join(keep)
+    # When FORWARD drops by default, its own rules are what can still rescue a
+    # packet before the policy applies -- so they decide which bridges are
+    # actually at risk.
+    return rules, (rules if policy_drop else ""), policy_drop
+
+
+def _jump_targets(rule):
+    """Chain names a rule hands control to (``jump`` / ``goto``)."""
+    targets = []
+    for expr in rule.get("expr") or []:
+        if not isinstance(expr, dict):
+            continue
+        for verb in ("jump", "goto"):
+            spec = expr.get(verb)
+            if isinstance(spec, dict) and spec.get("target"):
+                targets.append(spec["target"])
+    return targets
 
 
 def nft_forward_facts(json_text):
     """Forward-hook facts from ``nft -j list ruleset`` output.
 
-    Returns ``(rules_text, policy_drop, libvirt_table, parsed)``: the
-    serialised rules of every base chain on the forward hook, whether any such
-    chain drops by default, whether libvirt owns a table (proof that it is
-    using the nftables backend instead of sharing docker's), and whether the
-    output was understood at all.
+    Returns ``(rules_text, drop_rules_text, policy_drop, libvirt_table,
+    parsed)``: the serialised rules reachable from the forward hook, the subset
+    of those reachable from chains that *drop by default*, whether any such
+    chain exists, whether libvirt owns a table (proof that it is using the
+    nftables backend instead of sharing docker's), and whether the output was
+    understood at all.
+
+    The drop subset matters because a default drop only kills what its own
+    chain did not already accept -- so it is per-bridge, not per-host.
 
     ``parsed`` guards against schema drift.  If a future nft speaks a shape
     this function does not recognise, every fact above comes back empty and
@@ -215,12 +236,13 @@ def nft_forward_facts(json_text):
     try:
         doc = json.loads(json_text)
     except (ValueError, TypeError):
-        return "", False, False, False
+        return "", "", False, False, False
 
     items = doc.get("nftables", []) if isinstance(doc, dict) else []
     if not isinstance(items, list) or not items:
-        return "", False, False, False
-    forward, policy_drop, libvirt_table = set(), False, False
+        return "", "", False, False, False
+
+    reachable, dropping, policy_drop, libvirt_table = set(), set(), False, False
     for item in items:
         if not isinstance(item, dict):
             continue
@@ -229,23 +251,62 @@ def nft_forward_facts(json_text):
             libvirt_table = True
         chain = item.get("chain")
         if isinstance(chain, dict) and chain.get("hook") == "forward":
-            forward.add((chain.get("family"), chain.get("table"), chain.get("name")))
+            key = (chain.get("family"), chain.get("table"), chain.get("name"))
+            reachable.add(key)
             if chain.get("policy") == "drop":
                 policy_drop = True
+                dropping.add(key)
 
-    rules = []
+    by_chain = {}
     for item in items:
         if not isinstance(item, dict):
             continue
         rule = item.get("rule")
-        if isinstance(rule, dict) and (
-                rule.get("family"), rule.get("table"), rule.get("chain")) in forward:
-            rules.append(json.dumps(rule, sort_keys=True))
-    return "\n".join(rules), policy_drop, libvirt_table, True
+        if isinstance(rule, dict):
+            key = (rule.get("family"), rule.get("table"), rule.get("chain"))
+            by_chain.setdefault(key, []).append(rule)
+
+    # Base chains are only the entry point. libvirt's nftables backend keeps
+    # its `forward` base chain nearly empty and jumps to guest_cross /
+    # guest_input / guest_output, which is where the bridge is actually named
+    # -- so stopping at base chains would find no rules for a perfectly
+    # healthy network. Follow jump/goto within the same table until the
+    # reachable set stops growing.
+    def close_over(seed):
+        found, pending = set(seed), list(seed)
+        while pending:
+            family, table_name, chain_name = pending.pop()
+            for rule in by_chain.get((family, table_name, chain_name), []):
+                for target in _jump_targets(rule):
+                    nxt = (family, table_name, target)
+                    if nxt not in found:
+                        found.add(nxt)
+                        pending.append(nxt)
+        return found
+
+    def serialise(keys):
+        out = []
+        for key in sorted(keys, key=lambda k: [str(part) for part in k]):
+            for rule in by_chain.get(key, []):
+                out.append(json.dumps(rule, sort_keys=True))
+        return "\n".join(out)
+
+    return (serialise(close_over(reachable)), serialise(close_over(dropping)),
+            policy_drop, libvirt_table, True)
+
+
+def wiped_networks(networks, evidence):
+    """Networks that should carry forwarding rules but have none.
+
+    Word-anchored, not a substring test: plain containment would let virbr10's
+    rules vouch for virbr1 and hide a genuinely wiped network.
+    """
+    return [name for name, bridge, expects in networks
+            if expects and not re.search(r"\b%s\b" % re.escape(bridge), evidence)]
 
 
 def forwarding_verdict(networks, evidence, docker_present, backend,
-                       policy_drop=False, complete_view=True):
+                       policy_drop=False, drop_evidence="", complete_view=True):
     """Grade the host forward path from facts already gathered.
 
     ``networks`` is ``[(name, bridge, expects_rules), ...]`` for the active
@@ -269,8 +330,18 @@ def forwarding_verdict(networks, evidence, docker_present, backend,
 
     # Word-anchored, not a substring test: plain containment would let
     # virbr10's rules vouch for virbr1 and hide a genuinely wiped network.
-    wiped = [name for name, bridge, expects in networks
-             if expects and not re.search(r"\b%s\b" % re.escape(bridge), evidence)]
+    def named(bridge):
+        return re.search(r"\b%s\b" % re.escape(bridge), evidence) is not None
+
+    wiped = wiped_networks(networks, evidence)
+    # A default drop only kills what its own chain did not already accept, so
+    # this is decided per bridge. It catches the half-fixed host (libvirt moved
+    # to its own table, policy never cleared) and 'open' networks alike -- for
+    # those libvirt writes nothing by design, which is exactly why a drop is
+    # fatal to them.
+    at_risk = [name for name, bridge, _ in networks
+               if policy_drop
+               and not re.search(r"\b%s\b" % re.escape(bridge), drop_evidence)]
 
     if wiped and not complete_view:
         return INFO, ("part of the ruleset was unreadable, so the rules for %s "
@@ -283,13 +354,15 @@ def forwarding_verdict(networks, evidence, docker_present, backend,
             detail += "\ndocker shares this table and rebuilds it on restart"
         return WARN, detail, True
 
-    # libvirt is safely in its own table, but a foreign DROP at the same hook
-    # still kills the packet. This is the half-fixed state: protecting the
-    # rules without clearing the policy changes nothing for the guest.
-    if backend == "nftables" and policy_drop:
-        return WARN, ("libvirt has its own table, but the FORWARD policy is "
-                      "DROP -- a drop in any table at the hook is final, so "
-                      "guests still cannot forward"), True
+    if at_risk and complete_view:
+        detail = ("a chain at the forward hook drops by default and nothing "
+                  "in it accepts: %s\n"
+                  "a drop in any table at the hook is final, so these guests "
+                  "cannot forward" % ", ".join(at_risk))
+        if backend == "nftables":
+            # the half-fixed host: rules protected, policy never cleared
+            detail += "\nlibvirt already has its own table -- only the policy is left"
+        return WARN, detail, True
 
     if docker_present and backend != "nftables":
         detail = ("forwarding works now, but libvirt shares the filter table "
@@ -490,7 +563,9 @@ class Doctor(object):
     def _ask(self, prompt):
         try:
             answer = input("%s [y/N] " % prompt).strip().lower()
-        except (EOFError, KeyboardInterrupt):
+        except (EOFError, KeyboardInterrupt, OSError):
+            # OSError: the terminal went away mid-prompt (EIO on hangup).
+            # Declining is the only safe reading of "no answer".
             print()
             return False
         return answer in ("y", "yes")
@@ -944,7 +1019,7 @@ class Doctor(object):
                 return True
         return False
 
-    def _forwarding_fix(self, backend, docker_manages):
+    def _forwarding_fix(self, backend, docker_manages, wiped=False):
         """Commands that take libvirt out of the table docker rebuilds.
 
         ``backend`` is the *effective* backend, so a host that already keeps
@@ -954,11 +1029,34 @@ class Doctor(object):
         binary exists would contradict the reason we stopped trusting it.
         """
         configured, supported = self._libvirt_fw_backend()
-        commands = []
+        unit = self._libvirt_net_unit()
+
+        # Migrate libvirt FIRST. The docker half ends in a docker restart --
+        # the very event that wipes the shared table -- so running it before
+        # libvirt has moved out means an abort at any later step leaves a host
+        # that was merely at risk actually broken.
+        libvirt_cmds = []
+        if supported and backend != "nftables":
+            libvirt_cmds = [
+                "sudo sh -c '[ ! -f /etc/libvirt/network.conf ] || "
+                "cp -an /etc/libvirt/network.conf "
+                "/etc/libvirt/network.conf.boxman-bak'",
+                # the leading newline guards against a file with no trailing
+                # one, where a bare append would fuse onto the last setting
+                "sudo sh -c 'sed -i "
+                "\"/^[[:space:]]*firewall_backend[[:space:]]*=/d\" "
+                "/etc/libvirt/network.conf && printf "
+                "\"\\nfirewall_backend = \\\"nftables\\\"\\n\" "
+                ">> /etc/libvirt/network.conf'",
+                "sudo systemctl restart %s" % unit,
+            ]
+
+        docker_cmds = []
         if docker_manages:
-            commands += [
-                "sudo cp -an /etc/docker/daemon.json "
-                "/etc/docker/daemon.json.boxman-bak 2>/dev/null || true",
+            docker_cmds = [
+                "sudo sh -c '[ ! -f /etc/docker/daemon.json ] || "
+                "cp -an /etc/docker/daemon.json "
+                "/etc/docker/daemon.json.boxman-bak'",
                 # merge and restart are chained: if the merge fails, restarting
                 # docker would perform the very wipe this fix exists to prevent
                 "sudo python3 -c \"import json,pathlib;"
@@ -972,17 +1070,13 @@ class Doctor(object):
                 # one docker already set, so this one-off reset is required
                 "sudo iptables -P FORWARD ACCEPT",
             ]
-        if supported and backend != "nftables":
-            commands += [
-                "sudo cp -an /etc/libvirt/network.conf "
-                "/etc/libvirt/network.conf.boxman-bak 2>/dev/null || true",
-                "sudo sh -c 'sed -i "
-                "\"/^[[:space:]]*firewall_backend[[:space:]]*=/d\" "
-                "/etc/libvirt/network.conf && printf "
-                "\"firewall_backend = \\\"nftables\\\"\\n\" "
-                ">> /etc/libvirt/network.conf'",
-                "sudo systemctl restart %s" % self._libvirt_net_unit(),
-            ]
+
+        commands = libvirt_cmds + docker_cmds
+        if wiped and not libvirt_cmds and commands:
+            # Nothing above re-applies libvirt's rules, and they are gone.
+            # Without this the guided fix "succeeds" and the re-probe still
+            # reports the network as wiped.
+            commands.append("sudo systemctl restart %s" % unit)
         description = ("give libvirt its own nftables table and stop docker "
                        "forcing FORWARD to DROP (a .boxman-bak backup is "
                        "written next to each file)")
@@ -1006,18 +1100,20 @@ class Doctor(object):
     def _forward_evidence(self):
         """Gather forward-scoped rules from both firewall views.
 
-        Returns ``(evidence, policy_drop, libvirt_table, complete_view)``.
-        Only rules on the forward hook are collected: scanning a whole ruleset
-        would let nat and mangle -- which survive a docker rebuild -- vouch for
-        filter rules that are long gone.
+        Returns ``(evidence, drop_evidence, policy_drop, libvirt_table,
+        complete_view)``.  Only rules on the forward hook are collected:
+        scanning a whole ruleset would let nat and mangle -- which survive a
+        docker rebuild -- vouch for filter rules that are long gone.
         """
-        evidence, policy_drop, libvirt_table, complete_view = [], False, False, True
+        evidence, drops = [], []
+        policy_drop, libvirt_table, complete_view = False, False, True
 
         if have("iptables"):
             rc, out = self._root_capture(["iptables", "-S"])
             if rc == 0:
-                rules, drop = iptables_forward_facts(out)
+                rules, drop_rules, drop = iptables_forward_facts(out)
                 evidence.append(rules)
+                drops.append(drop_rules)
                 policy_drop = policy_drop or drop
             else:
                 complete_view = False
@@ -1026,10 +1122,11 @@ class Doctor(object):
 
         if have("nft"):
             rc, out = self._root_capture(["nft", "-j", "list", "ruleset"])
-            rules, drop, libvirt_table, parsed = nft_forward_facts(out) \
-                if rc == 0 else ("", False, False, False)
+            rules, drop_rules, drop, libvirt_table, parsed = \
+                nft_forward_facts(out) if rc == 0 else ("", "", False, False, False)
             if parsed:
                 evidence.append(rules)
+                drops.append(drop_rules)
                 policy_drop = policy_drop or drop
             else:
                 # ran but told us nothing we understood -- same standing as
@@ -1038,7 +1135,8 @@ class Doctor(object):
         else:
             complete_view = False
 
-        return "\n".join(evidence), policy_drop, libvirt_table, complete_view
+        return ("\n".join(evidence), "\n".join(drops), policy_drop,
+                libvirt_table, complete_view)
 
     def _check_host_forwarding(self):
         """Report whether libvirt's forwarding rules are intact -- see
@@ -1058,18 +1156,24 @@ class Doctor(object):
                     ["virsh", "-c", "qemu:///system", "net-dumpxml", name])
                 if rc != 0:
                     continue
-                mode = re.search(r"<forward[^>]*mode=['\"](nat|route|open)", xml)
+                forward = re.search(r"<forward\b[^>]*>", xml)
+                if not forward:
+                    continue
+                # libvirt defaults a mode-less <forward/> to nat
+                mode = re.search(r"mode=['\"]([a-z]+)", forward.group(0))
+                mode = mode.group(1) if mode else "nat"
+                if mode not in ("nat", "route", "open"):
+                    continue
                 bridge = re.search(r"<bridge[^>]*name=['\"]([^'\"]+)", xml)
-                if mode and bridge:
+                if bridge:
                     # 'open' means libvirt deliberately writes no rules, so its
                     # bridge must not be judged against the ruleset -- but the
                     # host's forward policy still decides whether it works
-                    networks.append((name, bridge.group(1),
-                                     mode.group(1) != "open"))
+                    networks.append((name, bridge.group(1), mode != "open"))
             if not networks:
                 return SKIP, "no active forwarding libvirt networks", None
 
-            evidence, policy_drop, libvirt_table, complete_view = \
+            evidence, drop_evidence, policy_drop, libvirt_table, complete_view = \
                 self._forward_evidence()
             if not evidence and not complete_view:
                 return INFO, ("cannot read the firewall ruleset without "
@@ -1083,9 +1187,10 @@ class Doctor(object):
             docker_manages = self._docker_manages_firewall(evidence)
             status, detail, needs_fix = forwarding_verdict(
                 networks, evidence, docker_manages, backend, policy_drop,
-                complete_view)
+                drop_evidence, complete_view)
+            wiped = bool(wiped_networks(networks, evidence))
             return status, detail, (
-                self._forwarding_fix(backend, docker_manages)
+                self._forwarding_fix(backend, docker_manages, wiped)
                 if needs_fix else None)
 
         self.check("Host forwarding (docker/libvirt)", forwarding)

--- a/tests/test_check_prerequisites.py
+++ b/tests/test_check_prerequisites.py
@@ -163,6 +163,18 @@ def test_parse_firewall_backend_absent_means_unsupported():
     assert checker.parse_firewall_backend("# some other option\n") == ("", False)
 
 
+def test_parse_firewall_backend_ignores_the_bare_word_in_prose():
+    """Support is inferred from a real declaration, not a mention.
+
+    The word can appear in unrelated prose (a changelog note, a comment about
+    another distro) and must not be read as "this build supports the option".
+    """
+    text = "# see the firewall_backend discussion upstream for context\n"
+    assert checker.parse_firewall_backend(text) == ("", False)
+    assert checker.parse_firewall_backend(
+        '#firewall_backend = "iptables"\n') == ("", True)
+
+
 # --------------------------------------------------------------------------- #
 # iptables_forward_facts                                                      #
 # --------------------------------------------------------------------------- #

--- a/tests/test_check_prerequisites.py
+++ b/tests/test_check_prerequisites.py
@@ -238,10 +238,11 @@ def test_nft_forward_facts_ignores_nat_and_mangle():
         {"rule": {"family": "ip", "table": "mangle", "chain": "POSTROUTING",
                   "expr": [{"match": {"right": "virbr0"}}]}},
     )
-    rules, policy_drop, libvirt_table = checker.nft_forward_facts(doc)
+    rules, policy_drop, libvirt_table, parsed = checker.nft_forward_facts(doc)
     assert "virbr0" not in rules
     assert policy_drop is False
     assert libvirt_table is False
+    assert parsed is True
 
 
 def test_nft_forward_facts_collects_forward_chains_and_policy():
@@ -254,15 +255,27 @@ def test_nft_forward_facts_collects_forward_chains_and_policy():
         {"chain": {"family": "ip", "table": "filter", "name": "FORWARD",
                    "hook": "forward", "policy": "drop"}},
     )
-    rules, policy_drop, libvirt_table = checker.nft_forward_facts(doc)
+    rules, policy_drop, libvirt_table, parsed = checker.nft_forward_facts(doc)
+    assert parsed is True
     assert "virbr0" in rules
     assert policy_drop is True
     assert libvirt_table is True
 
 
 def test_nft_forward_facts_survives_garbage():
-    assert checker.nft_forward_facts("not json") == ("", False, False)
-    assert checker.nft_forward_facts("") == ("", False, False)
+    assert checker.nft_forward_facts("not json") == ("", False, False, False)
+    assert checker.nft_forward_facts("") == ("", False, False, False)
+
+
+def test_nft_forward_facts_reports_an_unrecognised_shape():
+    """Schema drift must read as "I did not understand", not as "no libvirt".
+
+    Silently returning empty facts would mark a healthy nftables host as
+    sharing docker's table and offer it a disruptive fix.
+    """
+    assert checker.nft_forward_facts('{"something_else": []}')[3] is False
+    assert checker.nft_forward_facts('{"nftables": []}')[3] is False
+    assert checker.nft_forward_facts("[]")[3] is False
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_check_prerequisites.py
+++ b/tests/test_check_prerequisites.py
@@ -336,8 +336,8 @@ def test_half_fixed_nftables_host_is_caught_end_to_end():
 
 
 def test_nft_forward_facts_survives_garbage():
-    assert checker.nft_forward_facts("not json") == ("", "", False, False, False)
-    assert checker.nft_forward_facts("") == ("", "", False, False, False)
+    assert checker.nft_forward_facts("not json") == ("", [], False, False, False)
+    assert checker.nft_forward_facts("") == ("", [], False, False, False)
 
 
 def test_nft_forward_facts_reports_an_unrecognised_shape():
@@ -601,3 +601,77 @@ def test_open_mode_network_is_fine_when_something_accepts_it():
 def test_wiped_networks_ignores_networks_that_expect_no_rules():
     nets = [("lab", "virbr7", False), ("default", "virbr0", True)]
     assert checker.wiped_networks(nets, "") == ["default"]
+
+
+# --------------------------------------------------------------------------- #
+# round-3 regressions                                                         #
+# --------------------------------------------------------------------------- #
+def test_each_dropping_chain_must_accept_the_bridge():
+    """An accept in one dropping chain cannot vouch past a second one.
+
+    Two independent default-drop forward chains (a hardened host plus docker):
+    the packet dies in whichever one has no accept for the bridge.
+    """
+    accepts = '-A FORWARD -i virbr0 -j ACCEPT'
+    status, detail, needs_fix = checker.forwarding_verdict(
+        _NAT, accepts, True, "nftables", policy_drop=True,
+        drop_evidence=[accepts, "-A FORWARD -j DOCKER-USER"])
+    assert status == checker.WARN, detail
+    assert needs_fix is True
+
+    # accepted in both -> genuinely safe
+    status, _, needs_fix = checker.forwarding_verdict(
+        _NAT, accepts, True, "nftables", policy_drop=True,
+        drop_evidence=[accepts, accepts])
+    assert status == checker.OK
+    assert needs_fix is False
+
+
+def test_nft_forward_facts_keeps_dropping_chains_separate():
+    doc = _nft(
+        {"table": {"family": "ip", "name": "filter"}},
+        {"chain": {"family": "ip", "table": "filter", "name": "FORWARD",
+                   "type": "filter", "hook": "forward", "policy": "drop"}},
+        {"rule": {"family": "ip", "table": "filter", "chain": "FORWARD",
+                  "expr": [{"match": {"right": "virbr0"}}]}},
+        {"table": {"family": "ip", "name": "hardened"}},
+        {"chain": {"family": "ip", "table": "hardened", "name": "fwd",
+                   "type": "filter", "hook": "forward", "policy": "drop"}},
+    )
+    _, drop_closures, policy_drop, _, _ = checker.nft_forward_facts(doc)
+    assert policy_drop is True
+    assert len(drop_closures) == 2
+    # one chain names the bridge, the other is empty -> not safe
+    assert any("virbr0" in closure for closure in drop_closures)
+    assert any("virbr0" not in closure for closure in drop_closures)
+
+
+def test_latent_host_on_old_libvirt_still_reapplies_rules(monkeypatch):
+    """A docker restart against the shared table wipes rules even when the
+    host was only *at risk* at the time the fix was built."""
+    doctor = _fix_doctor(monkeypatch, supported=False)
+    monkeypatch.setattr(doctor, "_docker_supports_no_drop", lambda: True,
+                        raising=False)
+    fix = doctor._forwarding_fix("iptables", docker_manages=True, wiped=False)
+    assert any("restart docker" in cmd for cmd in fix.commands)
+    assert fix.commands[-1] == "sudo systemctl restart virtnetworkd"
+
+
+def test_old_docker_engine_is_not_offered_the_daemon_json_edit(monkeypatch):
+    """dockerd refuses to start on an unknown directive -- writing it would
+    leave docker down, which is worse than the problem."""
+    doctor = _fix_doctor(monkeypatch, supported=False)
+    monkeypatch.setattr(doctor, "_docker_supports_no_drop", lambda: False,
+                        raising=False)
+    fix = doctor._forwarding_fix("iptables", docker_manages=True)
+    assert not any("daemon.json" in cmd for cmd in fix.commands)
+    assert not any("restart docker" in cmd for cmd in fix.commands)
+    assert "sudo iptables -P FORWARD ACCEPT" in fix.commands
+    assert "predates" in fix.description
+
+
+def test_fix_describes_no_docker_host_without_mentioning_docker(monkeypatch):
+    doctor = _fix_doctor(monkeypatch, supported=False)
+    fix = doctor._forwarding_fix("iptables", docker_manages=False, wiped=True)
+    assert fix.commands == ["sudo systemctl restart virtnetworkd"]
+    assert "docker" not in fix.description

--- a/tests/test_check_prerequisites.py
+++ b/tests/test_check_prerequisites.py
@@ -164,28 +164,112 @@ def test_parse_firewall_backend_absent_means_unsupported():
 
 
 # --------------------------------------------------------------------------- #
+# iptables_forward_facts                                                      #
+# --------------------------------------------------------------------------- #
+def test_iptables_forward_facts_keeps_only_forward_rules():
+    text = (
+        "-P FORWARD DROP\n"
+        "-A INPUT -i lo -j ACCEPT\n"
+        "-A FORWARD -i virbr0 -o eth0 -j ACCEPT\n"
+        "-A OUTPUT -o virbr9 -j ACCEPT\n"
+    )
+    rules, policy_drop = checker.iptables_forward_facts(text)
+    assert "virbr0" in rules
+    # an OUTPUT rule must never vouch for a bridge's forwarding
+    assert "virbr9" not in rules
+    assert policy_drop is True
+
+
+def test_iptables_forward_facts_ignores_orphaned_libvirt_chains():
+    """A populated chain nothing jumps to is inert.
+
+    Docker's rebuild removes the FORWARD jumps but leaves the LIBVIRT_FW*
+    chains behind, so counting their contents would call a dead host healthy.
+    """
+    orphaned = (
+        "-P FORWARD DROP\n"
+        "-A FORWARD -j DOCKER-USER\n"
+        "-A LIBVIRT_FWI -d 192.168.122.0/24 -o virbr0 -j ACCEPT\n"
+    )
+    rules, _ = checker.iptables_forward_facts(orphaned)
+    assert "virbr0" not in rules
+
+    wired = "-A FORWARD -j LIBVIRT_FWX\n" + orphaned
+    rules, _ = checker.iptables_forward_facts(wired)
+    assert "virbr0" in rules
+
+
+def test_iptables_forward_facts_accept_policy():
+    _, policy_drop = checker.iptables_forward_facts("-P FORWARD ACCEPT\n")
+    assert policy_drop is False
+
+
+# --------------------------------------------------------------------------- #
+# nft_forward_facts                                                           #
+# --------------------------------------------------------------------------- #
+def _nft(*items):
+    import json as _json
+    return _json.dumps({"nftables": list(items)})
+
+
+def test_nft_forward_facts_ignores_nat_and_mangle():
+    """The regression that made the acute case undetectable.
+
+    libvirt's mangle CHECKSUM rule names the bridge and survives a docker
+    rebuild, so scanning the whole ruleset finds the bridge on a host whose
+    forwarding is dead.
+    """
+    doc = _nft(
+        {"table": {"family": "ip", "name": "mangle"}},
+        {"chain": {"family": "ip", "table": "mangle", "name": "POSTROUTING",
+                   "hook": "postrouting", "policy": "accept"}},
+        {"rule": {"family": "ip", "table": "mangle", "chain": "POSTROUTING",
+                  "expr": [{"match": {"right": "virbr0"}}]}},
+    )
+    rules, policy_drop, libvirt_table = checker.nft_forward_facts(doc)
+    assert "virbr0" not in rules
+    assert policy_drop is False
+    assert libvirt_table is False
+
+
+def test_nft_forward_facts_collects_forward_chains_and_policy():
+    doc = _nft(
+        {"table": {"family": "ip", "name": "libvirt_network"}},
+        {"chain": {"family": "ip", "table": "libvirt_network", "name": "forward",
+                   "hook": "forward", "policy": "accept"}},
+        {"rule": {"family": "ip", "table": "libvirt_network", "chain": "forward",
+                  "expr": [{"match": {"right": "virbr0"}}]}},
+        {"chain": {"family": "ip", "table": "filter", "name": "FORWARD",
+                   "hook": "forward", "policy": "drop"}},
+    )
+    rules, policy_drop, libvirt_table = checker.nft_forward_facts(doc)
+    assert "virbr0" in rules
+    assert policy_drop is True
+    assert libvirt_table is True
+
+
+def test_nft_forward_facts_survives_garbage():
+    assert checker.nft_forward_facts("not json") == ("", False, False)
+    assert checker.nft_forward_facts("") == ("", False, False)
+
+
+# --------------------------------------------------------------------------- #
 # forwarding_verdict                                                          #
 # --------------------------------------------------------------------------- #
-_HEALTHY = (
-    "-P FORWARD ACCEPT\n"
-    "-A FORWARD -i virbr0 -o virbr0 -j ACCEPT\n"
-)
-_WIPED = (
-    "-P FORWARD DROP\n"
-    "-A FORWARD -j DOCKER-USER\n"
-    "-A FORWARD -j DOCKER-FORWARD\n"
-)
+_PRESENT = '-A FORWARD -i virbr0 -o eth0 -j ACCEPT'
+_ABSENT = '-A FORWARD -j DOCKER-USER'
+_NAT = [("default", "virbr0", True)]
 
 
 def test_forwarding_verdict_skips_when_nothing_is_forwarded():
-    status, _, needs_fix = checker.forwarding_verdict([], _WIPED, True, "")
+    status, _, needs_fix = checker.forwarding_verdict([], _ABSENT, True, "")
     assert status == checker.SKIP
     assert needs_fix is False
 
 
 def test_forwarding_verdict_flags_wiped_rules():
     status, detail, needs_fix = checker.forwarding_verdict(
-        [("default", "virbr0")], _WIPED, True, "")
+        _NAT, _ABSENT, True, "", policy_drop=True)
     assert status == checker.WARN
     assert needs_fix is True
     assert "default" in detail
@@ -196,74 +280,130 @@ def test_forwarding_verdict_flags_wiped_rules():
 def test_forwarding_verdict_flags_the_latent_case():
     """Rules are present, but they live in the table docker rebuilds."""
     status, detail, needs_fix = checker.forwarding_verdict(
-        [("default", "virbr0")], _HEALTHY, True, "iptables")
+        _NAT, _PRESENT, True, "iptables")
     assert status == checker.WARN
     assert needs_fix is True
     assert "wipes these rules" in detail
-    # policy is ACCEPT here, so the extra DROP warning must not appear
     assert "FORWARD policy is DROP" not in detail
 
 
 def test_forwarding_verdict_notes_a_drop_policy():
-    rules = _HEALTHY.replace("-P FORWARD ACCEPT", "-P FORWARD DROP")
     _, detail, _ = checker.forwarding_verdict(
-        [("default", "virbr0")], rules, True, "iptables")
+        _NAT, _PRESENT, True, "iptables", policy_drop=True)
     assert "FORWARD policy is DROP" in detail
 
 
-def test_forwarding_verdict_ok_once_libvirt_owns_its_table():
+def test_forwarding_verdict_catches_the_half_fixed_host():
+    """libvirt in its own table is not enough while a foreign chain drops.
+
+    This is the state the README calls out as "the step everyone misses":
+    firewall_backend switched, `iptables -P FORWARD ACCEPT` never run. The
+    rules are pristine and the guest is still dead.
+    """
+    status, detail, needs_fix = checker.forwarding_verdict(
+        _NAT, _PRESENT, True, "nftables", policy_drop=True)
+    assert status == checker.WARN
+    assert needs_fix is True
+    assert "still cannot forward" in detail
+
+
+def test_forwarding_verdict_ok_once_both_halves_are_done():
     status, _, needs_fix = checker.forwarding_verdict(
-        [("default", "virbr0")], _HEALTHY, True, "nftables")
+        _NAT, _PRESENT, True, "nftables", policy_drop=False)
     assert status == checker.OK
     assert needs_fix is False
 
 
 def test_forwarding_verdict_ok_without_docker():
     status, _, needs_fix = checker.forwarding_verdict(
-        [("default", "virbr0")], _HEALTHY, False, "")
+        _NAT, _PRESENT, False, "iptables")
     assert status == checker.OK
     assert needs_fix is False
 
 
 def test_forwarding_verdict_will_not_cry_wolf_on_a_partial_view():
-    """Unreadable ruleset => "unknown", never "wiped".
-
-    libvirt's nftables backend keeps its rules in a private table. If we could
-    not read it, their absence from `iptables -S` proves nothing.
-    """
+    """Unreadable ruleset => "unknown", never "wiped"."""
     status, detail, needs_fix = checker.forwarding_verdict(
-        [("default", "virbr0")], _WIPED, True, "", complete_view=False)
+        _NAT, _ABSENT, True, "", complete_view=False)
     assert status == checker.INFO
     assert needs_fix is False
     assert "could not be confirmed" in detail
 
 
-def test_forwarding_verdict_accepts_rules_from_the_nft_table():
-    """Rules found in libvirt's own nft table count as present."""
-    rules = (
-        "-P FORWARD DROP\n"
-        "-A FORWARD -j DOCKER-USER\n"
-        'table ip libvirt_network {\n'
-        '  chain forward {\n'
-        '    iifname "virbr0" accept\n'
-        "  }\n"
-        "}\n"
-    )
+def test_forwarding_verdict_reports_an_undetermined_backend():
+    status, detail, needs_fix = checker.forwarding_verdict(
+        _NAT, _PRESENT, False, "", complete_view=False)
+    assert status == checker.INFO
+    assert needs_fix is False
+    assert "backend could not be determined" in detail
+
+
+def test_forwarding_verdict_open_mode_is_never_called_wiped():
+    """libvirt writes no rules for mode='open'; absence proves nothing."""
     status, _, needs_fix = checker.forwarding_verdict(
-        [("default", "virbr0")], rules, True, "nftables")
+        [("lab", "virbr7", False)], _ABSENT, False, "nftables")
     assert status == checker.OK
     assert needs_fix is False
 
 
 def test_forwarding_verdict_bridge_match_is_not_a_substring():
-    """virbr10's rules must not vouch for virbr1.
-
-    Plain containment would report virbr1 as healthy here and hide a network
-    with no rules at all.
-    """
-    rules = "-P FORWARD DROP\n-A FORWARD -i virbr10 -o virbr10 -j ACCEPT\n"
+    """virbr10's rules must not vouch for virbr1."""
+    evidence = "-A FORWARD -i virbr10 -o virbr10 -j ACCEPT"
     status, detail, needs_fix = checker.forwarding_verdict(
-        [("lab", "virbr1")], rules, True, "")
+        [("lab", "virbr1", True)], evidence, True, "")
     assert status == checker.WARN
     assert needs_fix is True
     assert "lab" in detail
+
+
+# --------------------------------------------------------------------------- #
+# disruptive fixes are never applied unattended                               #
+# --------------------------------------------------------------------------- #
+class _Opts(object):
+    def __init__(self, yes=True, check_only=False):
+        self.yes = yes
+        self.check_only = check_only
+        self.runtime = "local"
+        self.verbose = False
+
+
+def _doctor(monkeypatch, stdin_isatty):
+    monkeypatch.setattr(checker.sys.stdin, "isatty", lambda: stdin_isatty,
+                        raising=False)
+    doctor = checker.Doctor.__new__(checker.Doctor)
+    doctor.opts = _Opts()
+    doctor.results = []
+    doctor.manual_steps = []
+    doctor.relogin_needed = False
+    doctor.use_color = False
+    doctor.interactive = True          # --yes implies this
+    return doctor
+
+
+def test_disruptive_fix_is_not_run_by_yes_without_a_terminal(monkeypatch):
+    """`yes | check_prerequisites.py --yes` must not bounce a container host."""
+    doctor = _doctor(monkeypatch, stdin_isatty=False)
+    ran = []
+    monkeypatch.setattr(doctor, "_run_fix", lambda fix: ran.append(fix) or True)
+    monkeypatch.setattr(doctor, "_ask", lambda prompt: pytest.fail(
+        "must not even ask without a terminal"))
+
+    fix = checker.Fix("restart docker", ["sudo systemctl restart docker"],
+                      disruptive=True)
+    result = checker.Result("Host forwarding", checker.WARN, "", fix)
+    doctor._handle_fix(result, lambda: (checker.WARN, "", fix))
+
+    assert ran == []
+    assert any("needs a terminal" in step for step in doctor.manual_steps)
+
+
+def test_non_disruptive_fix_still_honours_yes(monkeypatch):
+    doctor = _doctor(monkeypatch, stdin_isatty=False)
+    ran = []
+    monkeypatch.setattr(doctor, "_run_fix", lambda fix: ran.append(fix) or True)
+
+    fix = checker.Fix("install sshpass", ["sudo pacman -S sshpass"])
+    result = checker.Result("sshpass", checker.FAIL, "", fix)
+    doctor._handle_fix(result, lambda: (checker.OK, "installed", None))
+
+    assert len(ran) == 1

--- a/tests/test_check_prerequisites.py
+++ b/tests/test_check_prerequisites.py
@@ -130,3 +130,140 @@ def test_worst_status_severity_order():
 def test_fix_runnable_flag():
     assert checker.Fix("do a thing", commands=["echo hi"]).runnable is True
     assert checker.Fix("read a doc", commands=[]).runnable is False
+
+
+def test_fix_is_not_disruptive_by_default():
+    assert checker.Fix("install a package").disruptive is False
+    assert checker.Fix("restart docker", disruptive=True).disruptive is True
+
+
+# --------------------------------------------------------------------------- #
+# parse_firewall_backend                                                      #
+# --------------------------------------------------------------------------- #
+def test_parse_firewall_backend_reads_the_setting():
+    assert checker.parse_firewall_backend(
+        'firewall_backend = "nftables"\n') == ("nftables", True)
+    assert checker.parse_firewall_backend(
+        "firewall_backend = iptables\n") == ("iptables", True)
+
+
+def test_parse_firewall_backend_commented_out_still_means_supported():
+    """The shipped network.conf documents the option even when unset.
+
+    That is the signal we use to tell "libvirt supports this but nobody set
+    it" (fixable) apart from "this build has never heard of it" (not).
+    """
+    text = ('# firewall_backend = "nftables"\n'
+            "#\n"
+            "# Firewall backend to use...\n")
+    assert checker.parse_firewall_backend(text) == ("", True)
+
+
+def test_parse_firewall_backend_absent_means_unsupported():
+    assert checker.parse_firewall_backend("# some other option\n") == ("", False)
+
+
+# --------------------------------------------------------------------------- #
+# forwarding_verdict                                                          #
+# --------------------------------------------------------------------------- #
+_HEALTHY = (
+    "-P FORWARD ACCEPT\n"
+    "-A FORWARD -i virbr0 -o virbr0 -j ACCEPT\n"
+)
+_WIPED = (
+    "-P FORWARD DROP\n"
+    "-A FORWARD -j DOCKER-USER\n"
+    "-A FORWARD -j DOCKER-FORWARD\n"
+)
+
+
+def test_forwarding_verdict_skips_when_nothing_is_forwarded():
+    status, _, needs_fix = checker.forwarding_verdict([], _WIPED, True, "")
+    assert status == checker.SKIP
+    assert needs_fix is False
+
+
+def test_forwarding_verdict_flags_wiped_rules():
+    status, detail, needs_fix = checker.forwarding_verdict(
+        [("default", "virbr0")], _WIPED, True, "")
+    assert status == checker.WARN
+    assert needs_fix is True
+    assert "default" in detail
+    assert "NAT but never forward" in detail
+    assert "docker shares this table" in detail
+
+
+def test_forwarding_verdict_flags_the_latent_case():
+    """Rules are present, but they live in the table docker rebuilds."""
+    status, detail, needs_fix = checker.forwarding_verdict(
+        [("default", "virbr0")], _HEALTHY, True, "iptables")
+    assert status == checker.WARN
+    assert needs_fix is True
+    assert "wipes these rules" in detail
+    # policy is ACCEPT here, so the extra DROP warning must not appear
+    assert "FORWARD policy is DROP" not in detail
+
+
+def test_forwarding_verdict_notes_a_drop_policy():
+    rules = _HEALTHY.replace("-P FORWARD ACCEPT", "-P FORWARD DROP")
+    _, detail, _ = checker.forwarding_verdict(
+        [("default", "virbr0")], rules, True, "iptables")
+    assert "FORWARD policy is DROP" in detail
+
+
+def test_forwarding_verdict_ok_once_libvirt_owns_its_table():
+    status, _, needs_fix = checker.forwarding_verdict(
+        [("default", "virbr0")], _HEALTHY, True, "nftables")
+    assert status == checker.OK
+    assert needs_fix is False
+
+
+def test_forwarding_verdict_ok_without_docker():
+    status, _, needs_fix = checker.forwarding_verdict(
+        [("default", "virbr0")], _HEALTHY, False, "")
+    assert status == checker.OK
+    assert needs_fix is False
+
+
+def test_forwarding_verdict_will_not_cry_wolf_on_a_partial_view():
+    """Unreadable ruleset => "unknown", never "wiped".
+
+    libvirt's nftables backend keeps its rules in a private table. If we could
+    not read it, their absence from `iptables -S` proves nothing.
+    """
+    status, detail, needs_fix = checker.forwarding_verdict(
+        [("default", "virbr0")], _WIPED, True, "", complete_view=False)
+    assert status == checker.INFO
+    assert needs_fix is False
+    assert "could not be confirmed" in detail
+
+
+def test_forwarding_verdict_accepts_rules_from_the_nft_table():
+    """Rules found in libvirt's own nft table count as present."""
+    rules = (
+        "-P FORWARD DROP\n"
+        "-A FORWARD -j DOCKER-USER\n"
+        'table ip libvirt_network {\n'
+        '  chain forward {\n'
+        '    iifname "virbr0" accept\n'
+        "  }\n"
+        "}\n"
+    )
+    status, _, needs_fix = checker.forwarding_verdict(
+        [("default", "virbr0")], rules, True, "nftables")
+    assert status == checker.OK
+    assert needs_fix is False
+
+
+def test_forwarding_verdict_bridge_match_is_not_a_substring():
+    """virbr10's rules must not vouch for virbr1.
+
+    Plain containment would report virbr1 as healthy here and hide a network
+    with no rules at all.
+    """
+    rules = "-P FORWARD DROP\n-A FORWARD -i virbr10 -o virbr10 -j ACCEPT\n"
+    status, detail, needs_fix = checker.forwarding_verdict(
+        [("lab", "virbr1")], rules, True, "")
+    assert status == checker.WARN
+    assert needs_fix is True
+    assert "lab" in detail

--- a/tests/test_check_prerequisites.py
+++ b/tests/test_check_prerequisites.py
@@ -185,7 +185,7 @@ def test_iptables_forward_facts_keeps_only_forward_rules():
         "-A FORWARD -i virbr0 -o eth0 -j ACCEPT\n"
         "-A OUTPUT -o virbr9 -j ACCEPT\n"
     )
-    rules, policy_drop = checker.iptables_forward_facts(text)
+    rules, _drop_rules, policy_drop = checker.iptables_forward_facts(text)
     assert "virbr0" in rules
     # an OUTPUT rule must never vouch for a bridge's forwarding
     assert "virbr9" not in rules
@@ -203,16 +203,16 @@ def test_iptables_forward_facts_ignores_orphaned_libvirt_chains():
         "-A FORWARD -j DOCKER-USER\n"
         "-A LIBVIRT_FWI -d 192.168.122.0/24 -o virbr0 -j ACCEPT\n"
     )
-    rules, _ = checker.iptables_forward_facts(orphaned)
+    rules, _, _ = checker.iptables_forward_facts(orphaned)
     assert "virbr0" not in rules
 
     wired = "-A FORWARD -j LIBVIRT_FWX\n" + orphaned
-    rules, _ = checker.iptables_forward_facts(wired)
+    rules, _, _ = checker.iptables_forward_facts(wired)
     assert "virbr0" in rules
 
 
 def test_iptables_forward_facts_accept_policy():
-    _, policy_drop = checker.iptables_forward_facts("-P FORWARD ACCEPT\n")
+    _, _, policy_drop = checker.iptables_forward_facts("-P FORWARD ACCEPT\n")
     assert policy_drop is False
 
 
@@ -238,33 +238,106 @@ def test_nft_forward_facts_ignores_nat_and_mangle():
         {"rule": {"family": "ip", "table": "mangle", "chain": "POSTROUTING",
                   "expr": [{"match": {"right": "virbr0"}}]}},
     )
-    rules, policy_drop, libvirt_table, parsed = checker.nft_forward_facts(doc)
+    rules, _drops, policy_drop, libvirt_table, parsed = checker.nft_forward_facts(doc)
     assert "virbr0" not in rules
     assert policy_drop is False
     assert libvirt_table is False
     assert parsed is True
 
 
-def test_nft_forward_facts_collects_forward_chains_and_policy():
-    doc = _nft(
+def _libvirt_ruleset(bridge="virbr0", filter_policy="accept"):
+    """A ruleset shaped like libvirt's actual nftables backend.
+
+    libvirt's `forward` base chain only jumps; the rules naming the bridge sit
+    in guest_cross / guest_input / guest_output one hop below it. A collector
+    that stops at base chains sees nothing and calls a healthy host wiped.
+    """
+    return _nft(
+        {"metainfo": {"version": "1.0.9"}},
         {"table": {"family": "ip", "name": "libvirt_network"}},
         {"chain": {"family": "ip", "table": "libvirt_network", "name": "forward",
-                   "hook": "forward", "policy": "accept"}},
+                   "type": "filter", "hook": "forward", "policy": "accept"}},
         {"rule": {"family": "ip", "table": "libvirt_network", "chain": "forward",
-                  "expr": [{"match": {"right": "virbr0"}}]}},
+                  "expr": [{"jump": {"target": "guest_cross"}}]}},
+        {"rule": {"family": "ip", "table": "libvirt_network", "chain": "forward",
+                  "expr": [{"jump": {"target": "guest_output"}}]}},
+        {"chain": {"family": "ip", "table": "libvirt_network", "name": "guest_cross"}},
+        {"chain": {"family": "ip", "table": "libvirt_network", "name": "guest_output"}},
+        {"rule": {"family": "ip", "table": "libvirt_network", "chain": "guest_output",
+                  "expr": [{"match": {"left": {"meta": {"key": "iifname"}},
+                                      "right": bridge}},
+                           {"accept": None}]}},
+        {"table": {"family": "ip", "name": "filter"}},
         {"chain": {"family": "ip", "table": "filter", "name": "FORWARD",
-                   "hook": "forward", "policy": "drop"}},
+                   "type": "filter", "hook": "forward", "policy": filter_policy}},
     )
-    rules, policy_drop, libvirt_table, parsed = checker.nft_forward_facts(doc)
+
+
+def test_nft_forward_facts_follows_jumps_into_libvirt_guest_chains():
+    """Regression: base chains alone find nothing on the nftables backend."""
+    rules, _drops, policy_drop, libvirt_table, parsed = checker.nft_forward_facts(
+        _libvirt_ruleset())
     assert parsed is True
-    assert "virbr0" in rules
-    assert policy_drop is True
     assert libvirt_table is True
+    assert "virbr0" in rules
+    assert policy_drop is False
+
+
+def test_nft_forward_facts_does_not_follow_jumps_across_tables():
+    """A same-named chain in another table must not be pulled in."""
+    doc = _nft(
+        {"table": {"family": "ip", "name": "filter"}},
+        {"chain": {"family": "ip", "table": "filter", "name": "FORWARD",
+                   "type": "filter", "hook": "forward", "policy": "drop"}},
+        {"rule": {"family": "ip", "table": "filter", "chain": "FORWARD",
+                  "expr": [{"jump": {"target": "shared"}}]}},
+        {"rule": {"family": "ip", "table": "filter", "chain": "shared",
+                  "expr": [{"match": {"right": "virbr0"}}]}},
+        {"table": {"family": "ip", "name": "other"}},
+        {"rule": {"family": "ip", "table": "other", "chain": "shared",
+                  "expr": [{"match": {"right": "virbr9"}}]}},
+    )
+    rules, _, _, _, _ = checker.nft_forward_facts(doc)
+    assert "virbr0" in rules
+    assert "virbr9" not in rules
+
+
+def test_nft_forward_facts_reads_a_base_chain_policy():
+    rules, _drops, policy_drop, _, parsed = checker.nft_forward_facts(
+        _libvirt_ruleset(filter_policy="drop"))
+    assert parsed is True
+    assert policy_drop is True
+
+
+# --------------------------------------------------------------------------- #
+# the two halves composed -- parser output fed to the verdict                 #
+# --------------------------------------------------------------------------- #
+def _verdict_for(ruleset, networks=None):
+    rules, drops, policy_drop, libvirt_table, _ = checker.nft_forward_facts(ruleset)
+    return checker.forwarding_verdict(
+        networks or [("default", "virbr0", True)], rules, True,
+        "nftables" if libvirt_table else "", policy_drop, drops)
+
+
+def test_healthy_nftables_host_is_not_called_wiped():
+    """The blocker, end to end: both halves done, nothing to report."""
+    status, detail, needs_fix = _verdict_for(_libvirt_ruleset())
+    assert status == checker.OK, detail
+    assert needs_fix is False
+
+
+def test_half_fixed_nftables_host_is_caught_end_to_end():
+    """Backend migrated but the DROP policy never cleared."""
+    status, detail, needs_fix = _verdict_for(_libvirt_ruleset(filter_policy="drop"))
+    assert status == checker.WARN
+    assert "cannot forward" in detail
+    assert "only the policy is left" in detail
+    assert needs_fix is True
 
 
 def test_nft_forward_facts_survives_garbage():
-    assert checker.nft_forward_facts("not json") == ("", False, False, False)
-    assert checker.nft_forward_facts("") == ("", False, False, False)
+    assert checker.nft_forward_facts("not json") == ("", "", False, False, False)
+    assert checker.nft_forward_facts("") == ("", "", False, False, False)
 
 
 def test_nft_forward_facts_reports_an_unrecognised_shape():
@@ -273,9 +346,9 @@ def test_nft_forward_facts_reports_an_unrecognised_shape():
     Silently returning empty facts would mark a healthy nftables host as
     sharing docker's table and offer it a disruptive fix.
     """
-    assert checker.nft_forward_facts('{"something_else": []}')[3] is False
-    assert checker.nft_forward_facts('{"nftables": []}')[3] is False
-    assert checker.nft_forward_facts("[]")[3] is False
+    assert checker.nft_forward_facts('{"something_else": []}')[4] is False
+    assert checker.nft_forward_facts('{"nftables": []}')[4] is False
+    assert checker.nft_forward_facts("[]")[4] is False
 
 
 # --------------------------------------------------------------------------- #
@@ -294,7 +367,7 @@ def test_forwarding_verdict_skips_when_nothing_is_forwarded():
 
 def test_forwarding_verdict_flags_wiped_rules():
     status, detail, needs_fix = checker.forwarding_verdict(
-        _NAT, _ABSENT, True, "", policy_drop=True)
+        _NAT, _ABSENT, True, "", policy_drop=True, drop_evidence=_ABSENT)
     assert status == checker.WARN
     assert needs_fix is True
     assert "default" in detail
@@ -314,7 +387,8 @@ def test_forwarding_verdict_flags_the_latent_case():
 
 def test_forwarding_verdict_notes_a_drop_policy():
     _, detail, _ = checker.forwarding_verdict(
-        _NAT, _PRESENT, True, "iptables", policy_drop=True)
+        _NAT, _PRESENT, True, "iptables", policy_drop=True,
+        drop_evidence=_PRESENT)
     assert "FORWARD policy is DROP" in detail
 
 
@@ -326,10 +400,11 @@ def test_forwarding_verdict_catches_the_half_fixed_host():
     rules are pristine and the guest is still dead.
     """
     status, detail, needs_fix = checker.forwarding_verdict(
-        _NAT, _PRESENT, True, "nftables", policy_drop=True)
+        _NAT, _PRESENT, True, "nftables", policy_drop=True, drop_evidence="")
     assert status == checker.WARN
     assert needs_fix is True
-    assert "still cannot forward" in detail
+    assert "cannot forward" in detail
+    assert "only the policy is left" in detail
 
 
 def test_forwarding_verdict_ok_once_both_halves_are_done():
@@ -432,3 +507,97 @@ def test_non_disruptive_fix_still_honours_yes(monkeypatch):
     doctor._handle_fix(result, lambda: (checker.OK, "installed", None))
 
     assert len(ran) == 1
+
+
+# --------------------------------------------------------------------------- #
+# _forwarding_fix command construction                                        #
+# --------------------------------------------------------------------------- #
+def _fix_doctor(monkeypatch, configured="", supported=True):
+    doctor = checker.Doctor.__new__(checker.Doctor)
+    monkeypatch.setattr(doctor, "_libvirt_fw_backend",
+                        lambda: (configured, supported), raising=False)
+    monkeypatch.setattr(doctor, "_libvirt_net_unit",
+                        lambda: "virtnetworkd", raising=False)
+    return doctor
+
+
+def test_fix_migrates_libvirt_before_touching_docker(monkeypatch):
+    """Ordering is a safety property, not a style choice.
+
+    The docker half ends in a docker restart -- the event that wipes the
+    shared table. Running it before libvirt has moved out means an abort at
+    any later step leaves a merely at-risk host actually broken.
+    """
+    fix = _fix_doctor(monkeypatch)._forwarding_fix("iptables", True)
+    joined = " | ".join(fix.commands)
+    assert joined.index("network.conf") < joined.index("daemon.json"), joined
+    assert joined.index("restart virtnetworkd") < joined.index("restart docker")
+    assert fix.disruptive is True
+
+
+def test_fix_reapplies_libvirt_rules_when_nothing_else_would(monkeypatch):
+    """Acute case with the backend already migrated.
+
+    Without a restart the guided fix "succeeds" and the re-probe still
+    reports the network as wiped.
+    """
+    doctor = _fix_doctor(monkeypatch, configured="nftables")
+    fix = doctor._forwarding_fix("nftables", True, wiped=True)
+    assert fix.commands[-1] == "sudo systemctl restart virtnetworkd"
+
+
+def test_fix_does_not_double_restart_when_migrating(monkeypatch):
+    fix = _fix_doctor(monkeypatch)._forwarding_fix("iptables", True, wiped=True)
+    assert fix.commands.count("sudo systemctl restart virtnetworkd") == 1
+
+
+def test_fix_offers_nothing_runnable_when_docker_is_not_the_cause(monkeypatch):
+    """A DROP policy with no docker means some other owner set it."""
+    doctor = _fix_doctor(monkeypatch, configured="nftables")
+    fix = doctor._forwarding_fix("nftables", False)
+    assert fix.commands == []
+    assert fix.disruptive is False
+    assert "find what set" in fix.description
+
+
+def test_fix_leaves_daemon_json_alone_without_a_docker_daemon(monkeypatch):
+    fix = _fix_doctor(monkeypatch)._forwarding_fix("iptables", False)
+    assert not any("daemon.json" in cmd for cmd in fix.commands)
+    assert any("network.conf" in cmd for cmd in fix.commands)
+
+
+def test_fix_appends_the_backend_with_a_leading_newline(monkeypatch):
+    """A network.conf with no trailing newline must not have lines fused."""
+    fix = _fix_doctor(monkeypatch)._forwarding_fix("iptables", False)
+    sed = next(cmd for cmd in fix.commands if "firewall_backend" in cmd)
+    assert '\\nfirewall_backend' in sed
+
+
+# --------------------------------------------------------------------------- #
+# open-mode networks                                                          #
+# --------------------------------------------------------------------------- #
+def test_open_mode_network_is_flagged_when_the_policy_drops():
+    """libvirt writes no rules for mode='open', so a DROP kills it outright."""
+    status, detail, needs_fix = checker.forwarding_verdict(
+        [("lab", "virbr7", False)], _ABSENT, False, "nftables",
+        policy_drop=True, drop_evidence=_ABSENT)
+    assert status == checker.WARN
+    assert "lab" in detail
+    assert "drops by default" in detail
+    assert needs_fix is True
+
+
+def test_open_mode_network_is_fine_when_something_accepts_it():
+    # the accept lives in the dropping chain itself, so the policy is moot --
+    # this is what boxman's own routed-network FORWARD rules look like
+    evidence = "-A FORWARD -i virbr7 -j ACCEPT"
+    status, detail, needs_fix = checker.forwarding_verdict(
+        [("lab", "virbr7", False)], evidence, False, "nftables",
+        policy_drop=True, drop_evidence=evidence)
+    assert status == checker.OK, detail
+    assert needs_fix is False
+
+
+def test_wiped_networks_ignores_networks_that_expect_no_rules():
+    nets = [("lab", "virbr7", False), ("default", "virbr0", True)]
+    assert checker.wiped_networks(nets, "") == ["default"]


### PR DESCRIPTION
## The failure

Docker and libvirt both write the iptables `filter` table. Docker rebuilds it on every restart and leaves the FORWARD policy at `DROP`, so libvirt's rules — and boxman's own routed-network `FORWARD` rules from `apply_route_iptables_rule()` (`net.py:1051-1057`) — are swept away, with nothing to re-apply them.

Every base chain on the forward hook is evaluated and **a drop in any of them is final**; an accept only ends its own chain. So libvirt's ACCEPTs cannot rescue a packet docker's policy drops. The nat table usually survives, so guests keep NATing while forwarding is dead — which is why this presents as a slow or flaky network rather than a firewall fault.

```text
  guest ──▶ [ FORWARD HOOK ] ──▶ internet
                   │
                   ├─ ip filter FORWARD .............. policy DROP   ◀ docker
                   │    LIBVIRT_FWI/FWO/FWX  ▓ empty, no jumps ▓  ◀ wiped
                   └─ ip6 filter FORWARD ............. policy accept
                        verdict = DROP
```

Observed live on a production host: `LIBVIRT_FW*` chains present but empty with no FORWARD jumps, while `LIBVIRT_PRT` MASQUERADE rules were intact.

## What this adds

**`Host forwarding (docker/libvirt)` check** in the prerequisites checker, catching two states:

- **acute** — an active NAT/routed network with no forwarding rules anywhere
- **latent** — rules present, but sharing the table docker rebuilds; the next `systemctl restart docker` takes them

with a guided fix that gives libvirt its own nftables table (`firewall_backend = "nftables"`) and stops docker forcing the policy (`ip-forward-no-drop`).

**`## Advanced` README section** documenting the failure mode, both diagrams, the commands, and why firewalld fixes neither half.

## Two bugs found by running it, not reading it

The first live run **failed** — it reported all five active networks as wiped on a libvirt 11.2.0 host. False positive: libvirt ≥ 11 defaults to the **nftables** backend, so its rules live in a private nft table `iptables -S` cannot see. Fixed by:

- reading **both** `iptables -S` and `nft list ruleset`, and deriving the effective backend from a live `table ip libvirt_*` rather than trusting `network.conf` — which is unset precisely when the answer is "nftables"
- reporting **INFO "could not be confirmed either way"** when either ruleset is unreadable, never WARN. A checker that could not look in libvirt's private table must not claim the rules are gone.

Separately, `bridge not in rules` was a substring test — `virbr10`'s rules would have vouched for `virbr1`. Now word-anchored, with a regression test.

## Design calls

- **`--yes` does not run this fix.** It restarts docker. Disruptive fixes always prompt, even under `--yes`, so an unattended run cannot bounce a container host. Every edited file gets a `.boxman-bak` copy first.
- **Severity is WARN, not FAIL**, matching the existing "Default libvirt network" check. Exit code unaffected.
- **`--runtime docker` is out of scope**, and documented as such: `docker-compose.yml` has no `network_mode: host`, so the inner libvirt has its own netns and its own tables.

## Testing

- **1267 passed**, 113 deselected (was 1254) — 13 new tests over the pure helpers, matching that file's existing style
- Checker exercised end-to-end with `--check-only` on an Arch/libvirt 11.2.0 host: correctly returns INFO where `nft` is outside the NOPASSWD scope

**Not verified:** the acute (true-positive) path has unit coverage only. I intended to validate it on a host with genuinely wiped rules where both `nft` and `iptables` are readable non-interactively, but that host's tunnel went down mid-attempt. Worth one run before relying on the WARN wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)