### PR TITLE
fix: cdrom bus derivation, force-recreate race, DHCP fail-fast (#85 item 26)

### DIFF
--- a/src/boxman/providers/libvirt/cdrom.py
+++ b/src/boxman/providers/libvirt/cdrom.py
@@ -82,8 +82,9 @@ class CDROMManager(VirshCommand):
         """
         try:
             # Generate XML for the device to detach (source not needed for detach)
+            bus = self._bus_for_target(target_dev)
             xml_content = f"""<disk type='file' device='cdrom'>
-  <target dev='{target_dev}' bus='ide'/>
+  <target dev='{target_dev}' bus='{bus}'/>
   <readonly/>
 </disk>"""
 
@@ -209,12 +210,26 @@ class CDROMManager(VirshCommand):
         Returns:
             XML string for CDROM attachment
         """
+        bus = self._bus_for_target(target_dev)
         return f"""<disk type='file' device='cdrom'>
   <driver name='qemu' type='raw'/>
   <source file='{source_path}'/>
-  <target dev='{target_dev}' bus='ide'/>
+  <target dev='{target_dev}' bus='{bus}'/>
   <readonly/>
 </disk>"""
+
+    @staticmethod
+    def _bus_for_target(target_dev: str) -> str:
+        """
+        Derive the libvirt bus from a target device name.
+
+        ``_find_next_available_target`` falls back to sd* names once the
+        four IDE slots are taken, so the bus cannot be hardcoded to ide.
+
+        Returns:
+            'sata' for sd* targets, 'ide' otherwise (hd*)
+        """
+        return 'sata' if target_dev.startswith('sd') else 'ide'
 
     def _find_next_available_target(self) -> str | None:
         """

--- a/src/boxman/providers/libvirt/cloudinit.py
+++ b/src/boxman/providers/libvirt/cloudinit.py
@@ -830,6 +830,21 @@ class CloudInitTemplate:
         self._shutdown_template()
         return True
 
+    def _wait_until_shut_off(self, attempts: int = 30, interval: int = 2) -> bool:
+        """
+        Poll ``domstate`` until the template VM is shut off.
+
+        Returns:
+            True once the domain reports "shut off", False when *attempts*
+            run out.
+        """
+        for _ in range(attempts):
+            result = self.virsh.execute("domstate", self.template_name, hide=True, warn=True)
+            if result.ok and "shut off" in result.stdout.strip():
+                return True
+            time.sleep(interval)
+        return False
+
     def _shutdown_template(self) -> None:
         """
         Shut the template VM down, forcing it off if it will not go quietly.
@@ -842,12 +857,9 @@ class CloudInitTemplate:
         self.virsh.execute("shutdown", self.template_name, hide=True, warn=True)
 
         self.logger.info("waiting for VM to shut off...")
-        for _ in range(30):
-            result = self.virsh.execute("domstate", self.template_name, hide=True, warn=True)
-            if result.ok and "shut off" in result.stdout.strip():
-                self.logger.info("VM is successfully shut off.")
-                return
-            time.sleep(2)
+        if self._wait_until_shut_off():
+            self.logger.info("VM is successfully shut off.")
+            return
 
         self.logger.warning("VM did not shut off gracefully. Forcing destroy...")
         self.virsh.execute("destroy", self.template_name, hide=True, warn=True)
@@ -907,19 +919,38 @@ class CloudInitTemplate:
                     f"destroying first (--force was specified)")
                 self.virsh.execute(
                     "destroy", self.template_name, hide=True, warn=True)
