### PR TITLE
fix: containerlab ensure_up lab-prefix collision + shell quoting (#85 item 19)

### DIFF
--- a/src/boxman/netlab/containerlab.py
+++ b/src/boxman/netlab/containerlab.py
@@ -15,6 +15,7 @@ the currently-loaded config, no long-lived client.
 from __future__ import annotations
 
 import json
+import shlex
 import shutil
 from pathlib import Path
 from typing import Any
@@ -220,22 +221,25 @@ class ContainerlabManager:
                 f"(did you call render_topology()?)"
             )
         self.logger.info(f"deploying containerlab lab {self.lab_name!r}")
-        run(f"containerlab deploy -t {topology}")
+        run(f"containerlab deploy -t {shlex.quote(str(topology))}")
 
     def ensure_up(self) -> None:
         """Idempotent: deploy the lab if absent, else start any stopped nodes.
 
         Safe to call repeatedly from ``boxman up``. Lists existing Docker
-        containers matching the lab's ``clab-<lab>-*`` naming prefix:
+        containers carrying the ``containerlab=<lab_name>`` label that
+        containerlab sets on every node it deploys. (A ``name=clab-<lab>-``
+        filter would be a *substring* match, so sibling labs like ``foo``
+        and ``foo-bar`` on one host would see each other's containers.)
 
         - No matches → render + deploy fresh.
         - All matches running → no-op.
         - Some matches stopped (e.g. after host reboot) → ``docker start``
           each one. No need to re-render or re-deploy.
         """
-        prefix = f"clab-{self.lab_name}-"
         result = run(
-            f"docker ps -a --filter name={prefix} "
+            f"docker ps -a "
+            f"--filter label=containerlab={shlex.quote(self.lab_name)} "
             f"--format '{{{{.Names}}}} {{{{.State}}}}'",
             hide=True, warn=True,
         )
@@ -263,23 +267,25 @@ class ContainerlabManager:
 
         for name in stopped:
             self.logger.info(f"starting stopped lab container {name!r}")
-            run(f"docker start {name}", warn=True)
+            run(f"docker start {shlex.quote(name)}", warn=True)
 
     def destroy(self) -> None:
         """Run ``containerlab destroy --name <lab_name>`` (graceful if absent)."""
         self.logger.info(f"destroying containerlab lab {self.lab_name!r}")
         topology = self.topology_path
         if topology.exists():
-            run(f"containerlab destroy -t {topology} --cleanup", warn=True)
+            run(f"containerlab destroy -t {shlex.quote(str(topology))} "
+                f"--cleanup", warn=True)
         else:
             # Fall back to name-based destroy if the rendered topology is gone.
-            run(f"containerlab destroy --name {self.lab_name} --cleanup",
-                warn=True)
+            run(f"containerlab destroy --name {shlex.quote(self.lab_name)} "
+                f"--cleanup", warn=True)
 
     def inspect(self) -> dict[str, Any]:
         """Return ``containerlab inspect --format json`` output for the lab."""
         result = run(
-            f"containerlab inspect --name {self.lab_name} --format json",
+            f"containerlab inspect --name {shlex.quote(self.lab_name)} "
+            f"--format json",
             hide=True, warn=True,
         )
         if not result.ok:

--- a/tests/test_netlab_containerlab.py
+++ b/tests/test_netlab_containerlab.py
@@ -334,6 +334,69 @@ class TestEnsureUp:
         assert not any("docker start clab-netlab-sw1" in c for c in cmds)
         assert not any("containerlab deploy" in c for c in cmds)
 
+    def test_filter_uses_exact_containerlab_label(self, simple_lab_config, tmp_path):
+        """Regression (#85 item 19): docker's ``name=`` filter is a SUBSTRING
+        match, so labs ``netlab`` and ``netlab-b2`` on one host both match
+        ``clab-netlab-`` and interfere. ensure_up must filter on the exact
+        ``containerlab=<lab>`` label containerlab sets on every node."""
+        mgr = ContainerlabManager(simple_lab_config, tmp_path)
+
+        def fake_run(cmd, **kwargs):
+            if "docker ps" in cmd:
+                return _result(stdout="clab-netlab-sw1 running\n", ok=True)
+            return _result(ok=True)
+
+        with patch("boxman.netlab.containerlab.run", side_effect=fake_run) as run:
+            mgr.ensure_up()
+
+        ps_cmd = next(c.args[0] for c in run.call_args_list
+                      if "docker ps" in c.args[0])
+        assert "--filter label=containerlab=netlab" in ps_cmd
+        assert "--filter name=" not in ps_cmd
+
+    def test_sibling_lab_containers_not_matched(self, simple_lab_config, tmp_path):
+        """With the label filter applied by docker, a *stopped* sibling-lab
+        container (clab-netlab-b2-sw1) is never listed, so it is never
+        passed to ``docker start`` and the running sibling doesn't make
+        ensure_up no-op while our own lab is down."""
+        mgr = ContainerlabManager(simple_lab_config, tmp_path)
+        calls: list[str] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if "docker ps" in cmd:
+                # docker honours label=containerlab=netlab: our lab has no
+                # containers, the sibling lab's are not returned.
+                assert "label=containerlab=netlab" in cmd
+                return _result(stdout="", ok=True)
+            return _result(ok=True)
+
+        with patch("boxman.netlab.containerlab.run", side_effect=fake_run):
+            mgr.ensure_up()
+
+        assert not any("docker start" in c for c in calls)
+        assert any("containerlab deploy" in c for c in calls)
+
+    def test_lab_name_is_shell_quoted(self, simple_lab_config, tmp_path):
+        """A lab name with shell metacharacters is quoted in shell-outs."""
+        simple_lab_config["lab_name"] = "net;lab"
+        mgr = ContainerlabManager(simple_lab_config, tmp_path)
+
+        def fake_run(cmd, **kwargs):
+            if "docker ps" in cmd:
+                return _result(stdout="", ok=True)
+            return _result(ok=True)
+
+        with patch("boxman.netlab.containerlab.run", side_effect=fake_run) as run:
+            mgr.ensure_up()
+
+        cmds = [c.args[0] for c in run.call_args_list]
+        ps_cmd = next(c for c in cmds if "docker ps" in c)
+        assert "label=containerlab='net;lab'" in ps_cmd
+        deploy_cmd = next(c for c in cmds if "containerlab deploy" in c)
+        # the rendered topology path contains the metachar lab name → quoted
+        assert f"-t '{mgr.topology_path}'" in deploy_cmd
+
 
 class TestSshCommand:
 


### PR DESCRIPTION
Refs #85 (item 19).

## What
`ContainerlabManager.ensure_up` listed nodes with `docker ps -a --filter name=clab-<lab>-`. Docker's `name` filter is a **substring** match, so sibling labs `foo` / `foo-bar` on one host interfere: `ensure_up('foo')` sees the other lab's containers and can no-op while its own lab is down, or `docker start` stopped nodes of the sibling lab.

Fix: filter on the exact label containerlab sets on every node container:
`docker ps -a --filter label=containerlab=<lab_name>`.

Also `shlex.quote` the interpolated topology paths / lab names / container names in `deploy`, `ensure_up`, `destroy`, `inspect`.

## Tests
- New regression tests in tests/test_netlab_containerlab.py: the ps command uses `--filter label=containerlab=<lab>` (never `--filter name=`); sibling-lab containers are not matched/started and a down own-lab still deploys; lab names with shell metacharacters are quoted.
- Netlab suites: 89 passed. ruff: no new violations (N818/I001 pre-existing).