### PR TITLE
fix: exact network name match in destroy/undefine checks (#85 item 13)

### DIFF
--- a/src/boxman/providers/libvirt/net.py
+++ b/src/boxman/providers/libvirt/net.py
@@ -781,16 +781,19 @@ class Network(VirshCommand):
             True if successful, False otherwise
         """
         try:
-            # check if network exists first
-            result = self.execute("net-list", "--all", "| grep -q " + self.name, warn=True)
-            if result.return_code != 0:
+            # check if network exists first -- by exact name, not a grep
+            # substring ('prod' must not match 'prod-backup')
+            listed = self._listed_networks()
+            if listed is None:
+                self.logger.error(
+                    f"could not ask libvirt whether network {self.name} exists")
+                return False
+            if self.name not in listed:
                 self.logger.info(f"network {self.name} does not exist, nothing to destroy")
                 return True
 
-            # check if network is active
-            result = self.execute("net-list", "| grep -q " + self.name, warn=True)
-            if result.return_code == 0:
-                # the network is active, stop it
+            # destroy only when the network itself is active
+            if self.is_active():
                 self.execute("net-destroy", self.name)
                 self.logger.info(f"network {self.name} destroyed successfully")
 
@@ -807,9 +810,13 @@ class Network(VirshCommand):
             True if successful, False otherwise
         """
         try:
-            # check if network exists
-            result = self.execute("net-list", "--all", "| grep -q " + self.name, warn=True)
-            if result.return_code != 0:
+            # check if network exists (exact name match, as in destroy_network)
+            listed = self._listed_networks()
+            if listed is None:
+                self.logger.error(
+                    f"could not ask libvirt whether network {self.name} exists")
+                return False
+            if self.name not in listed:
                 self.logger.info(f"Network {self.name} does not exist, nothing to undefine")
                 return True
 

--- a/tests/test_libvirt_net.py
+++ b/tests/test_libvirt_net.py
@@ -414,3 +414,80 @@ class TestNetworkInterfaceConfigureFromConfig:
             })
         _args, kwargs = add.call_args
         assert kwargs["model"] == "virtio"
+
+
+class TestDestroyUndefineExactName:
+    """Existence checks must match the network name exactly.
+
+    Regression tests for issue #85 item 13: the checks used to be
+    ``net-list | grep -q <name>``, so destroying ``prod`` while
+    ``prod-backup`` existed matched the grep and spuriously ran
+    ``net-destroy prod`` against an undefined network, failing the remove.
+    """
+
+    @pytest.fixture
+    def net(self) -> Network:
+        with patch.object(Network, "find_available_bridge_name",
+                          return_value="virbr9"):
+            return Network(name="prod", info={}, assign_new_bridge=True,
+                           provider_config={"use_sudo": False})
+
+    def test_destroy_skips_net_destroy_when_only_superstring_exists(self, net):
+        calls = []
+
+        def listed(active_only: bool = False):
+            return ["prod-backup"]
+
+        with patch.object(net, "_listed_networks", side_effect=listed), \
+             patch.object(net, "execute",
+                          side_effect=lambda *a, **k: calls.append(a) or _result()):
+            assert net.destroy_network() is True
+        assert not any(args[0] == "net-destroy" for args in calls)
+
+    def test_destroy_runs_net_destroy_when_name_matches_exactly(self, net):
+        calls = []
+
+        def listed(active_only: bool = False):
+            return ["prod", "prod-backup"]
+
+        with patch.object(net, "_listed_networks", side_effect=listed), \
+             patch.object(net, "execute",
+                          side_effect=lambda *a, **k: calls.append(a) or _result()):
+            assert net.destroy_network() is True
+        assert ("net-destroy", "prod") in calls
+
+    def test_destroy_defined_but_inactive_is_left_alone(self, net):
+        calls = []
+
+        def listed(active_only: bool = False):
+            return [] if active_only else ["prod"]
+
+        with patch.object(net, "_listed_networks", side_effect=listed), \
+             patch.object(net, "execute",
+                          side_effect=lambda *a, **k: calls.append(a) or _result()):
+            assert net.destroy_network() is True
+        assert not any(args[0] == "net-destroy" for args in calls)
+
+    def test_destroy_fails_when_libvirt_cannot_be_asked(self, net):
+        with patch.object(net, "_listed_networks", return_value=None):
+            assert net.destroy_network() is False
+
+    def test_undefine_skips_net_undefine_when_only_superstring_exists(self, net):
+        calls = []
+        with patch.object(net, "_listed_networks", return_value=["prod-backup"]), \
+             patch.object(net, "execute",
+                          side_effect=lambda *a, **k: calls.append(a) or _result()):
+            assert net.undefine_network() is True
+        assert not any(args[0] == "net-undefine" for args in calls)
+
+    def test_undefine_runs_net_undefine_when_name_matches_exactly(self, net):
+        calls = []
+        with patch.object(net, "_listed_networks", return_value=["prod"]), \
+             patch.object(net, "execute",
+                          side_effect=lambda *a, **k: calls.append(a) or _result()):
+            assert net.undefine_network() is True
+        assert ("net-undefine", "prod") in calls
+
+    def test_undefine_fails_when_libvirt_cannot_be_asked(self, net):
+        with patch.object(net, "_listed_networks", return_value=None):
+            assert net.undefine_network() is False


### PR DESCRIPTION
Refs #85 (item 13).

**Problem:** `destroy_network()`/`undefine_network()` checked existence with `net-list --all | grep -q <name>` — a substring match with no `-x`/anchors, live regex metacharacters, and an unquoted name. Destroying `prod` while `prod-backup` existed matched the grep, so boxman ran `net-destroy prod` against an undefined network and failed the whole remove operation.

**Fix:** reuse `_listed_networks()` (`net-list --all --name` + exact line match) — the same helper `exists()` and `is_active()` already use. Destroy uses `is_active()` for the active check. When libvirt cannot be asked at all (`None`), the methods now fail instead of silently reporting "nothing to destroy".

**Tests:** `tests/test_libvirt_net.py::TestDestroyUndefineExactName` — `prod` vs `prod-backup` exactness for destroy (active/inactive) and undefine, plus the libvirt-unreachable path. 59 passed in `tests/test_libvirt_net.py`; ruff shows no new violations vs `origin/polish`.