-                self.virsh.execute(
+                # undefine fails while QEMU is still tearing the domain down,
+                # and the virt-install below would then die with "domain
+                # already exists" — wait for shut-off before removing it
+                if not self._wait_until_shut_off():
+                    self.logger.error(
+                        f"template VM '{self.template_name}' did not shut off "
+                        f"after destroy — refusing to recreate it")
+                    return False
+                undefine = self.virsh.execute(
                     "undefine", self.template_name,
                     "--remove-all-storage", hide=True, warn=True)
+                if not undefine.ok:
+                    self.logger.error(
+                        f"failed to undefine template VM "
+                        f"'{self.template_name}': {undefine.stderr}")
+                    return False
                 self.logger.info(
                     f"template VM '{self.template_name}' has been removed")
 
         # Resolve bridge device (auto-starts the network if needed)
         bridge_device = self._resolve_bridge()
 
-        # Verify DHCP is available (warn early rather than debug a silent failure)
+        # Verify DHCP is available (fail fast rather than debug a silent
+        # failure — without it the guest never gets an IP and the cloud-init
+        # verification below would burn the full agent timeout for nothing)
         if not self.bridge:
             # only check when using a libvirt-managed network
-            self._verify_dhcp_on_network()
+            if not self._verify_dhcp_on_network():
+                self.logger.error(
+                    f"cannot create template '{self.template_name}': "
+                    f"no DHCP on network '{self.network}' — see above")
+                return False
 
         template_dir = os.path.join(self.workdir, self.template_name)
         os.makedirs(template_dir, exist_ok=True)

--- a/tests/test_libvirt_cdrom.py
+++ b/tests/test_libvirt_cdrom.py
@@ -44,6 +44,33 @@ class TestGenerateXml:
         assert "<readonly/>" in xml
 
 
+class TestBusForTarget:
+    # _find_next_available_target falls back to sd* once the IDE slots are
+    # taken; the device XML bus must match the target prefix (#85 item 26)
+
+    def test_hd_targets_are_ide(self, cd: CDROMManager):
+        assert cd._bus_for_target("hdc") == "ide"
+
+    def test_sd_targets_are_sata(self, cd: CDROMManager):
+        assert cd._bus_for_target("sda") == "sata"
+
+    def test_generated_xml_matches_sata_target(self, cd: CDROMManager):
+        xml = cd._generate_cdrom_xml("/tmp/foo.iso", "sda")
+        assert "dev='sda' bus='sata'" in xml
+
+    def test_detach_xml_matches_sata_target(self, cd: CDROMManager):
+        written = {}
+
+        def capture(*args, **kwargs):
+            # the temp XML still exists while detach-device runs
+            written["xml"] = Path(args[2]).read_text()
+            return _result()
+
+        with patch.object(cd, "execute", side_effect=capture):
+            assert cd.detach_cdrom("sda") is True
+        assert "dev='sda' bus='sata'" in written["xml"]
+
+
 class TestFindNextAvailableTarget:
     # domblklist --details has 4 columns: Type Device Target Source
     DOMBLKLIST = (

--- a/tests/test_libvirt_cloudinit.py
+++ b/tests/test_libvirt_cloudinit.py
@@ -443,3 +443,102 @@ class TestAgentCommand:
                 patch("boxman.providers.libvirt.cloudinit.time.sleep"):
             assert t.verify_and_shutdown() is True
         assert ex.call_args_list[0].args[0] == "qemu-agent-command"
+
+
+class TestCreateTemplateSafeguards:
+    """
+    Safeguards in create_template (#85 item 26):
+
+    - ``--force`` must wait for the old domain to shut off before undefine,
+      and must abort when undefine fails (otherwise the virt-install below
+      dies with "domain already exists").
+    - A libvirt network without DHCP must abort before virt-install instead
+      of burning the full guest-agent timeout.
+    """
+
+    SLEEP = "boxman.providers.libvirt.cloudinit.time.sleep"
+    SHELL_RUN = "boxman.providers.libvirt.cloudinit._shell_run"
+
+    @staticmethod
+    def _stub_success_path(t: CloudInitTemplate) -> None:
+        """Stub out everything past the VM-exists / DHCP gates."""
+        t._resolve_bridge = MagicMock(return_value="virbr0")
+        t._verify_dhcp_on_network = MagicMock(return_value=True)
+        t.copy_base_image = MagicMock(return_value=True)
+        t.prepare_nocloud_dir = MagicMock(return_value="/nocloud")
+        t.build_seed_iso = MagicMock(return_value=True)
+        t.verify_and_shutdown = MagicMock(return_value=True)
+
+    def test_force_recreate_waits_for_shut_off_before_undefine(self, tmp_path: Path):
+        t = _make_template(tmp_path)
+        self._stub_success_path(t)
+        t._check_vm_exists = MagicMock(return_value=True)
+        calls: list[str] = []
+        states = iter(["running", "running", "shut off"])
+
+        def fake_execute(cmd, *args, **kwargs):
+            calls.append(cmd)
+            if cmd == "domstate":
+                return _result(stdout=next(states, "shut off"))
+            return _result()
+
+        with patch.object(t.virsh, "execute", side_effect=fake_execute), \
+                patch(self.SLEEP), \
+                patch(self.SHELL_RUN, return_value=_result()):
+            assert t.create_template(force=True) is True
+        assert calls.index("destroy") < calls.index("domstate") < calls.index("undefine")
+        # two "running" polls + one "shut off" before undefine
+        assert calls[:calls.index("undefine")].count("domstate") == 3
+
+    def test_force_recreate_aborts_when_undefine_fails(self, tmp_path: Path):
+        t = _make_template(tmp_path)
+        self._stub_success_path(t)
+        t._check_vm_exists = MagicMock(return_value=True)
+
+        def fake_execute(cmd, *args, **kwargs):
+            if cmd == "domstate":
+                return _result(stdout="shut off")
+            if cmd == "undefine":
+                return _result(ok=False, stderr="domain is still active")
+            return _result()
+
+        with patch.object(t.virsh, "execute", side_effect=fake_execute), \
+                patch(self.SLEEP):
+            assert t.create_template(force=True) is False
+        t.copy_base_image.assert_not_called()
+
+    def test_force_recreate_aborts_when_vm_stays_running(self, tmp_path: Path):
+        t = _make_template(tmp_path)
+        self._stub_success_path(t)
+        t._check_vm_exists = MagicMock(return_value=True)
+        calls: list[str] = []
+
+        def fake_execute(cmd, *args, **kwargs):
+            calls.append(cmd)
+            if cmd == "domstate":
+                return _result(stdout="running")
+            return _result()
+
+        with patch.object(t.virsh, "execute", side_effect=fake_execute), \
+                patch(self.SLEEP):
+            assert t.create_template(force=True) is False
+        assert calls.count("domstate") == 30  # polled until the cap, then gave up
+        assert "undefine" not in calls
+
+    def test_create_template_aborts_when_dhcp_missing(self, tmp_path: Path):
+        t = _make_template(tmp_path)
+        self._stub_success_path(t)
+        t._check_vm_exists = MagicMock(return_value=False)
+        t._verify_dhcp_on_network = MagicMock(return_value=False)
+        with patch.object(t.virsh, "execute", return_value=_result()):
+            assert t.create_template() is False
+        t.copy_base_image.assert_not_called()
+
+    def test_explicit_bridge_skips_the_dhcp_check(self, tmp_path: Path):
+        t = _make_template(tmp_path, bridge="virbr0")
+        self._stub_success_path(t)
+        t._check_vm_exists = MagicMock(return_value=False)
+        with patch.object(t.virsh, "execute", return_value=_result()), \
+                patch(self.SHELL_RUN, return_value=_result()):
+            assert t.create_template() is True
+        t._verify_dhcp_on_network.assert_not_called()


### PR DESCRIPTION
Refs #85 (item 26). Three small fixes:

**(a) CDROM target/bus mismatch** — `_find_next_available_target` may return an `sdX` target once IDE slots are taken, but `_generate_cdrom_xml` and the detach XML hardcoded `bus='ide'` → inconsistent device XML. Fix: new `_bus_for_target()` derives the bus from the target prefix (`hd*→ide`, `sd*→sata`); used by both attach and detach XML.

**(b) Template force-recreate race** — `create_template --force` did destroy + undefine with `warn=True`, results ignored, no wait for shut-off → undefine could fail while QEMU was alive and the subsequent virt-install died with "domain already exists". Fix: extracted the existing shutdown-wait loop as `_wait_until_shut_off()` (reused by `_shutdown_template`), wait for shut-off after destroy, abort with a clear error if the VM stays running or undefine fails.

**(c) Ignored DHCP check** — `_verify_dhcp_on_network()` result was dropped, proceeding into a multi-minute guest-agent timeout when DHCP is known-absent. Fix: fail fast before virt-install. Check is still skipped when an explicit `bridge` is configured.

Tests: `TestBusForTarget` (cdrom, incl. detach XML captured mid-execute) and `TestCreateTemplateSafeguards` (cloudinit: wait-ordering, undefine-failure abort, never-shut-off abort after 30 polls, DHCP-missing abort, explicit-bridge skip). 71 passed in the two touched test files; no new ruff violations.