### PR TITLE
fix: route cloud-init guest-agent calls through VirshCommand (#85 item 5)

### DIFF
--- a/src/boxman/providers/libvirt/cloudinit.py
+++ b/src/boxman/providers/libvirt/cloudinit.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import shutil
 import tempfile
 import time
@@ -584,6 +585,19 @@ class CloudInitTemplate:
         finally:
             shutil.rmtree(tmp_dir, ignore_errors=True)
 
+    def _agent_command(self, payload: str) -> invoke.runners.Result:
+        """
+        Run a QEMU guest-agent command against the template VM.
+
+        Routes through :class:`VirshCommand` instead of a raw ``virsh …``
+        shell string so the configured libvirt ``uri``, a ``virsh_cmd``
+        override, sudo, and runtime wrapping all apply — a raw string would
+        silently hit the default local libvirt daemon.
+        """
+        return self.virsh.execute(
+            "qemu-agent-command", self.template_name, shlex.quote(payload),
+            hide=True, warn=True)
+
     def _wait_cloudinit_fallback(self, seconds: int | None = None) -> None:
         """
         Time-based fallback: wait *seconds* for cloud-init to finish when
@@ -603,10 +617,7 @@ class CloudInitTemplate:
         for i in range(0, seconds, 10):
             time.sleep(10)
             # Confirm the VM is still responsive
-            ping = self.virsh.execute_shell(
-                f"virsh qemu-agent-command {self.template_name} "
-                f"'{{\"execute\":\"guest-ping\"}}'",
-                hide=True, warn=True)
+            ping = self._agent_command('{"execute":"guest-ping"}')
             if not ping.ok:
                 self.logger.warning(
                     f"guest agent stopped responding after {i + 10}s — "
@@ -644,9 +655,7 @@ class CloudInitTemplate:
                 '"test -f ' + marker_path + ' && echo MARKER_FOUND || echo MARKER_MISSING"],'
                 '"capture-output":true}}'
             )
-            res = self.virsh.execute_shell(
-                f"virsh qemu-agent-command {self.template_name} '{check_cmd}'",
-                hide=True, warn=True)
+            res = self._agent_command(check_cmd)
 
             if res.ok:
                 found = self._guest_exec_output(res.stdout)
@@ -683,10 +692,7 @@ class CloudInitTemplate:
                 f'"arguments":{{"pid":{pid}}}}}'
             )
             for _ in range(10):
-                status_res = self.virsh.execute_shell(
-                    f"virsh qemu-agent-command {self.template_name} "
-                    f"'{status_cmd}'",
-                    hide=True, warn=True)
+                status_res = self._agent_command(status_cmd)
                 if not status_res.ok:
                     return None
                 ret = json.loads(
@@ -711,9 +717,7 @@ class CloudInitTemplate:
             + log_script
             + '"],"capture-output":true}}'
         )
-        res = self.virsh.execute_shell(
-            f"virsh qemu-agent-command {self.template_name} '{exec_cmd}'",
-            hide=True, warn=True)
+        res = self._agent_command(exec_cmd)
         if not res.ok:
             return
         output = self._guest_exec_output(res.stdout)
@@ -730,9 +734,7 @@ class CloudInitTemplate:
         agent_poll_interval = 2
         agent_attempts = max(1, self.cloudinit_agent_timeout // agent_poll_interval)
         for i in range(agent_attempts):
-            result = self.virsh.execute_shell(
-                f"virsh qemu-agent-command {self.template_name} '{{\"execute\":\"guest-ping\"}}'",
-                hide=True, warn=True)
+            result = self._agent_command('{"execute":"guest-ping"}')
             if result.ok:
                 agent_up = True
                 break
@@ -775,9 +777,7 @@ class CloudInitTemplate:
                     '{"path":"/bin/sh","arg":["-c","echo ok"],'
                     '"capture-output":true}}'
                 )
-                res = self.virsh.execute_shell(
-                    f"virsh qemu-agent-command {self.template_name} '{exec_cmd}'",
-                    hide=True, warn=True)
+                res = self._agent_command(exec_cmd)
                 if res.ok:
                     guest_exec_ok = True
                     self.logger.info("guest-exec is available")

--- a/tests/test_libvirt_cloudinit.py
+++ b/tests/test_libvirt_cloudinit.py
@@ -254,7 +254,7 @@ class TestCloudinitTimeouts:
 
     def test_poll_done_marker_honours_configured_timeout(self, tmp_path: Path):
         t = _make_template(tmp_path, cloudinit_done_timeout=7)
-        with patch.object(t.virsh, "execute_shell", return_value=_result(ok=False)), \
+        with patch.object(t.virsh, "execute", return_value=_result(ok=False)), \
                 patch(self.SLEEP) as sleep:
             assert t._poll_done_marker("/var/log/done") is False
         # back-off 1 + 2 + 4 == the 7s cap
@@ -262,14 +262,14 @@ class TestCloudinitTimeouts:
 
     def test_explicit_max_wait_still_wins(self, tmp_path: Path):
         t = _make_template(tmp_path, cloudinit_done_timeout=900)
-        with patch.object(t.virsh, "execute_shell", return_value=_result(ok=False)), \
+        with patch.object(t.virsh, "execute", return_value=_result(ok=False)), \
                 patch(self.SLEEP) as sleep:
             assert t._poll_done_marker("/var/log/done", max_wait=3) is False
         assert sum(c.args[0] for c in sleep.call_args_list) == 3
 
     def test_fallback_wait_honours_configured_timeout(self, tmp_path: Path):
         t = _make_template(tmp_path, cloudinit_fallback_timeout=30)
-        with patch.object(t.virsh, "execute_shell", return_value=_result(ok=True)), \
+        with patch.object(t.virsh, "execute", return_value=_result(ok=True)), \
                 patch(self.SLEEP) as sleep:
             t._wait_cloudinit_fallback()
         assert sleep.call_count == 3          # range(0, 30, 10)
@@ -279,13 +279,19 @@ class TestCloudinitTimeouts:
         # then a zero-length blind wait, then the shutdown path
         t = _make_template(
             tmp_path, cloudinit_agent_timeout=10, cloudinit_fallback_timeout=0)
-        with patch.object(t.virsh, "execute_shell",
-                          return_value=_result(ok=False)) as shell, \
-                patch.object(t.virsh, "execute",
-                             return_value=_result(stdout="shut off")), \
+        pings = 0
+
+        def fake_execute(*args, **kwargs):
+            nonlocal pings
+            if args and args[0] == "qemu-agent-command":
+                pings += 1
+                return _result(ok=False)
+            return _result(stdout="shut off")
+
+        with patch.object(t.virsh, "execute", side_effect=fake_execute), \
                 patch(self.SLEEP):
             assert t.verify_and_shutdown() is True
-        assert shell.call_count == 5
+        assert pings == 5
 
     def test_guest_exec_loop_scales_with_timeout(self, tmp_path: Path):
         # agent answers guest-ping but guest-exec stays blacklisted:
@@ -293,18 +299,22 @@ class TestCloudinitTimeouts:
         t = _make_template(
             tmp_path, cloudinit_guest_exec_timeout=20,
             cloudinit_fallback_timeout=0)
-        calls: list[str] = []
+        exec_probes = 0
 
-        def fake_shell(cmd, **kwargs):
-            calls.append(cmd)
-            return _result(ok="guest-ping" in cmd)
+        def fake_execute(*args, **kwargs):
+            nonlocal exec_probes
+            if args and args[0] == "qemu-agent-command":
+                payload = args[2]
+                if "guest-exec" in payload:
+                    exec_probes += 1
+                    return _result(ok=False)
+                return _result(ok=True)  # guest-ping
+            return _result(stdout="shut off")
 
-        with patch.object(t.virsh, "execute_shell", side_effect=fake_shell), \
-                patch.object(t.virsh, "execute",
-                             return_value=_result(stdout="shut off")), \
+        with patch.object(t.virsh, "execute", side_effect=fake_execute), \
                 patch(self.SLEEP):
             assert t.verify_and_shutdown() is True
-        assert sum("guest-exec" in c for c in calls) == 4
+        assert exec_probes == 4
 
 
 class TestVerificationFailureLeavesCleanState:
@@ -329,23 +339,21 @@ class TestVerificationFailureLeavesCleanState:
             # domstate is asked whether the VM went down
             if args and args[0] == "domstate":
                 return _result(stdout="shut off")
+            if args and args[0] == "qemu-agent-command":
+                payload = args[2]
+                # the agent answers, guest-exec works, the marker never appears
+                return _result(ok=("guest-ping" in payload or "guest-exec" in payload),
+                               stdout='{"return": {"pid": 1}}')
             return _result()
 
-        def fake_shell(cmd, **kwargs):
-            calls.append(("shell", cmd))
-            # the agent answers, guest-exec works, the marker never appears
-            return _result(ok=("guest-ping" in cmd or "guest-exec" in cmd),
-                           stdout='{"return": {"pid": 1}}')
-
         t.virsh.execute = fake_execute
-        t.virsh.execute_shell = fake_shell
         return t, calls
 
     def test_a_missing_marker_still_shuts_the_vm_down(self, tmp_path: Path):
         t, calls = self._template(tmp_path, cloudinit_done_timeout=1)
         with patch(self.SLEEP):
             assert t.verify_and_shutdown() is False
-        assert any(args[0] == "shutdown" for args in calls if args and args[0] != "shell"), \
+        assert any(args[0] == "shutdown" for args in calls), \
             "the template VM was left running"
 
     def test_no_marker_configured_is_not_a_hard_failure(self, tmp_path: Path):
@@ -354,10 +362,13 @@ class TestVerificationFailureLeavesCleanState:
         t = _make_template(tmp_path, cloudinit_userdata="#cloud-config\n",
                            cloudinit_fallback_timeout=0)
         assert t.cloudinit_done_marker is None
-        t.virsh.execute = lambda *a, **k: _result(stdout="shut off")
-        t.virsh.execute_shell = lambda cmd, **k: _result(
-            ok=("guest-ping" in cmd or "guest-exec" in cmd),
-            stdout='{"return": {"pid": 1}}')
+
+        def fake_execute(*args, **kwargs):
+            if args and args[0] == "qemu-agent-command":
+                return _result(ok=True)
+            return _result(stdout="shut off")
+
+        t.virsh.execute = fake_execute
         with patch(self.SLEEP):
             assert t.verify_and_shutdown() is True
 
@@ -375,3 +386,60 @@ class TestVerificationFailureLeavesCleanState:
         assert DEFAULT_DONE_MARKER not in DEFAULT_USER_DATA.split("runcmd:")[0]
         last_runcmd = DEFAULT_USER_DATA.rstrip().splitlines()[-1]
         assert DEFAULT_DONE_MARKER in last_runcmd, last_runcmd
+
+
+class TestAgentCommand:
+    """
+    Guest-agent calls must go through VirshCommand (#85 item 5).
+
+    A raw ``virsh qemu-agent-command …`` shell string ignores the configured
+    ``uri`` (e.g. qemu+ssh://…) and the ``virsh_cmd`` override, so template
+    creation with a non-default URI polled the wrong libvirt daemon.
+    """
+
+    SHELL_RUN = "boxman.providers.libvirt.commands._shell_run"
+
+    def _run_capture(self, t: CloudInitTemplate, payload: str) -> str:
+        with patch(self.SHELL_RUN, return_value=_result()) as run:
+            t._agent_command(payload)
+        return run.call_args.args[0]
+
+    def test_custom_uri_is_used(self, tmp_path: Path):
+        t = _make_template(tmp_path, provider_config={
+            "use_sudo": False,
+            "uri": "qemu+ssh://root@example.com/system",
+        })
+        cmd = self._run_capture(t, '{"execute":"guest-ping"}')
+        assert "-c qemu+ssh://root@example.com/system" in cmd
+
+    def test_virsh_cmd_override_is_used(self, tmp_path: Path):
+        t = _make_template(tmp_path, provider_config={
+            "use_sudo": False,
+            "virsh_cmd": "/usr/local/bin/virsh",
+        })
+        cmd = self._run_capture(t, '{"execute":"guest-ping"}')
+        assert cmd.startswith("/usr/local/bin/virsh ")
+
+    def test_sudo_is_applied(self, tmp_path: Path):
+        t = _make_template(tmp_path, provider_config={"use_sudo": True})
+        cmd = self._run_capture(t, '{"execute":"guest-ping"}')
+        assert cmd.startswith("sudo virsh -c qemu:///system ")
+
+    def test_payload_is_a_single_quoted_token(self, tmp_path: Path):
+        t = _make_template(tmp_path)
+        cmd = self._run_capture(t, '{"execute":"guest-ping"}')
+        assert "qemu-agent-command ubuntu-template " in cmd
+        assert cmd.endswith('\'{"execute":"guest-ping"}\'')
+
+    def test_verify_and_shutdown_routes_pings_through_virsh(self, tmp_path: Path):
+        # the polling loop must call virsh.execute("qemu-agent-command", …),
+        # not a raw shell string
+        t = _make_template(
+            tmp_path, cloudinit_agent_timeout=2, cloudinit_fallback_timeout=0,
+            cloudinit_userdata="#cloud-config\n",  # no implicit done marker
+        )
+        with patch.object(t.virsh, "execute",
+                          return_value=_result(stdout="shut off")) as ex, \
+                patch("boxman.providers.libvirt.cloudinit.time.sleep"):
+            assert t.verify_and_shutdown() is True
+        assert ex.call_args_list[0].args[0] == "qemu-agent-command"


### PR DESCRIPTION
Refs #85 (item 5).

Six sites in `cloudinit.py` ran a raw `virsh qemu-agent-command …` shell string, bypassing `VirshCommand.build_command`, so the configured `uri` (e.g. `qemu+ssh://…`) and `virsh_cmd` override were ignored and commands hit the default local libvirt daemon. Template creation with a non-default URI polled the wrong daemon until timeout.

Fix: new `CloudInitTemplate._agent_command(payload)` helper goes through `virsh.execute()` so URI/sudo/runtime wrapping apply (payload shlex-quoted); all 6 call sites migrated, and the duplicated guest-exec payload plumbing removed.

Tests: `tests/test_libvirt_cloudinit.py` — new `TestAgentCommand` class (custom uri appears as `-c <uri>`, `virsh_cmd` override, sudo, payload quoting, verify_and_shutdown routing); existing wait-loop tests updated to mock at the new call level. 44 passed. No new ruff violations (one pre-existing F401 actually fixed by this change).