### PR TITLE
fix: honor --vms/--cluster in control, storage, snapshot list/log (#85 item 2)

### DIFF
--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -4518,8 +4518,8 @@ class BoxmanManager:
             allow_recreate=getattr(cli_args, 'recreate_networks', False),
             auto_accept=getattr(cli_args, 'yes', False)))
 
-        # Build workdir lookup from process_vm_list for restore operations
-        vm_workdir_map = {vm_name: workdir for vm_name, workdir in cls.process_vm_list(cli_args)}
+        # Build workdir lookup for restore operations
+        vm_workdir_map = dict(cls._control_vm_targets(cls, cli_args))
 
         def _bring_up(vm_name, state, workdir):
             session = cls.session_for_vm(vm_name)
@@ -4607,7 +4607,7 @@ class BoxmanManager:
         pause analog wired in this phase, so the flag is a no-op for dc
         clusters.
 
-        Reuses ``process_vm_list()`` and the same provider methods as
+        Reuses ``_control_vm_targets()`` and the same provider methods as
         ``boxman control save`` / ``boxman control suspend``.
         """
         # Ensure provider configs reflect runtime settings
@@ -4615,7 +4615,7 @@ class BoxmanManager:
             if hasattr(_session, 'update_provider_config_with_runtime'):
                 _session.update_provider_config_with_runtime()
 
-        vm_list = cls.process_vm_list(cli_args)
+        vm_list = cls._control_vm_targets(cls, cli_args)
 
         if not vm_list and not cls._compose_clusters:
             cls.logger.info("no VMs found in configuration")
@@ -5008,13 +5008,11 @@ class BoxmanManager:
         """
         List snapshots of the VMs and docker-compose clusters in the project.
         """
-        prj_name = f'bprj__{cls.config["project"]}__bprj'
-        for cluster_name, cluster in cls._vm_clusters.items():
-            for vm_name, _ in cluster['vms'].items():
-                full_vm_name = f"{prj_name}_{cluster_name}_{vm_name}"
-                cls.session_for_cluster(cluster_name).snapshot_list(full_vm_name)
+        for full_vm_name, cluster_name, _vm_name, _workdir in (
+                cls._select_vm_targets(cls, cli_args)):
+            cls.session_for_cluster(cluster_name).snapshot_list(full_vm_name)
         # docker-compose clusters (docker commit-backed, D3)
-        for cname, cluster in cls._compose_clusters.items():
+        for cname, cluster in cls._select_dc_clusters(cli_args):
             snaps = cls.session_for_cluster(cname).snapshot_list_cluster(cname, cluster)
             cls.logger.info(f"cluster: {cname} (docker-compose)")
             if not snaps:
@@ -5047,11 +5045,10 @@ class BoxmanManager:
 
         # 1. Per-VM data.
         per_vm: dict[str, dict] = {}
-        for cluster_name, cluster in cls._vm_clusters.items():
-            for vm_name, _ in cluster['vms'].items():
-                full_vm_name = f"{prj_name}_{cluster_name}_{vm_name}"
-                data = cls.session_for_cluster(cluster_name).snapshot_log_data(full_vm_name)
-                per_vm[full_vm_name] = data
+        for full_vm_name, cluster_name, _vm_name, _workdir in (
+                cls._select_vm_targets(cls, cli_args)):
+            data = cls.session_for_cluster(cluster_name).snapshot_log_data(full_vm_name)
+            per_vm[full_vm_name] = data
 
         if not any(d.get('chain') for d in per_vm.values()):
             cls.logger.info("no snapshots found")
@@ -5198,6 +5195,10 @@ class BoxmanManager:
         targets = []
         for cluster_name, cluster in clusters.items():
             if cluster_filter is not None and cluster_name != cluster_filter:
+                continue
+            if cls._is_compose_cluster(cluster_name):
+                # docker-compose clusters carry ``boxes:``, not ``vms:`` —
+                # they are selected via ``_select_dc_clusters`` instead.
                 continue
             workdir = os.path.expanduser(cluster['workdir'])
             for vm_name in cluster.get('vms', {}):
@@ -5522,7 +5523,11 @@ class BoxmanManager:
         no_shutdown = getattr(cli_args, 'no_shutdown', False)
         yes = getattr(cli_args, 'yes', False)
 
-        targets = list(cls._storage_targets(cls, cli_args))
+        targets = []
+        for full_vm_name, cluster_name, vm_name, workdir in (
+                cls._select_vm_targets(cls, cli_args)):
+            vm_info = cls.config['clusters'][cluster_name]['vms'][vm_name] or {}
+            targets.append((full_vm_name, workdir, vm_info))
 
         if not yes and not dry_run:
             cls.logger.warning(
@@ -5554,16 +5559,6 @@ class BoxmanManager:
 
     ### start storage functions ####
     @staticmethod
-    def _storage_targets(cls, cli_args=None):
-        """Yield ``(full_vm_name, workdir, vm_info)`` for every VM in every cluster."""
-        prj_name = f'bprj__{cls.config["project"]}__bprj'
-        for cluster_name, cluster in cls._vm_clusters.items():
-            workdir = os.path.expanduser(cluster['workdir'])
-            for vm_name, vm_info in cluster['vms'].items():
-                full_vm_name = f"{prj_name}_{cluster_name}_{vm_name}"
-                yield full_vm_name, workdir, vm_info or {}
-
-    @staticmethod
     def _format_bytes(num: int | None) -> str:
         if num is None:
             return "-"
@@ -5584,7 +5579,9 @@ class BoxmanManager:
         storage = cls.provider.storage  # Phase 1 (#49): storage_df stays on the default session until Phase 3
         rows = []
         snap_mem_total_per_vm: dict[str, int] = {}
-        for full_vm_name, workdir, vm_info in cls._storage_targets(cls, cli_args):
+        for full_vm_name, cluster_name, vm_name, workdir in (
+                cls._select_vm_targets(cls, cli_args)):
+            vm_info = cls.config['clusters'][cluster_name]['vms'][vm_name] or {}
             disks = vm_disk_paths(workdir, full_vm_name, vm_info)
             snap_count = storage.count_snapshots(full_vm_name)
             mem_files = storage.snapshot_memory_files(workdir, full_vm_name)
@@ -5641,7 +5638,7 @@ class BoxmanManager:
         but nothing will be returned to the host.
         """
         storage = cls.provider.storage  # Phase 1 (#49): storage_trim stays on the default session until Phase 3
