### PR TITLE
fix: standardize user-facing errors on ConfigError; safe task-command assembly (#85 item 17)

### DIFF
--- a/src/boxman/runtime/__init__.py
+++ b/src/boxman/runtime/__init__.py
@@ -6,6 +6,7 @@ A *runtime* controls **where** provider commands are executed:
   - ``docker``         – inside a boxman docker-compose container
 """
 
+from boxman.exceptions import ConfigError
 from boxman.runtime.base import RuntimeBase
 from boxman.runtime.docker_compose import DockerComposeRuntime
 from boxman.runtime.local import LocalRuntime
@@ -23,7 +24,7 @@ def create_runtime(name: str, **kwargs) -> RuntimeBase:
         A RuntimeBase subclass instance.
 
     Raises:
-        ValueError: If the runtime name is unknown.
+        ConfigError: If the runtime name is unknown.
     """
     runtimes = {
         "local": LocalRuntime,
@@ -31,7 +32,7 @@ def create_runtime(name: str, **kwargs) -> RuntimeBase:
         "docker-compose": DockerComposeRuntime,
     }
     if name not in runtimes:
-        raise ValueError(
+        raise ConfigError(
             f"unknown runtime '{name}', supported: {', '.join(runtimes)}"
         )
     return runtimes[name](**kwargs)

--- a/src/boxman/task_runner.py
+++ b/src/boxman/task_runner.py
@@ -78,10 +78,12 @@ Usage::
 
 import os
 import re
+import shlex
 import subprocess
 from typing import Any
 
 from boxman import log
+from boxman.exceptions import ConfigError
 from boxman.utils.env_loader import load_workspace_env
 
 
@@ -130,7 +132,7 @@ class TaskRunner:
         clusters = config.get("clusters", {})
         if cluster_name:
             if cluster_name not in clusters:
-                raise ValueError(f"cluster '{cluster_name}' not found in config")
+                raise ConfigError(f"cluster '{cluster_name}' not found in config")
             self.cluster_name = cluster_name
         else:
             self.cluster_name = next(iter(clusters)) if clusters else None
@@ -212,26 +214,28 @@ class TaskRunner:
             The exit code of the task process.
 
         Raises:
-            KeyError: If the task is not defined.
+            ConfigError: If the task is not defined.
         """
         if task_name not in self.tasks:
             available = ", ".join(self.tasks.keys()) if self.tasks else "(none)"
-            raise KeyError(
+            raise ConfigError(
                 f"task '{task_name}' not found. Available tasks: {available}"
             )
 
         task = self.tasks[task_name]
         command = task["command"].strip()
 
-        # Substitute {placeholder} markers with values from task_flags
+        # Substitute {placeholder} markers with values from task_flags.
+        # Whitespace adjacent to a removed placeholder collapses to a single
+        # space; spacing anywhere else — e.g. inside quoted arguments of a
+        # flag value — is preserved as written.
         def _replace(match):
-            name = match.group(1)
-            if task_flags and name in task_flags:
-                return task_flags[name]
-            return ""
+            lead, name, trail = match.groups()
+            if task_flags and task_flags.get(name):
+                return f"{lead}{task_flags[name]}{trail}"
+            return " " if lead and trail else ""
 
-        command = re.sub(r"\{(\w+)\}", _replace, command)
-        command = re.sub(r" {2,}", " ", command).strip()
+        command = re.sub(r"( ?)\{(\w+)\}( ?)", _replace, command).strip()
 
         # Append extra arguments (everything after -- on the CLI).
         # "quoted" mode joins them into a single shell-quoted argument
@@ -239,7 +243,6 @@ class TaskRunner:
         if extra_args:
             mode = task.get("extra_args_mode", "append")
             if mode == "quoted":
-                import shlex
                 command = command + " " + shlex.quote(" ".join(extra_args))
             else:
                 command = command + " " + " ".join(extra_args)
@@ -296,7 +299,9 @@ class TaskRunner:
         if extra_args:
             command = command + " " + " ".join(extra_args)
 
-        ansible_cmd = f'ansible all -m ansible.builtin.shell -a "{command}"'
+        ansible_cmd = (
+            "ansible all -m ansible.builtin.shell -a " + shlex.quote(command)
+        )
         if ansible_flags:
             ansible_cmd = ansible_cmd + " " + ansible_flags
 

--- a/src/boxman/utils/jinja_env.py
+++ b/src/boxman/utils/jinja_env.py
@@ -15,6 +15,8 @@ import os
 
 from jinja2 import Environment, FileSystemLoader
 
+from boxman.exceptions import ConfigError
+
 
 def env(var_name: str, default: str = "") -> str:
     """
@@ -29,12 +31,13 @@ def env_required(var_name: str, message: str = None) -> str:
     """
     Return the value of environment variable *var_name*.
 
-    Raises ``ValueError`` if the variable is not set or is empty.
+    Raises :class:`~boxman.exceptions.ConfigError` if the variable is not
+    set or is empty.
     """
     value = os.environ.get(var_name)
     if not value:
         msg = message or f"required environment variable '{var_name}' is not set"
-        raise ValueError(msg)
+        raise ConfigError(msg)
     return value
 
 

--- a/tests/test_jinja_env.py
+++ b/tests/test_jinja_env.py
@@ -6,6 +6,7 @@ import os
 import pytest
 import yaml
 
+from boxman.exceptions import BoxmanError, ConfigError
 from boxman.utils.jinja_env import env, env_required, env_is_set, create_jinja_env
 from boxman.manager import BoxmanManager
 
@@ -41,17 +42,23 @@ class TestEnvRequiredFunction:
 
     def test_raises_when_unset(self, monkeypatch):
         monkeypatch.delenv("BOXMAN_TEST_VAR", raising=False)
-        with pytest.raises(ValueError, match="not set"):
+        with pytest.raises(ConfigError, match="not set"):
             env_required("BOXMAN_TEST_VAR")
 
     def test_raises_with_custom_message(self, monkeypatch):
         monkeypatch.delenv("BOXMAN_TEST_VAR", raising=False)
-        with pytest.raises(ValueError, match="provide BOXMAN_TEST_VAR"):
+        with pytest.raises(ConfigError, match="provide BOXMAN_TEST_VAR"):
             env_required("BOXMAN_TEST_VAR", "provide BOXMAN_TEST_VAR")
 
     def test_raises_when_empty(self, monkeypatch):
         monkeypatch.setenv("BOXMAN_TEST_VAR", "")
-        with pytest.raises(ValueError):
+        with pytest.raises(ConfigError):
+            env_required("BOXMAN_TEST_VAR")
+
+    def test_config_error_is_a_boxman_error(self, monkeypatch):
+        """app.py maps BoxmanError → log.error + exit 2 (no traceback)."""
+        monkeypatch.delenv("BOXMAN_TEST_VAR", raising=False)
+        with pytest.raises(BoxmanError):
             env_required("BOXMAN_TEST_VAR")
 
 
@@ -125,7 +132,7 @@ class TestJinjaTemplateRendering:
 
         jinja_env = create_jinja_env(str(tmp_path))
         template = jinja_env.get_template("test.yml")
-        with pytest.raises(ValueError, match="set MY_PASSWORD!"):
+        with pytest.raises(ConfigError, match="set MY_PASSWORD!"):
             template.render()
 
     def test_env_is_set_in_template(self, tmp_path, monkeypatch):
@@ -205,7 +212,7 @@ class TestBoxmanManagerLoadConfigWithJinja:
         )
 
         mgr = BoxmanManager()
-        with pytest.raises(ValueError, match="not set"):
+        with pytest.raises(ConfigError, match="not set"):
             mgr.load_config(str(conf))
 
     def test_load_config_conditional_with_env_is_set(self, tmp_path, monkeypatch):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4,6 +4,7 @@ Tests for boxman.runtime – runtime factory, wrapping, and config injection.
 
 import pytest
 from unittest.mock import patch, MagicMock
+from boxman.exceptions import BoxmanError, ConfigError
 from boxman.runtime import create_runtime
 from boxman.runtime.local import LocalRuntime
 from boxman.runtime.docker_compose import DockerComposeRuntime
@@ -22,7 +23,12 @@ class TestCreateRuntime:
         assert rt.name == "docker-compose"
 
     def test_unknown_raises(self):
-        with pytest.raises(ValueError, match="unknown runtime"):
+        with pytest.raises(ConfigError, match="unknown runtime"):
+            create_runtime("aws-magic")
+
+    def test_unknown_raises_boxman_error(self):
+        """app.py maps BoxmanError → log.error + exit 2 (no traceback)."""
+        with pytest.raises(BoxmanError):
             create_runtime("aws-magic")
 
 

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -11,6 +11,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
+from boxman.exceptions import BoxmanError, ConfigError
 from boxman.utils.env_loader import source_env_file, load_workspace_env
 from boxman.task_runner import TaskRunner
 from boxman.manager import BoxmanManager
@@ -264,7 +265,13 @@ class TestTaskRunner:
 
     def test_run_nonexistent_task_raises(self, basic_config):
         runner = TaskRunner(basic_config)
-        with pytest.raises(KeyError, match="not found"):
+        with pytest.raises(ConfigError, match="not found"):
+            runner.run("nonexistent")
+
+    def test_run_nonexistent_task_is_boxman_error(self, basic_config):
+        """app.py maps BoxmanError → log.error + exit 2 (no traceback)."""
+        runner = TaskRunner(basic_config)
+        with pytest.raises(BoxmanError):
             runner.run("nonexistent")
 
     def test_run_task_executes_command(self, basic_config, tmp_path):
@@ -300,7 +307,7 @@ class TestTaskRunner:
         exit_code = runner.run_command("whoami")
         assert exit_code == 0
         called_cmd = mock_run.call_args[0][0]
-        assert called_cmd == 'ansible all -m ansible.builtin.shell -a "whoami"'
+        assert called_cmd == 'ansible all -m ansible.builtin.shell -a whoami'
 
     @patch("boxman.task_runner.subprocess.run")
     def test_run_command_adhoc_with_ansible_flags(self, mock_run, basic_config, tmp_path):
@@ -309,7 +316,19 @@ class TestTaskRunner:
         exit_code = runner.run_command("whoami", ansible_flags="--limit node01")
         assert exit_code == 0
         called_cmd = mock_run.call_args[0][0]
-        assert called_cmd == 'ansible all -m ansible.builtin.shell -a "whoami" --limit node01'
+        assert called_cmd == 'ansible all -m ansible.builtin.shell -a whoami --limit node01'
+
+    @patch("boxman.task_runner.subprocess.run")
+    def test_run_command_adhoc_quotes_command(self, mock_run, basic_config):
+        """The user command is shlex-quoted so embedded quotes/spaces
+        can't break out of the ansible -a argument."""
+        mock_run.return_value = MagicMock(returncode=0)
+        runner = TaskRunner(basic_config)
+        runner.run_command('echo "hi"; rm -rf /')
+        called_cmd = mock_run.call_args[0][0]
+        assert called_cmd == (
+            "ansible all -m ansible.builtin.shell -a 'echo \"hi\"; rm -rf /'"
+        )
 
     def test_sets_infra_from_project(self, basic_config):
         runner = TaskRunner(basic_config)
@@ -320,7 +339,7 @@ class TestTaskRunner:
         assert runner.cluster_name == "cluster_1"
 
     def test_invalid_cluster_raises(self, basic_config):
-        with pytest.raises(ValueError, match="not found"):
+        with pytest.raises(ConfigError, match="not found"):
             TaskRunner(basic_config, cluster_name="nonexistent")
 
     def test_no_tasks_section(self, tmp_path):
@@ -653,6 +672,24 @@ class TestTaskRunnerFlagsPassing:
             task_flags={"flags": "-v"},
         )
         assert cmd == "mycommand -v 'arg1 arg2 arg3'"
