### PR TITLE
fix: storage compact can run while QEMU holds the disk (#85 item 18)

### DIFF
--- a/src/boxman/providers/libvirt/storage.py
+++ b/src/boxman/providers/libvirt/storage.py
@@ -28,6 +28,7 @@ from boxman import log
 from boxman.loggers.logger import is_verbose
 
 from .commands import LibVirtCommandBase, VirshCommand
+from .destroy_vm import DestroyVM
 
 
 def vm_disk_paths(
@@ -132,6 +133,18 @@ class StorageManager:
             return False
         return "running" in result.stdout
 
+    def is_shut_off(self, vm_name: str) -> bool:
+        """
+        True only when the domain is fully "shut off" (or gone).
+
+        Stricter than ``not is_running()``: a *paused* or *in shutdown*
+        domain no longer reads as "running" but its QEMU process is still
+        alive and holding the disk — compacting the image then corrupts
+        it. Reuses :meth:`DestroyVM.is_vm_shut_off` for the check.
+        """
+        return DestroyVM(
+            vm_name, provider_config=self.provider_config).is_vm_shut_off()
+
     def is_libguestfs_available(self) -> bool:
         """Whether ``virt-sparsify`` is reachable in the configured runtime."""
         result = self.cmd.execute_shell(
@@ -173,7 +186,7 @@ class StorageManager:
     # ── vm state transitions ────────────────────────────────────────────
 
     def shutdown_and_wait(self, vm_name: str, timeout_s: int = 120) -> bool:
-        if not self.is_running(vm_name):
+        if self.is_shut_off(vm_name):
             return True
         self.logger.info(f"shutting down vm {vm_name} (timeout {timeout_s}s)")
         result = self.virsh.execute("shutdown", vm_name, warn=True)
@@ -183,7 +196,7 @@ class StorageManager:
             return False
         deadline = time.time() + timeout_s
         while time.time() < deadline:
-            if not self.is_running(vm_name):
+            if self.is_shut_off(vm_name):
                 return True
             time.sleep(2)
         self.logger.warning(

--- a/tests/test_libvirt_storage.py
+++ b/tests/test_libvirt_storage.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from boxman.providers.libvirt.destroy_vm import DestroyVM
 from boxman.providers.libvirt.storage import StorageManager, vm_disk_paths
 
 
@@ -322,32 +323,73 @@ class TestConvert:
         assert "rm -f" in shell.call_args_list[1].args[0]
 
 
+class TestIsShutOff:
+
+    def test_true_when_shut_off(self, sm: StorageManager):
+        with patch.object(DestroyVM, "execute",
+                          return_value=_result(stdout="shut off\n")):
+            assert sm.is_shut_off("vm01") is True
+
+    def test_true_when_domain_gone(self, sm: StorageManager):
+        with patch.object(DestroyVM, "execute",
+                          return_value=_result(ok=False, stderr="not found")):
+            assert sm.is_shut_off("vm01") is True
+
+    def test_false_when_paused(self, sm: StorageManager):
+        """Regression for issue #85 item 18: a paused VM reads as 'not
+        running' but QEMU still holds the disk — compacting it would
+        corrupt the image."""
+        with patch.object(DestroyVM, "execute",
+                          return_value=_result(stdout="paused\n")):
+            assert sm.is_shut_off("vm01") is False
+
+    def test_false_when_in_shutdown(self, sm: StorageManager):
+        """Regression for issue #85 item 18: 'in shutdown' is not
+        'shut off' — QEMU is still alive."""
+        with patch.object(DestroyVM, "execute",
+                          return_value=_result(stdout="in shutdown\n")):
+            assert sm.is_shut_off("vm01") is False
+
+
 class TestShutdownAndWait:
 
-    def test_noop_when_not_running(self, sm: StorageManager):
-        with patch.object(sm, "is_running", return_value=False), \
+    def test_noop_when_shut_off(self, sm: StorageManager):
+        with patch.object(sm, "is_shut_off", return_value=True), \
              patch.object(sm.virsh, "execute") as exe:
             assert sm.shutdown_and_wait("vm01") is True
         exe.assert_not_called()
 
+    def test_paused_vm_is_shut_down_not_skipped(self, sm: StorageManager):
+        """Regression for issue #85 item 18: a paused VM must not take
+        the 'already stopped' shortcut — shutdown must be issued and the
+        wait must hold until 'shut off'."""
+        shut_off_states = iter([False, True])  # paused, then shut off
+        with patch.object(sm, "is_shut_off",
+                          side_effect=lambda _vm: next(shut_off_states)), \
+             patch.object(sm.virsh, "execute", return_value=_result()) as exe, \
+             patch("boxman.providers.libvirt.storage.time.sleep"):
+            assert sm.shutdown_and_wait("vm01", timeout_s=10) is True
+        verbs = [c.args[0] for c in exe.call_args_list]
+        assert "shutdown" in verbs
+
     def test_success_when_vm_stops_in_time(self, sm: StorageManager):
-        # First is_running True (initial check), then False after shutdown
-        running_states = iter([True, False])
-        with patch.object(sm, "is_running",
-                          side_effect=lambda _vm: next(running_states)), \
+        # First is_shut_off False (initial check), then True after shutdown
+        shut_off_states = iter([False, True])
+        with patch.object(sm, "is_shut_off",
+                          side_effect=lambda _vm: next(shut_off_states)), \
              patch.object(sm.virsh, "execute", return_value=_result()), \
              patch("boxman.providers.libvirt.storage.time.sleep"):
             assert sm.shutdown_and_wait("vm01", timeout_s=10) is True
 
     def test_destroys_after_timeout(self, sm: StorageManager):
-        # is_running stays True forever — must fall through to destroy
+        # is_shut_off stays False forever — must fall through to destroy
         time_values = [0]  # always before deadline=5 on entry, after on second check
 
         def fake_time():
             time_values[0] += 100
             return time_values[0]
 
-        with patch.object(sm, "is_running", return_value=True), \
+        with patch.object(sm, "is_shut_off", return_value=False), \
              patch.object(sm.virsh, "execute", return_value=_result()) as exe, \
              patch("boxman.providers.libvirt.storage.time.time",
                    side_effect=fake_time), \


### PR DESCRIPTION
Refs #85

**Item 18** — `storage.py`: `shutdown_and_wait` gated on `is_running` (`"running" in domstate`); a paused or in-shutdown VM reads as "not running", so `qemu-img convert … && mv` ran on an image a live QEMU still held.

Fix: new `StorageManager.is_shut_off()` reuses `DestroyVM.is_vm_shut_off` semantics (true only for "shut off" or a gone domain); both the initial shortcut and the wait loop in `shutdown_and_wait` now gate on it.

Tests: `TestIsShutOff` pins paused/in-shutdown → False, shut-off/gone → True; `TestShutdownAndWait` updated to the new seam plus a regression proving a paused VM gets a shutdown issued instead of the no-op shortcut.