-        for full_vm_name, _workdir, _vm_info in cls._storage_targets(cls, cli_args):
+        for full_vm_name, _c, _v, _workdir in cls._select_vm_targets(cls, cli_args):
             if not storage.is_running(full_vm_name):
                 cls.logger.warning(
                     f"skip trim: vm {full_vm_name} is not running")
@@ -5720,7 +5717,11 @@ class BoxmanManager:
         chain-flattening methods when snapshots exist unless
         ``--drop-snapshots`` is passed.
         """
-        targets = list(cls._storage_targets(cls, cli_args))
+        targets = []
+        for full_vm_name, cluster_name, vm_name, workdir in (
+                cls._select_vm_targets(cls, cli_args)):
+            vm_info = cls.config['clusters'][cluster_name]['vms'][vm_name] or {}
+            targets.append((full_vm_name, workdir, vm_info))
         method = getattr(cli_args, 'method', 'auto')
         drop_snapshots = getattr(cli_args, 'drop_snapshots', False)
         no_shutdown = getattr(cli_args, 'no_shutdown', False)
@@ -5765,7 +5766,7 @@ class BoxmanManager:
         decompress = getattr(cli_args, 'decompress', False)
         level = getattr(cli_args, 'level', 3)
         action = "decompress" if decompress else "compress"
-        for full_vm_name, _workdir, _vm_info in cls._storage_targets(cls, cli_args):
+        for full_vm_name, _c, _v, _workdir in cls._select_vm_targets(cls, cli_args):
             cls.logger.info(f"storage {action}-snapshots: {full_vm_name}")
             processed, total = cls.session_for_vm(full_vm_name).compress_snapshots_memory(
                 full_vm_name, level=level, decompress=decompress)
@@ -5775,18 +5776,17 @@ class BoxmanManager:
     ### end storage functions ####
 
     ### start control vm functions ####
-    def process_vm_list(self, cli_args):
+    @staticmethod
+    def _control_vm_targets(cls, cli_args):
         """
