### PR TITLE
fix: get_latest_snapshot raises on VMs with no snapshot (#85 item 12)

### DIFF
--- a/src/boxman/providers/libvirt/snapshot.py
+++ b/src/boxman/providers/libvirt/snapshot.py
@@ -447,7 +447,8 @@ class SnapshotManager:
         Returns:
             str: Name of the current snapshot, or None if none exists
         """
-        result = self.virsh.execute("snapshot-current", vm_name, "--name")
+        result = self.virsh.execute(
+            "snapshot-current", vm_name, "--name", warn=True)
         if result.ok:
             name = result.stdout.strip()
             return name if name else None

--- a/tests/test_libvirt_snapshot.py
+++ b/tests/test_libvirt_snapshot.py
@@ -117,6 +117,15 @@ class TestGetLatestSnapshot:
         with patch.object(sm.virsh, "execute", return_value=_result(ok=False)):
             assert sm.get_latest_snapshot("vm01") is None
 
+    def test_passes_warn_true(self, sm: SnapshotManager):
+        """Regression for issue #85 item 12: without warn=True a VM with
+        no current snapshot makes virsh exit non-zero and execute raise
+        RuntimeError instead of returning None."""
+        with patch.object(sm.virsh, "execute",
+                          return_value=_result(stdout="snap1\n")) as execute:
+            sm.get_latest_snapshot("vm01")
+        assert execute.call_args.kwargs.get("warn") is True
+
 
 class TestValidateSnapshot:
 


### PR DESCRIPTION
Refs #85

**Item 12** — `snapshot.py`: `get_latest_snapshot` ran `virsh snapshot-current --name` without `warn=True`; virsh exits non-zero when the VM has no current snapshot, so `boxman snapshot restore <vm>` on a never-snapshotted VM crashed with a RuntimeError traceback instead of hitting the graceful "no snapshot found" paths in the manager.

Fix: pass `warn=True`; the existing `not result.ok` branch returns `None` (the documented contract). No manager.py change needed — its None-handling already exists.

Test: pins that `warn=True` is passed to `virsh.execute`; the None-on-failure path was already covered.