### PR TITLE
fix: let libvirtd own NAT iptables rules, unhardcode sudo (#85 item 14)

### DIFF
--- a/src/boxman/providers/libvirt/net.py
+++ b/src/boxman/providers/libvirt/net.py
@@ -13,7 +13,7 @@ from jinja2 import Environment, FileSystemLoader
 from boxman import log
 
 from . import net_reconcile
-from .commands import LibVirtCommandBase, VirshCommand
+from .commands import VirshCommand
 
 
 class Network(VirshCommand):
@@ -736,12 +736,13 @@ class Network(VirshCommand):
             self.execute("net-start", self.name)
             self.execute("net-autostart", self.name)
 
-            # apply appropriate network configuration based on type
+            # apply appropriate network configuration based on type. NAT
+            # needs nothing from boxman: libvirtd installs the masquerade
+            # and FORWARD rules for <forward mode='nat'/> itself when the
+            # network starts (and removes them when it stops)
             if self.forward_mode == 'route':
                 self.apply_route_iptables_rule()
-            elif self.forward_mode == 'nat':
-                self.apply_nat_config()
-            else:
+            elif self.forward_mode != 'nat':
                 raise RuntimeError(f"Unsupported forward mode: {self.forward_mode}")
 
             return True
@@ -844,11 +845,12 @@ class Network(VirshCommand):
         if not self.undefine_network():
             return False
 
-        # remove iptables rules if any
+        # remove iptables rules if any. NAT needs no cleanup: the rules are
+        # libvirtd's own and go away with the network
         if self.forward_mode == 'route':
             return self.remove_route_iptables_rule()
         elif self.forward_mode == 'nat':
-            return self.remove_nat_config()
+            return True
         else:
             raise RuntimeError(f"Unsupported forward mode: {self.forward_mode}")
 
@@ -1001,22 +1003,24 @@ class Network(VirshCommand):
             br_name = self.bridge_name
             self.logger.info(f"removing route isolation rules for bridge {br_name}")
 
+            # no embedded 'sudo': execute_shell routes that decision through
+            # _should_use_sudo_for_command, so use_sudo: false is honoured
             if not self._ensure_rule(
                     self,
-                    f"sudo iptables -C FORWARD -i {br_name} -o {br_name} -j ACCEPT",
-                    f"sudo iptables -D FORWARD -i {br_name} -o {br_name} -j ACCEPT",
+                    f"iptables -C FORWARD -i {br_name} -o {br_name} -j ACCEPT",
+                    f"iptables -D FORWARD -i {br_name} -o {br_name} -j ACCEPT",
                     present=False):
                 return False
             if not self._ensure_rule(
                     self,
-                    f"sudo iptables -C INPUT  -i {br_name} -j DROP",
-                    f"sudo iptables -D INPUT  -i {br_name} -j DROP",
+                    f"iptables -C INPUT  -i {br_name} -j DROP",
+                    f"iptables -D INPUT  -i {br_name} -j DROP",
                     present=False):
                 return False
             if not self._ensure_rule(
                     self,
-                    f"sudo iptables -C OUTPUT -o {br_name} -j DROP",
-                    f"sudo iptables -D OUTPUT -o {br_name} -j DROP",
+                    f"iptables -C OUTPUT -o {br_name} -j DROP",
+                    f"iptables -D OUTPUT -o {br_name} -j DROP",
                     present=False):
                 return False
 
@@ -1025,79 +1029,6 @@ class Network(VirshCommand):
         except Exception as exc:
             self.logger.error(f"error removing route isolation rules: {exc}")
             return False
-
-    def remove_nat_config(self) -> bool:
-        """
-        Remove the forwarding and masquerade rules inserted by apply_nat_config.
-        """
-        if self.forward_mode != 'nat':
-            return True
-
-        status = True
-
-        def remove_ip_tables_rules():
-
-            if not self.bridge_name:
-                self.logger.warning("no bridge name found, cannot remove isolation rules")
-                return True
-
-            try:
-                # discover outgoing iface (same logic as insertion)
-                cmd_exec = LibVirtCommandBase(
-                    provider_config=self.provider_config,
-                    override_config_use_sudo=False)
-
-                cmd = "ip route get 8.8.8.8 | awk '{print $5}'"
-                res = cmd_exec.execute_shell(cmd, hide=True, warn=True)
-                out_iface = res.stdout.strip() if res.ok else ""
-                bridge_name = self.bridge_name
-
-                if out_iface:
-                    self._ensure_rule(
-                        self,
-                        f"sudo iptables -C FORWARD -i {out_iface} -o {bridge_name} -j ACCEPT",
-                        f"sudo iptables -D FORWARD -i {out_iface} -o {bridge_name} -j ACCEPT",
-                        present=False)
-                    self._ensure_rule(
-                        self,
-                        f"sudo iptables -C FORWARD -i {bridge_name} -o {out_iface} -j ACCEPT",
-                        f"sudo iptables -D FORWARD -i {bridge_name} -o {out_iface} -j ACCEPT",
-                        present=False)
-                else:
-                    self.logger.warning(
-                        "could not determine outgoing iface while cleaning nat rules")
-
-                return True
-            except Exception as exc:
-                self.logger.error(f"error removing NAT configuration for {self.name}: {exc}")
-                return False
-
-        status &= remove_ip_tables_rules()
-
-        def remove_iptables_nat_rules():
-            try:
-                # remove masquerade
-                import ipaddress
-                try:
-                    net_cidr = str(ipaddress.IPv4Interface(
-                        f"{self.ip_address}/{self.netmask}").network)
-                    self._ensure_rule(
-                        self,
-                        f"sudo iptables -t nat -C POSTROUTING -s {net_cidr} -j MASQUERADE",
-                        f"sudo iptables -t nat -D POSTROUTING -s {net_cidr} -j MASQUERADE",
-                        present=False)
-                except ValueError:
-                    self.logger.warning(
-                        "could not compute network cidr while cleaning masquerade rule")
-
-                return True
-            except Exception as exc:
-                self.logger.error(f"error removing NAT configuration for {self.name}: {exc}")
-                return False
-
-        status &= remove_iptables_nat_rules()
-
-        return status
 
     def apply_route_iptables_rule(self) -> bool:
         """
@@ -1119,21 +1050,23 @@ class Network(VirshCommand):
             self.logger.info(
                 f"configuring complete isolation for routed network with bridge {bridge_name}")
 
-            # 1. allow vm-to-vm communication on the same bridge
-            vm2vm_check = f"sudo iptables -C FORWARD -i {bridge_name} -o {bridge_name} -j ACCEPT"
-            vm2vm_cmd   = f"sudo iptables -I FORWARD -i {bridge_name} -o {bridge_name} -j ACCEPT"
+            # 1. allow vm-to-vm communication on the same bridge. No embedded
+            # 'sudo' here or below: execute_shell routes that decision through
+            # _should_use_sudo_for_command, so use_sudo: false is honoured
+            vm2vm_check = f"iptables -C FORWARD -i {bridge_name} -o {bridge_name} -j ACCEPT"
+            vm2vm_cmd   = f"iptables -I FORWARD -i {bridge_name} -o {bridge_name} -j ACCEPT"
             if not self._ensure_rule(self, vm2vm_check, vm2vm_cmd):
                 return False
 
             # 2. block all traffic from the VMs to the host
-            host2vm_check = f"sudo iptables -C INPUT -i {bridge_name} -j DROP"
-            host2vm_cmd   = f"sudo iptables -I INPUT -i {bridge_name} -j DROP"
+            host2vm_check = f"iptables -C INPUT -i {bridge_name} -j DROP"
+            host2vm_cmd   = f"iptables -I INPUT -i {bridge_name} -j DROP"
             if not self._ensure_rule(self, host2vm_check, host2vm_cmd):
                 return False
 
             # 3. block all traffic from host to the VMs
-            vm2host_check = f"sudo iptables -C OUTPUT -o {bridge_name} -j DROP"
-            vm2host_cmd   = f"sudo iptables -I OUTPUT -o {bridge_name} -j DROP"
+            vm2host_check = f"iptables -C OUTPUT -o {bridge_name} -j DROP"
+            vm2host_cmd   = f"iptables -I OUTPUT -o {bridge_name} -j DROP"
             if not self._ensure_rule(self, vm2host_check, vm2host_cmd):
                 return False
 
@@ -1142,82 +1075,6 @@ class Network(VirshCommand):
 
         except Exception as exc:
             self.logger.error(f"error applying route isolation rules: {exc}")
-            return False
-
-    def apply_nat_config(self) -> bool:
-        """
-        Apply nat configuration for networks with forward mode 'nat'.
-
-        This method:
-
-          - finds the outgoing interface (eth0, wlan0, etc.)
-          - gets the bridge name for this network
-          - allows forwarding between the bridge and outgoing interface
-          - enables ip masquerading for the network
-
-        Returns:
-            True if successful, False otherwise
-        """
-        try:
-            # find the outgoing interface
-            cmd_executor = LibVirtCommandBase(
-                provider_config=self.provider_config,
-                override_config_use_sudo=False)
-
-            # get the outgoing interface using 'ip route'
-            # .. todo:: figure out how to get the default route interface in case the host
-            #           is not connected to the internet. This should work even if the host is not
-            #           connected to the internet.
-            cmd = "ip route get 8.8.8.8 | awk '{print $5}'"
-            result = cmd_executor.execute_shell(cmd, hide=True)
-            if not result.ok:
-                self.logger.error(f"failed to find outgoing interface: {result.stderr}")
-                return False
-
-            bridge = self.bridge_name
-
-            out_iface = result.stdout.strip()
-            if not out_iface:
-                self.logger.error("could not determine outgoing interface")
-                return False
-
-            self.logger.info(f"found outgoing interface: {out_iface}")
-
-            # bridge interface is already known (self.bridge_name)
-            self.logger.info(f"using bridge interface: {bridge}")
-
-            # allow forwarding between interfaces
-            fwd1_check = f"sudo iptables -C FORWARD -i {out_iface} -o {bridge} -j ACCEPT"
-            fwd1_cmd   = f"sudo iptables -I FORWARD -i {out_iface} -o {bridge} -j ACCEPT"
-            if not self._ensure_rule(self, fwd1_check, fwd1_cmd):
-                return False
-
-            fwd2_check = f"sudo iptables -C FORWARD -i {bridge} -o {out_iface} -j ACCEPT"
-            fwd2_cmd   = f"sudo iptables -I FORWARD -i {bridge} -o {out_iface} -j ACCEPT"
-            if not self._ensure_rule(self, fwd2_check, fwd2_cmd):
-                return False
-
-            # enable nat for the virtual network
-            if self.ip_address:
-                try:
-                    ip_interface = ipaddress.IPv4Interface(f"{self.ip_address}/{self.netmask}")
-                    network_cidr = str(ip_interface.network)
-
-                    masq_check = f"sudo iptables -t nat -C POSTROUTING -s {network_cidr} -j MASQUERADE"
-                    masq_cmd   = f"sudo iptables -t nat -A POSTROUTING -s {network_cidr} -j MASQUERADE"
-                    if not self._ensure_rule(self, masq_check, masq_cmd):
-                        return False
-
-                    self.logger.info(
-                        f"successfully configured nat for network {self.name} ({network_cidr})")
-                    return True
-
-                except ValueError as exc:
-                    self.logger.error(f"error calculating network cidr: {exc}")
-                    return False
-
-        except Exception as exc:
-            self.logger.error(f"error configuring NAT for network {self.name}: {exc}")
             return False
 
     @staticmethod

--- a/tests/test_libvirt_net.py
+++ b/tests/test_libvirt_net.py
@@ -491,3 +491,95 @@ class TestDestroyUndefineExactName:
     def test_undefine_fails_when_libvirt_cannot_be_asked(self, net):
         with patch.object(net, "_listed_networks", return_value=None):
             assert net.undefine_network() is False
+
+
+class TestNatIsLibvirtdsJob:
+    """Boxman must not install its own NAT iptables rules.
+
+    Regression tests for issue #85 item 14: a ``<forward mode='nat'/>``
+    network already makes libvirtd install the masquerade and FORWARD
+    rules. Boxman's hand-rolled duplicates (keyed off
+    ``ip route get 8.8.8.8``) fought libvirtd's and leaked stale rules on
+    removal, so apply/remove of a nat network must not touch iptables.
+    """
+
+    @staticmethod
+    def _net(mode: str = "nat", use_sudo: bool = False) -> Network:
+        with patch.object(Network, "find_available_bridge_name",
+                          return_value="virbr9"):
+            return Network(name="nat-net", info={"mode": mode},
+                           assign_new_bridge=True,
+                           provider_config={"use_sudo": use_sudo})
+
+    def test_define_nat_network_runs_no_iptables(self, tmp_path):
+        net = self._net("nat")
+        with patch.object(net, "check_network_exists"), \
+             patch.object(net, "_get_libvirt_bridges", return_value=set()), \
+             patch.object(net, "update_network_cache"), \
+             patch.object(net, "execute", return_value=_result()), \
+             patch.object(net, "execute_shell") as shell:
+            assert net.define_network(str(tmp_path / "net.xml")) is True
+        for call in shell.call_args_list:
+            assert "iptables" not in call.args[0]
+            assert "ip route get" not in call.args[0]
+
+    def test_remove_nat_network_runs_no_iptables(self):
+        net = self._net("nat")
+        with patch.object(net, "destroy_network", return_value=True), \
+             patch.object(net, "undefine_network", return_value=True), \
+             patch.object(net, "execute_shell") as shell:
+            assert net.remove_network() is True
+        shell.assert_not_called()
+
+
+class TestRouteIsolationRules:
+    """The routed-network isolation rules stay; sudo is execute_shell's call."""
+
+    @staticmethod
+    def _net(use_sudo: bool = False) -> Network:
+        with patch.object(Network, "find_available_bridge_name",
+                          return_value="virbr9"):
+            return Network(name="routed-net", info={"mode": "route"},
+                           assign_new_bridge=True,
+                           provider_config={"use_sudo": use_sudo})
+
+    def test_apply_commands_embed_no_sudo(self):
+        net = self._net()
+        seen = []
+        with patch.object(
+                net, "_ensure_rule",
+                side_effect=lambda cls, chk, act, present=True:
+                    seen.append((chk, act)) or True):
+            assert net.apply_route_iptables_rule() is True
+        # the three isolation rules (vm-to-vm, vm->host, host->vm) survive
+        assert len(seen) == 3
+        for check_cmd, action_cmd in seen:
+            assert not check_cmd.startswith("sudo")
+            assert not action_cmd.startswith("sudo")
+            assert "virbr9" in check_cmd
+
+    def test_remove_commands_embed_no_sudo(self):
+        net = self._net()
+        seen = []
+        with patch.object(
+                net, "_ensure_rule",
+                side_effect=lambda cls, chk, act, present=True:
+                    seen.append((chk, act, present)) or True):
+            assert net.remove_route_iptables_rule() is True
+        assert len(seen) == 3
+        for check_cmd, action_cmd, present in seen:
+            assert present is False
+            assert not check_cmd.startswith("sudo")
+            assert not action_cmd.startswith("sudo")
+
+    @pytest.mark.parametrize("use_sudo, expected_prefix", [
+        (False, "iptables"),
+        (True, "sudo iptables"),
+    ])
+    def test_sudo_comes_from_use_sudo_via_execute_shell(
+            self, use_sudo, expected_prefix):
+        net = self._net(use_sudo=use_sudo)
+        with patch("boxman.providers.libvirt.commands._shell_run",
+                   return_value=_result()) as run:
+            net.execute_shell("iptables -C INPUT -i virbr9 -j DROP", warn=True)
+        assert run.call_args.args[0].startswith(expected_prefix)