-        Process the list of VMs to control.
+        ``(full_vm_name, workdir)`` pairs for the VMs selected by
+        ``--cluster`` / ``--vms`` (every VM when neither flag is given).
         """
-        retval = []
-        prj_name = f'bprj__{self.config["project"]}__bprj'
-        for cluster_name, cluster in self._vm_clusters.items():
-            workdir = os.path.expanduser(cluster['workdir'])
-            for vm_name, _ in cluster['vms'].items():
-                full_vm_name = f"{prj_name}_{cluster_name}_{vm_name}"
-                retval.append((full_vm_name, workdir))
-        return retval
+        return [
+            (full_vm_name, workdir)
+            for full_vm_name, _c, _v, workdir
+            in cls._select_vm_targets(cls, cli_args)
+        ]
 
     @staticmethod
     def suspend_vm(cls, cli_args):
@@ -5794,7 +5794,7 @@ class BoxmanManager:
         Suspend the machines: libvirt VMs → virsh suspend; docker-compose
         containers → ``docker compose pause``.
         """
-        for vm_name, _ in cls.process_vm_list(cli_args):
+        for vm_name, _ in cls._control_vm_targets(cls, cli_args):
             cls.session_for_vm(vm_name).suspend_vm(vm_name)
             cls.logger.info(f"vm {vm_name} suspended")
         for cluster_name, cluster in cls._select_dc_clusters(cli_args):
@@ -5806,7 +5806,7 @@ class BoxmanManager:
         Resume the machines: libvirt VMs → virsh resume; docker-compose
         containers → ``docker compose unpause``.
         """
-        for vm_name, _ in cls.process_vm_list(cli_args):
+        for vm_name, _ in cls._control_vm_targets(cls, cli_args):
             cls.session_for_vm(vm_name).resume_vm(vm_name)
             cls.logger.info(f"VM {vm_name} resumed")
         for cluster_name, cluster in cls._select_dc_clusters(cli_args):
@@ -5819,7 +5819,7 @@ class BoxmanManager:
         docker-compose containers (no save-to-file state) — an explanatory
         message is logged, no traceback.
         """
