### PR TITLE
fix: vm_differ silently skips desired disk when a stale image exists (#85 item 23)

### DIFF
--- a/src/boxman/providers/libvirt/disk.py
+++ b/src/boxman/providers/libvirt/disk.py
@@ -154,7 +154,9 @@ class DiskManager(VirshCommand):
         Configure a disk from configuration.
 
         Args:
-            disk_config: Dictionary with disk configuration
+            disk_config: Dictionary with disk configuration. When it
+                contains ``attach_only: True`` the image file is expected
+                to already exist and creation is skipped (attach only).
             workdir: Working directory for disk images
             disk_prefix: Prefix to add to disk image filename
 
@@ -184,8 +186,13 @@ class DiskManager(VirshCommand):
             # ensure path is expanded
             disk_path = os.path.expanduser(disk_path)
 
-            # 1. create the disk
-            if not self.create_disk(disk_path, disk_size, format=driver_type):
+            # 1. create the disk — unless the caller flagged the config
+            # attach_only (image file already exists, e.g. a leftover
+            # from a failed earlier run): recreating it would wipe data.
+            if disk_config.get("attach_only"):
+                self.logger.info(
+                    f"using existing disk image {disk_path} (attach only)")
+            elif not self.create_disk(disk_path, disk_size, format=driver_type):
                 self.logger.error(f"failed to create disk {disk_path}")
                 return False
 

--- a/src/boxman/providers/libvirt/vm_differ.py
+++ b/src/boxman/providers/libvirt/vm_differ.py
@@ -289,6 +289,9 @@ class VMStateDiffer:
               - max_vcpus_changed, desired_max_vcpus, actual_max_vcpus
               - max_memory_changed, desired_max_memory_mb, actual_max_memory_mb
               - new_disks: list of disk configs to create and attach
+                (a config carries ``attach_only: True`` when its image
+                file already exists on disk — attach it as-is instead of
+                recreating it)
               - resize_disks: list of dicts with target, source, current_size_mb, desired_size_mb
               - new_cdroms, removed_cdroms, changed_cdroms
               - new_shared_folders, removed_shared_folders, changed_shared_folders
@@ -345,9 +348,20 @@ class VMStateDiffer:
             desired_size = disk_config.get('size', 1024)
             expected_path = self._expected_disk_path(disk_config, workdir, disk_prefix)
 
-            if target not in actual_targets and not os.path.exists(expected_path):
-                # new disk — not attached and file doesn't exist
-                new_disks.append(disk_config)
+            if target not in actual_targets:
+                if os.path.exists(expected_path):
+                    # Leftover image from a failed earlier run — the disk
+                    # is neither new nor a resize. Attach the existing
+                    # file as-is (skip create) rather than silently
+                    # dropping the desired disk.
+                    self.logger.warning(
+                        f"disk {target} on {domain_name}: image "
+                        f"{expected_path} exists but is not attached — "
+                        f"attaching existing file (skipping create)")
+                    new_disks.append({**disk_config, 'attach_only': True})
+                else:
+                    # new disk — not attached and file doesn't exist
+                    new_disks.append(disk_config)
             elif target in actual_targets:
                 # disk exists — check if resize needed
                 actual_disk = actual_by_target[target]

--- a/tests/test_libvirt_disk.py
+++ b/tests/test_libvirt_disk.py
@@ -1,0 +1,54 @@
+"""
+Unit tests for boxman.providers.libvirt.disk.DiskManager.
+
+Currently pins the attach_only flag from issue #85 item 23: when the
+image file already exists (leftover from a failed earlier run),
+``configure_from_disk_config`` must skip ``qemu-img create`` and only
+attach the existing file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from boxman.providers.libvirt.disk import DiskManager
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def dm() -> DiskManager:
+    return DiskManager(vm_name="vm01",
+                       provider_config={"use_sudo": False,
+                                        "uri": "qemu:///system"})
+
+
+class TestConfigureFromDiskConfig:
+
+    def test_creates_then_attaches_by_default(self, dm: DiskManager,
+                                              tmp_path: Path):
+        config = {"name": "data", "target": "vdb", "size": 1024}
+        with patch.object(dm, "create_disk", return_value=True) as create, \
+             patch.object(dm, "attach_disk", return_value=True) as attach:
+            assert dm.configure_from_disk_config(config, str(tmp_path),
+                                                 "vm01") is True
+        create.assert_called_once()
+        attach.assert_called_once()
+
+    def test_attach_only_skips_create(self, dm: DiskManager,
+                                      tmp_path: Path):
+        """Regression for issue #85 item 23: attach_only must not run
+        qemu-img create — that would wipe the existing image."""
+        (tmp_path / "vm01_data.qcow2").write_bytes(b"x")
+        config = {"name": "data", "target": "vdb", "size": 1024,
+                  "attach_only": True}
+        with patch.object(dm, "create_disk") as create, \
+             patch.object(dm, "attach_disk", return_value=True) as attach:
+            assert dm.configure_from_disk_config(config, str(tmp_path),
+                                                 "vm01") is True
+        create.assert_not_called()
+        attach.assert_called_once()
+        assert (tmp_path / "vm01_data.qcow2").read_bytes() == b"x"

--- a/tests/test_libvirt_vm_differ.py
+++ b/tests/test_libvirt_vm_differ.py
@@ -1,0 +1,90 @@
+"""
+Unit tests for boxman.providers.libvirt.vm_differ.VMStateDiffer.
+
+Currently pins the disk-diff regression from issue #85 item 23: a
+desired disk whose image file already exists (leftover from a failed
+earlier run) but which is not attached must be reported as an
+attach-only new disk — not silently skipped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from boxman.providers.libvirt.vm_differ import VMStateDiffer
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def differ() -> VMStateDiffer:
+    return VMStateDiffer(provider_config={"use_sudo": False,
+                                          "uri": "qemu:///system"})
+
+
+def _diff_disks(differ: VMStateDiffer,
+                desired_disks: list[dict],
+                actual_disks: list[dict],
+                workdir: str) -> dict:
+    """Run diff_vm with every non-disk probe mocked out."""
+    with patch.object(differ, "get_vm_state", return_value="running"), \
+         patch.object(differ, "get_actual_cpu",
+                      return_value={"sockets": 1, "cores": 1, "threads": 1,
+                                    "total_vcpus": 1, "current_vcpus": 1}), \
+         patch.object(differ, "get_max_vcpus", return_value=1), \
+         patch.object(differ, "get_actual_memory_mb", return_value=1024), \
+         patch.object(differ, "get_max_memory_mb", return_value=1024), \
+         patch.object(differ, "get_actual_disks", return_value=actual_disks), \
+         patch.object(differ, "get_actual_cdroms", return_value=[]), \
+         patch.object(differ, "get_actual_shared_folders", return_value=[]):
+        return differ.diff_vm(
+            domain_name="vm01",
+            desired_cpus=None,
+            desired_memory_mb=None,
+            desired_disks=desired_disks,
+            workdir=workdir,
+            disk_prefix="vm01",
+        )
+
+
+class TestDiskDiff:
+
+    def test_new_disk_when_file_missing(self, differ: VMStateDiffer,
+                                        tmp_path: Path):
+        desired = [{"name": "data", "target": "vdb", "size": 1024}]
+        diff = _diff_disks(differ, desired, [], str(tmp_path))
+        assert diff["new_disks"] == desired
+        assert "attach_only" not in diff["new_disks"][0]
+
+    def test_stale_file_becomes_attach_only(self, differ: VMStateDiffer,
+                                            tmp_path: Path):
+        """Regression for issue #85 item 23: image exists but is not
+        attached — must surface as attach-only, not vanish silently."""
+        (tmp_path / "vm01_data.qcow2").write_bytes(b"x")
+        desired = [{"name": "data", "target": "vdb", "size": 1024}]
+        diff = _diff_disks(differ, desired, [], str(tmp_path))
+        assert len(diff["new_disks"]) == 1
+        assert diff["new_disks"][0]["attach_only"] is True
+        assert diff["new_disks"][0]["name"] == "data"
+
+    def test_stale_file_logs_warning(self, differ: VMStateDiffer,
+                                     tmp_path: Path, caplog):
+        (tmp_path / "vm01_data.qcow2").write_bytes(b"x")
+        desired = [{"name": "data", "target": "vdb", "size": 1024}]
+        with caplog.at_level("WARNING"):
+            _diff_disks(differ, desired, [], str(tmp_path))
+        assert any("attach" in rec.message and "vdb" in rec.message
+                   for rec in caplog.records)
+
+    def test_attached_disk_not_in_new_disks(self, differ: VMStateDiffer,
+                                            tmp_path: Path):
+        desired = [{"name": "data", "target": "vdb", "size": 1024}]
+        actual = [{"target": "vdb",
+                   "source": str(tmp_path / "vm01_data.qcow2"),
+                   "size_mb": 1024}]
+        diff = _diff_disks(differ, desired, actual, str(tmp_path))
+        assert diff["new_disks"] == []
+        assert diff["resize_disks"] == []


### PR DESCRIPTION
Refs #85

**Item 23** — `vm_differ.py`: `diff_vm` only classified a desired disk as new when `target not in actual_targets and not os.path.exists(expected_path)`. A leftover image from a failed earlier run made the disk neither "new" nor "resize" — never attached, no warning, update reported success.

Fix:
- `vm_differ.py`: file-exists-but-not-attached disks go into `new_disks` with `attach_only: True` and a warning log.
- `disk.py`: `configure_from_disk_config` honors `attach_only` by skipping `qemu-img create` (which would wipe the existing image) and only attaching.

Note: `manager.py`/`session.py` pass the disk config dict through unchanged, so the flag flows without touching files owned by other groups.

Tests: new `tests/test_libvirt_vm_differ.py` (stale-file → attach-only + warning, missing file → normal new disk, attached → unchanged) and `tests/test_libvirt_disk.py` (attach_only skips create, default path still creates).