### PR TITLE
fix: prefix-glob disk sweep deletes other VMs' disks (#85 item 1)

### DIFF
--- a/src/boxman/providers/libvirt/disk_cleanup.py
+++ b/src/boxman/providers/libvirt/disk_cleanup.py
@@ -35,13 +35,16 @@ def remove_vm_disks(
     - ``<workdir>/<vm_name>.qcow2`` — the boot disk.
     - ``<workdir>/<vm_name>_<d['name']>.qcow2`` for each entry in
       *extra_disks*.
-    - Every remaining path matching ``<workdir>/<vm_name>*`` that is a
-      regular file — this sweeps up snapshot overlay files
-      (``<vm>.2026-04-21T08:00:00``, ``<vm>.1772465824``) and memory
-      snapshot files (``<vm>_snapshot_<name>.raw``).
+    - Snapshot artifacts matching ``<workdir>/<vm_name>.<suffix>``
+      (overlay files such as ``<vm>.2026-04-21T08:00:00`` or
+      ``<vm>.1772465824`` — note the literal dot separator) and
+      ``<workdir>/<vm_name>_snapshot_*`` (memory snapshot ``.raw``
+      files).
 
-    Other VMs' disks in the same workdir are untouched because the glob
-    is anchored at the VM name prefix.
+    Other VMs' disks in the same workdir are untouched because every
+    pattern requires the VM name to be followed by a literal ``.`` or
+    ``_snapshot_`` separator — a VM named ``web`` never matches files
+    belonging to a VM named ``web2``.
 
     Args:
         workdir: Directory the VM's files live in. ``~`` is expanded.
@@ -66,12 +69,20 @@ def remove_vm_disks(
         if os.path.isfile(disk_path):
             os.remove(disk_path)
 
-    # Snapshot artifacts: overlay files with timestamp/hash suffixes and
-    # memory snapshot .raw files — anything prefixed with vm_name that is
-    # still on disk after the named qcow2 files were removed above.
-    for leftover in _glob.glob(os.path.join(workdir, f'{vm_name}*')):
-        if os.path.isfile(leftover):
-            log.info(f"removing snapshot artifact: {leftover}")
-            os.remove(leftover)
+    # Snapshot artifacts: overlay files named ``<vm>.<suffix>`` (the
+    # literal dot separates the VM name from the timestamp/hash suffix)
+    # and memory snapshot files ``<vm>_snapshot_*``. A plain
+    # ``<vm>*`` prefix glob would also match disks of other VMs whose
+    # name starts with this VM's name (e.g. destroying ``web`` would
+    # delete ``web2.qcow2``), so both patterns require a separator.
+    patterns = (
+        os.path.join(workdir, f'{vm_name}.*'),
+        os.path.join(workdir, f'{vm_name}_snapshot_*'),
+    )
+    for pattern in patterns:
+        for leftover in _glob.glob(pattern):
+            if os.path.isfile(leftover):
+                log.info(f"removing snapshot artifact: {leftover}")
+                os.remove(leftover)
 
     return True

--- a/tests/test_libvirt_disk_cleanup.py
+++ b/tests/test_libvirt_disk_cleanup.py
@@ -57,6 +57,43 @@ class TestRemoveVmDisks:
         assert (tmp_path / "vm02.qcow2").exists()
         assert (tmp_path / "other-vm.qcow2").exists()
 
+    def test_prefix_collision_leaves_longer_named_vm_untouched(
+        self, tmp_path: Path
+    ):
+        """Regression for issue #85 item 1: destroying ``web`` in a
+        shared workdir must not delete files of a VM named ``web2``."""
+        # web's own files
+        (tmp_path / "web.qcow2").write_bytes(b"x")
+        (tmp_path / "web_data.qcow2").write_bytes(b"x")
+        (tmp_path / "web.1772465824").write_bytes(b"x")
+        (tmp_path / "web_snapshot_baseline.raw").write_bytes(b"x")
+        # web2's files — same workdir, name starts with "web"
+        (tmp_path / "web2.qcow2").write_bytes(b"x")
+        (tmp_path / "web2_data.qcow2").write_bytes(b"x")
+        (tmp_path / "web2.1772465824").write_bytes(b"x")
+        (tmp_path / "web2_snapshot_baseline.raw").write_bytes(b"x")
+
+        remove_vm_disks(str(tmp_path), "web", [{"name": "data"}])
+
+        for leftover in tmp_path.glob("web.*"):
+            assert not leftover.exists()
+        assert not (tmp_path / "web.qcow2").exists()
+        assert not (tmp_path / "web_data.qcow2").exists()
+        assert not (tmp_path / "web_snapshot_baseline.raw").exists()
+        # every web2 file survives
+        assert (tmp_path / "web2.qcow2").exists()
+        assert (tmp_path / "web2_data.qcow2").exists()
+        assert (tmp_path / "web2.1772465824").exists()
+        assert (tmp_path / "web2_snapshot_baseline.raw").exists()
+
+    def test_unrelated_named_extra_disk_survives(self, tmp_path: Path):
+        """Extra disks are only removed when named in extra_disks."""
+        (tmp_path / "vm01.qcow2").write_bytes(b"x")
+        (tmp_path / "vm01_orphan.qcow2").write_bytes(b"x")
+        remove_vm_disks(str(tmp_path), "vm01", [])
+        assert not (tmp_path / "vm01.qcow2").exists()
+        assert (tmp_path / "vm01_orphan.qcow2").exists()
+
     def test_tolerates_missing_files(self, tmp_path: Path):
         # Nothing in tmp_path — must not raise
         assert remove_vm_disks(str(tmp_path), "ghost-vm", []) is True


### PR DESCRIPTION
Refs #85

**Item 1** — `disk_cleanup.py`: `remove_vm_disks` swept `<workdir>/<vm>*` after removing named disks. Workdirs are per-cluster and shared, so destroying VM `web` deleted `web2.qcow2` and all `web2*` snapshot overlays (data loss).

Fix: replace the prefix glob with separator-anchored patterns — overlays `<vm>.<suffix>` (literal dot) and memory snapshots `<vm>_snapshot_*`. Boot disk and named extra disks were already exact-name.

Regression test: `web`/`web2` sharing a workdir — destroying `web` leaves every `web2` file intact.