-        for vm_name, workdir in cls.process_vm_list(cli_args):
+        for vm_name, workdir in cls._control_vm_targets(cls, cli_args):
             cls.session_for_vm(vm_name).save_vm(vm_name, workdir)
         for cluster_name, _cluster in cls._select_dc_clusters(cli_args):
             cls.logger.warning(
@@ -5834,7 +5834,7 @@ class BoxmanManager:
         Start the machines: libvirt VMs (optionally --restore); docker-compose
         containers → ``docker compose start``.
         """
-        for vm_name, workdir in cls.process_vm_list(cli_args):
+        for vm_name, workdir in cls._control_vm_targets(cls, cli_args):
             if cli_args.restore:
                 cls.session_for_vm(vm_name).restore_vm(vm_name, workdir)
             else:

--- a/tests/test_vm_scoping.py
+++ b/tests/test_vm_scoping.py
@@ -1,0 +1,166 @@
+"""
+Regression tests for #85 item 2: ``--vms`` (and ``--cluster``) must scope
+``control``, ``storage`` and ``snapshot list``/``snapshot log`` — previously
+these verbs silently operated on every VM in the project.
+"""
+
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+import boxman.manager
+from boxman.manager import BoxmanManager
+
+pytestmark = pytest.mark.unit
+
+
+def _manager():
+    mgr = BoxmanManager.__new__(BoxmanManager)
+    mgr.config = {
+        "project": "demo",
+        "clusters": {
+            "cluster_1": {
+                "workdir": "/tmp/ws/c1",
+                "vms": {"service01": {}, "node01": {}},
+            },
+            "cluster_2": {
+                "workdir": "/tmp/ws/c2",
+                "vms": {"service01": {}, "node01": {}},
+            },
+        },
+    }
+    mgr.provider = MagicMock()
+    mgr.logger = MagicMock()
+    return mgr
+
+
+def _full(cluster, vm):
+    return f"bprj__demo__bprj_{cluster}_{vm}"
+
+
+class _FakeProcess:
+    """Stand-in for multiprocessing.Process that only records its args."""
+
+    instances = []
+
+    def __init__(self, target=None, args=()):
+        self.target = target
+        self.args = args
+        _FakeProcess.instances.append(self)
+
+    def start(self):
+        pass
+
+    def join(self):
+        pass
+
+
+@pytest.fixture
+def fake_process(monkeypatch):
+    _FakeProcess.instances = []
+    monkeypatch.setattr(boxman.manager, "Process", _FakeProcess)
+    return _FakeProcess.instances
+
+
+class TestControlScoping:
+
+    def test_save_scoped_by_vms(self):
+        mgr = _manager()
+        ns = types.SimpleNamespace(vms="node01", cluster=None)
+        BoxmanManager.save_vm(mgr, ns)
+        saved = {c.args[0] for c in mgr.provider.save_vm.call_args_list}
+        assert saved == {_full("cluster_1", "node01"), _full("cluster_2", "node01")}
+
+    def test_save_defaults_to_all_vms(self):
+        mgr = _manager()
+        BoxmanManager.save_vm(mgr, types.SimpleNamespace())
+        assert mgr.provider.save_vm.call_count == 4
+
+    def test_suspend_scoped_by_vms(self):
+        mgr = _manager()
+        ns = types.SimpleNamespace(vms="cluster_2_service01", cluster=None)
+        BoxmanManager.suspend_vm(mgr, ns)
+        suspended = {c.args[0] for c in mgr.provider.suspend_vm.call_args_list}
+        assert suspended == {_full("cluster_2", "service01")}
+
+    def test_resume_scoped_by_cluster(self):
+        mgr = _manager()
+        ns = types.SimpleNamespace(vms="all", cluster="cluster_1")
+        BoxmanManager.resume_vm(mgr, ns)
+        resumed = {c.args[0] for c in mgr.provider.resume_vm.call_args_list}
+        assert resumed == {_full("cluster_1", "service01"), _full("cluster_1", "node01")}
+
+    def test_start_scoped_by_vms(self):
+        mgr = _manager()
+        ns = types.SimpleNamespace(vms="node01", cluster=None, restore=False)
+        BoxmanManager.start_vm(mgr, ns)
+        started = {c.args[0] for c in mgr.provider.start_vm.call_args_list}
+        assert started == {_full("cluster_1", "node01"), _full("cluster_2", "node01")}
+
+
+class TestSnapshotListLogScoping:
+
+    def test_snapshot_list_scoped_by_vms(self):
+        mgr = _manager()
+        ns = types.SimpleNamespace(vms="node01", cluster=None)
+        BoxmanManager.snapshot_list(mgr, ns)
+        listed = {c.args[0] for c in mgr.provider.snapshot_list.call_args_list}
+        assert listed == {_full("cluster_1", "node01"), _full("cluster_2", "node01")}
+
+    def test_snapshot_list_defaults_to_all_vms(self):
+        mgr = _manager()
+        BoxmanManager.snapshot_list(mgr, types.SimpleNamespace())
+        assert mgr.provider.snapshot_list.call_count == 4
+
+    def test_snapshot_log_scoped_by_vms(self):
+        mgr = _manager()
+        mgr.provider.snapshot_log_data.return_value = {"chain": [], "current": None}
+        ns = types.SimpleNamespace(vms="node01", cluster=None)
+        BoxmanManager.snapshot_log(mgr, ns)
+        logged = {c.args[0] for c in mgr.provider.snapshot_log_data.call_args_list}
+        assert logged == {_full("cluster_1", "node01"), _full("cluster_2", "node01")}
+
+
+class TestStorageScoping:
+
+    def test_storage_df_scoped_by_vms(self, monkeypatch):
+        mgr = _manager()
+        mgr.provider.storage.snapshot_memory_files.return_value = []
+        mgr.provider.storage.count_snapshots.return_value = 0
+        seen = []
+        monkeypatch.setattr(
+            "boxman.providers.libvirt.storage.vm_disk_paths",
+            lambda workdir, full_vm_name, vm_info: seen.append(full_vm_name) or [])
+        BoxmanManager.storage_df(mgr, types.SimpleNamespace(vms="node01"))
+        assert set(seen) == {_full("cluster_1", "node01"), _full("cluster_2", "node01")}
+
+    def test_storage_trim_scoped_by_vms(self):
+        mgr = _manager()
+        mgr.provider.storage.is_running.return_value = False
+        BoxmanManager.storage_trim(mgr, types.SimpleNamespace(vms="node01"))
+        trimmed = {c.args[0] for c in mgr.provider.storage.is_running.call_args_list}
+        assert trimmed == {_full("cluster_1", "node01"), _full("cluster_2", "node01")}
+
+    def test_storage_compact_scoped_by_vms(self, fake_process):
+        mgr = _manager()
+        BoxmanManager.storage_compact(mgr, types.SimpleNamespace(vms="node01"))
+        compacted = {p.args[1] for p in fake_process}
+        assert compacted == {_full("cluster_1", "node01"), _full("cluster_2", "node01")}
+
+    def test_storage_compress_snapshots_scoped_by_vms(self):
+        mgr = _manager()
+        mgr.provider.compress_snapshots_memory.return_value = (1, 1)
+        BoxmanManager.storage_compress_snapshots(
+            mgr, types.SimpleNamespace(vms="node01"))
+        compressed = {
+            c.args[0] for c in mgr.provider.compress_snapshots_memory.call_args_list}
+        assert compressed == {_full("cluster_1", "node01"), _full("cluster_2", "node01")}
+
+    def test_snapshot_collapse_scoped_by_vms(self, fake_process):
+        mgr = _manager()
+        ns = types.SimpleNamespace(
+            vms="node01", target="snap1", dry_run=False, no_shutdown=False, yes=True)
+        BoxmanManager.snapshot_collapse(mgr, ns)
+        collapsed = {p.args[1] for p in fake_process}
+        assert collapsed == {_full("cluster_1", "node01"), _full("cluster_2", "node01")}


### PR DESCRIPTION
Refs #85 (item 2).

`boxman control save --vms node01` saved **every** VM — `process_vm_list` and `_storage_targets` accepted `cli_args` but never read it; `snapshot list`/`snapshot log` iterated all clusters without filtering. The correct filter `_select_vm_targets` was only wired into snapshot take/restore/delete.

**Fix:** route all these verbs through `_select_vm_targets`:
- control suspend/resume/save/start and `down`/`up` via a thin `_control_vm_targets` adapter ((full_name, workdir) shape)
- storage df/trim/compact/compress-snapshots + snapshot collapse inline via `_select_vm_targets`
- `snapshot list`/`snapshot log` per-VM loops via `_select_vm_targets`; the dc side of `snapshot list` now uses `_select_dc_clusters`
- deleted `process_vm_list` and `_storage_targets`
- `_select_vm_targets` now skips docker-compose clusters (they carry `boxes:`, not `vms:`, and may lack `workdir` — exposed by the dc CLI-parity tests)

**Tests:** new `tests/test_vm_scoping.py` (unit) — scoping actually filters for each affected verb + default still selects all. Full unit suite: 1686 passed. Ruff: no new violations (24 pre-existing, identical profile to base).