### PR TITLE
fix: skip other-runtime cache entries for local runs too (#85 item 15)

### DIFF
--- a/src/boxman/providers/libvirt/net.py
+++ b/src/boxman/providers/libvirt/net.py
@@ -615,9 +615,10 @@ class Network(VirshCommand):
         """
         Check if there are any issues or conflicts with existing networks in the cache.
 
-        When running under a non-local runtime (e.g. docker-compose), only
-        projects registered under the **same** runtime are checked, because
-        each runtime has its own isolated libvirt instance.
+        Only projects registered under the **same** runtime are checked:
+        each runtime has its own isolated libvirt instance, so a network
+        living in a docker-compose runtime can never conflict with one on
+        the local host's libvirt (and vice versa).
 
         Returns:
             True if the network exists, False otherwise
@@ -631,9 +632,11 @@ class Network(VirshCommand):
         conflicts = {}
         n_conflicts = 0
         for project_name, project_data in projects_in_cache.items():
-            # Skip projects from a different runtime scope
+            # Skip projects from a different runtime scope -- including when
+            # the current runtime is 'local': a docker-compose runtime is a
+            # different libvirt instance, not the same one
             project_runtime = project_data.get('runtime', 'local')
-            if current_runtime != 'local' and project_runtime != current_runtime:
+            if project_runtime != current_runtime:
                 self.logger.debug(
                     f"skipping project {project_name} (runtime={project_runtime}) "
                     f"— current runtime is {current_runtime}")

--- a/tests/test_net_reconcile.py
+++ b/tests/test_net_reconcile.py
@@ -570,6 +570,64 @@ class TestCacheSelfConflict:
             net.define_network(str(tmp_path / 'net.xml'))
 
 
+class TestRuntimeScopeFiltering:
+    """
+    Conflicts are only meaningful within one runtime scope.
+
+    Regression tests for issue #85 item 15: each runtime has its own
+    isolated libvirt instance, but the filter used to be
+    ``current != 'local' and project_runtime != current`` -- so a local run
+    still conflict-checked projects living in a docker-compose runtime and
+    reported false name/bridge/IP conflicts against a libvirt it does not
+    even talk to.
+    """
+
+    @staticmethod
+    def _net(tmp_path, cached: dict, runtime: str):
+        from boxman.config_cache import BoxmanCache
+
+        cache = BoxmanCache.__new__(BoxmanCache)
+        cache.cache_dir = str(tmp_path)
+        cache.projects_cache_file = str(tmp_path / 'projects.json')
+        cache.projects = None
+        (tmp_path / 'projects.json').write_text(json.dumps(cached))
+
+        manager = MagicMock()
+        manager.cache = cache
+        manager.config = {'project': 'p1'}
+        manager._runtime_name = runtime
+
+        info = {"mode": "nat", "bridge": {"name": "virbr9"},
+                "ip": {"address": "10.5.3.1", "netmask": "255.255.255.0"}}
+        return Network(name="net-a", info=info, assign_new_bridge=True,
+                       provider_config={"use_sudo": False}, manager=manager)
+
+    # the other project collides on name, bridge AND address -- if it is
+    # checked at all, every conflict type fires
+    _OTHER = {'p2': {'runtime': None, 'networks': {
+        'net-a': {'ip_address': '10.5.3.1', 'bridge_name': 'virbr9'}}}}
+
+    def test_local_run_ignores_docker_compose_projects(self, tmp_path):
+        cached = {**self._OTHER, 'p2': {**self._OTHER['p2'],
+                                        'runtime': 'docker-compose'}}
+        net = self._net(tmp_path, cached, runtime='local')
+        net.check_network_exists()      # must not raise
+
+    def test_docker_compose_run_ignores_local_projects(self, tmp_path):
+        cached = {**self._OTHER, 'p2': {**self._OTHER['p2'],
+                                        'runtime': 'local'}}
+        net = self._net(tmp_path, cached, runtime='docker-compose')
+        net.check_network_exists()      # must not raise
+
+    def test_same_scope_still_conflicts(self, tmp_path):
+        for runtime in ('local', 'docker-compose'):
+            cached = {**self._OTHER, 'p2': {**self._OTHER['p2'],
+                                            'runtime': runtime}}
+            net = self._net(tmp_path, cached, runtime=runtime)
+            with pytest.raises(RuntimeError, match="conflict"):
+                net.check_network_exists()
+
+
 class TestElementRendering:
 
     def test_host_element_includes_the_optional_name(self):


### PR DESCRIPTION
Refs #85 (item 15).

**Problem:** `check_network_exists()` filtered cached projects with `if current_runtime != 'local' and project_runtime != current_runtime`. When the current runtime is `local`, projects registered under a docker-compose runtime — a **different, isolated libvirt instance** — were still conflict-checked, producing false name/bridge/IP conflicts.

**Fix:** always skip when `project_runtime != current_runtime`; updated the docstring accordingly.

**Related, deliberately left alone:** `_get_cached_bridges()` (net.py, same file) carries the same inverted condition for bridge-index allocation. Its failure mode is harmless (a local run may skip a virbr index used only inside a container runtime), and the item scopes the fix to the conflict filter — flagging it here in case a follow-up wants it.

**Tests:** new `TestRuntimeScopeFiltering` in `tests/test_net_reconcile.py` driving the real `BoxmanCache`: local run ignores docker-compose projects (previously raised), docker-compose run ignores local projects, and same-scope collisions on name+bridge+IP still raise for both runtimes. 138 passed across `tests/test_net_reconcile.py` + `tests/test_libvirt_net.py`; ruff shows no new violations vs `origin/polish`.