### PR TITLE
fix: packaging hygiene (#85 item 39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,14 @@ The main goal is to avoid having many dependencies and to keep it simple and cus
 ### Native (Host) Installation
 
 ```bash
-pip install -r requirements.txt
 pip install .
+```
+
+For docker-compose clusters, also install the optional extra (provides the
+Docker SDK needed by Ansible's `community.docker` connection plugin):
+
+```bash
+pip install '.[docker-compose]'
 ```
 
 ### Docker-based Libvirt Environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Boxman (box manager) – declarative VM/container provisioning vi
 authors = ["Mher Kazandjian <mherkazandjian@gmail.com>"]
 license = "MIT"
 readme = "README.md"
-homepage = "https://boxman.example.com"
+homepage = "https://github.com/mherkazandjian/boxman"
 packages = [
     { include = "boxman", from = "src" },
 ]
@@ -15,13 +15,16 @@ include = [
     { path = "containers/docker/Makefile", format = ["sdist", "wheel"] },
     { path = "containers/docker/supervisord.conf", format = ["sdist", "wheel"] },
     { path = "containers/docker/entrypoint.sh", format = ["sdist", "wheel"] },
-    { path = "containers/docker/.env", format = ["sdist", "wheel"] },
     { path = "containers/docker/README.md", format = ["sdist", "wheel"] },
-    { path = "boxes/**/*", format = ["sdist", "wheel"] },
-]
-exclude = [
-    "containers/docker/data/**",
-    "**/.boxman/**",
+    # Enumerate the file types boxes actually ship instead of `boxes/**/*`:
+    # a blanket include would sweep in gitignored, generated `*.rendered.yml`
+    # files (which can hold local secrets), and poetry's `exclude` does not
+    # override an explicit `include`.
+    { path = "boxes/**/conf.yml", format = ["sdist", "wheel"] },
+    { path = "boxes/**/site.yml", format = ["sdist", "wheel"] },
+    { path = "boxes/**/*.md", format = ["sdist", "wheel"] },
+    { path = "boxes/**/*.j2", format = ["sdist", "wheel"] },
+    { path = "boxes/**/*.html", format = ["sdist", "wheel"] },
 ]
 
 [tool.poetry.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-pyaml
-multiprocess
-invoke
-lxml
-typer
-requests
-gdown

--- a/src/boxman/metadata.py
+++ b/src/boxman/metadata.py
@@ -1,19 +1,7 @@
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _get_version
 
-package = 'boxman'
-project = 'boxman'
-project_no_spaces = project.replace(' ', '')
-
 try:
-    version = _get_version(package)
+    version = _get_version('boxman')
 except PackageNotFoundError:
     version = '0.0.0.dev0'
-
-description = 'Boxman (box manager) – declarative VM/container provisioning via YAML'
-authors = ['John Smith']
-authors_string = ', '.join(authors)
-emails = ['john@example.com']
-license = 'MIT'
-copyright = '20XX ' + authors_string
-url = 'https://boxman.example.com'


### PR DESCRIPTION
Refs #85 (item 39).

## Changes

1. **Deleted `requirements.txt`** — it listed `pyaml` (wrong package; the code imports `yaml` = PyYAML), `multiprocess`, `typer`, `requests`, `gdown` — none imported anywhere in `src/` (verified by grep) — and omitted real hard deps Jinja2 and passlib. `pyproject.toml` is the single source of truth. README Quick Start now uses just `pip install .`, with a note on the optional `pip install '.[docker-compose]'` extra (matches the `[tool.poetry.extras]` declaration, guarded by `tests/test_packaging.py`).

2. **Wheel/sdist no longer leak gitignored files.**
   - Removed the force-include of `containers/docker/.env` (gitignored; could ship local values).
   - Replaced the blanket `boxes/**/*` include with the exact patterns boxes actually ship (`conf.yml`, `site.yml`, `*.md`, `*.j2`, `*.html`). Poetry's `exclude` cannot override an explicit `include` (confirmed empirically: an `exclude = ["**/*.rendered.yml"]` first attempt still shipped a planted rendered file), so narrowing the include is the only reliable fix. The blanket include was sweeping in ~19 generated, gitignored `conf.rendered.yml` files containing demo plaintext passwords.
   - `boxes/libvirt-truenas-scale-cloudinit-bootstrap/`: **not tracked on `polish`** — nothing to remove in git. A stale untracked copy (only a leftover `conf.rendered.yml`) exists in the main checkout at `/home/mher/projects/boxman/boxman/boxes/`; deleting that local leftover is outside this PR.

3. **Placeholder metadata removed** — `src/boxman/metadata.py` shipped `authors = ['John Smith']`, `john@example.com`, `'20XX'`, `https://boxman.example.com`. Grep confirmed only `metadata.version` is consumed (`scripts/app.py:369`, `scripts/cli_parser.py:43`, `tests/test_cli_smoke.py:73`), so the module is now just the importlib.metadata version lookup with its fallback. `pyproject.toml` `homepage` now points at `https://github.com/mherkazandjian/boxman`.

## Verification

- Built wheel + sdist via `poetry.core.masonry.api` (poetry-core 2.4.1, isolated venv; no `poetry`/`build` on PATH) **with a planted gitignored `boxes/__leaktest/conf.rendered.yml` and `containers/docker/.env` present on disk**: `unzip -l dist/*.whl | grep -E '\.env|rendered'` and the equivalent `tar tzf` on the sdist both come back **empty**. The wheel still ships all 40 tracked box files (23 `conf.yml`/`site.yml`, 9 `README.md`, 6 `.j2`, 1 `.html`) and the six tracked `containers/docker` files. Planted files were removed after the check.
- `pytest tests/test_cli_smoke.py tests/test_packaging.py -q` → 44 passed.
- Full unit suite (`pytest tests -q`, integration/slow deselected) → 1673 passed.
- `ruff check src/boxman/metadata.py` → clean.

Nothing left unverified.