--- a/tests/test_network_reconcile_integration.py
+++ b/tests/test_network_reconcile_integration.py
@@ -30,8 +30,9 @@ Environment:
     the power cycle has to wait out the graceful-shutdown timeout, which adds
     about two minutes.
 
-The host also needs passwordless sudo for ``iptables``: boxman's NAT setup
-shells out to it when a network is defined.
+NAT is libvirtd's job (it installs the masquerade/FORWARD rules for
+``<forward mode='nat'/>`` itself), so boxman no longer shells out to
+``iptables`` for these networks.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Refs #85 (item 14).

**Problem:** `apply_nat_config()` hand-installed masquerade + FORWARD rules that duplicate the ones libvirtd installs for `<forward mode='nat'/>`, keyed off `ip route get 8.8.8.8` (breaks on offline hosts). `remove_nat_config()` reversed them using the *current* default route, which may differ from insertion time → stale rules leaked. Every iptables string also hardcoded `sudo`, ignoring `use_sudo: false`.

**Fix:**
- Deleted `apply_nat_config()`/`remove_nat_config()`; `define_network()` and `remove_network()` now leave NAT entirely to libvirtd (its rules come and go with the network).
- The routed-network isolation rules (boxman policy) are **kept intact**, but their command strings no longer embed `sudo ` — `execute_shell()` routes that through `_should_use_sudo_for_command`, so `use_sudo: false` is honoured.
- Removed the now-unused `LibVirtCommandBase` import from net.py.
- Updated the stale docstring in `tests/test_network_reconcile_integration.py` (host no longer needs passwordless sudo for boxman NAT setup).

**Note for follow-up (out of my allowed file set):** `doc/docker-compose-provider/design.md:370` shows `virbr1 (NAT) iptables MASQUERADE` in a diagram — still accurate at runtime (libvirtd installs it), but worth a glance when docs are next touched.

**Tests:** new `TestNatIsLibvirtdsJob` (define/remove of a nat network issues no iptables / `ip route get` at all) and `TestRouteIsolationRules` (the 3 isolation rules survive, embed no `sudo`; sudo is added by `execute_shell` only when `use_sudo` is true). 135 passed across `tests/test_libvirt_net.py` + `tests/test_net_reconcile.py`; ruff shows no new violations vs `origin/polish`.