+
+
+    # ------------------------------------------------------------------
+    # 13. Intentional spacing inside quoted args is preserved
+    # ------------------------------------------------------------------
+
+    def test_double_space_inside_quoted_flag_value_preserved(self, config):
+        """Regression: the old collapse-all-double-spaces pass corrupted
+        intentional spacing inside quoted arguments."""
+        self._add_task(config, "cmd", "echo {message} done")
+        cmd = self._run(config, "cmd", task_flags={"message": "'hello  world'"})
+        assert cmd == "echo 'hello  world' done"
+
+    def test_double_space_in_command_template_preserved(self, config):
+        """Spacing written into the command itself is left untouched."""
+        self._add_task(config, "cmd", 'echo "a  b" {flags}')
+        cmd = self._run(config, "cmd")
+        assert cmd == 'echo "a  b"'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #85 (item 17, G5 portion).

## What
app.py maps `BoxmanError` → clean `log.error` + exit 2, but several user-fixable config problems raised bare builtins → raw tracebacks. Fixed in G5-owned files:

- `TaskRunner.run`: unknown task `KeyError` → `ConfigError` (src/boxman/task_runner.py)
- `TaskRunner.__init__`: unknown `--cluster` `ValueError` → `ConfigError` (same file, same class of problem)
- `env_required()`: `ValueError` → `ConfigError` (src/boxman/utils/jinja_env.py)
- `create_runtime()`: unknown runtime `ValueError` → `ConfigError` (src/boxman/runtime/__init__.py)

Also in task_runner.py:
- Removed the `re.sub(r" {2,}", " ", command)` pass that collapsed intentional double spaces inside quoted args; whitespace adjacent to a *removed* `{placeholder}` still collapses, so unfilled-placeholder commands stay clean.
- `run_command` now `shlex.quote`s the user command interpolated into `ansible ... -a ...` instead of wrapping it in raw double quotes.

## NOT included (other group's file)
The manager.py part of item 17 — `load_config` `FileNotFoundError` → `ConfigError` — is owned by another group and deliberately untouched here.

## Tests
- Updated existing assertions (`ValueError`/`KeyError` → `ConfigError`) in test_jinja_env.py, test_runtime.py, test_task_runner.py.
- New regression tests: unknown task/cluster/runtime raise `ConfigError` (and are `BoxmanError` instances); double spaces inside quoted flag values/command templates are preserved; `run_command` shell-quotes embedded quotes/semicolons.
- Full unit suite: 1679 passed, 141 deselected (integration/slow excluded).
- ruff: no new violations on changed files (13 pre-existing, 13 after).