### PR TITLE
fix: monolithic force-undefine is version-fragile and non-idempotent (#85 item 25)

### DIFF
--- a/src/boxman/providers/libvirt/destroy_vm.py
+++ b/src/boxman/providers/libvirt/destroy_vm.py
@@ -230,7 +230,22 @@ class DestroyVM(VirshCommand):
         try:
             self.logger.info(f"**force** un-defining vm {self.name}")
 
-            self.execute("undefine --remove-all-storage --wipe-storage --delete-storage-volume-snapshots --snapshots-metadata", self.name)
+            # Try the full storage-removal form first. It is not
+            # idempotent (--remove-all-storage errors when the files are
+            # already gone) and --delete-storage-volume-snapshots
+            # requires a recent libvirt, so on failure fall back to a
+            # plain undefine that only drops snapshot metadata — the
+            # domain must always be removable.
+            result = self.execute(
+                "undefine", self.name,
+                "--remove-all-storage", "--wipe-storage",
+                "--delete-storage-volume-snapshots", "--snapshots-metadata",
+                warn=True)
+            if not result.ok:
+                self.logger.warning(
+                    f"undefine with storage removal failed for {self.name} "
+                    f"({result.stderr.strip()}) — retrying plain undefine")
+                self.execute("undefine", self.name, "--snapshots-metadata")
 
             # verify that the vm is no longer defined
             if not self.is_vm_defined():

--- a/tests/test_libvirt_destroy_vm.py
+++ b/tests/test_libvirt_destroy_vm.py
@@ -177,7 +177,9 @@ class TestForceUndefine:
             assert dv.force_undefine_vm() is True
         calls = [c.args[0] for c in execute.call_args_list]
         assert "destroy" in calls  # force-kill first
-        assert any("undefine --remove-all-storage" in c for c in calls)
+        rich = [c for c in execute.call_args_list
+                if c.args[0] == "undefine" and "--remove-all-storage" in c.args]
+        assert rich, "expected the full storage-removal undefine"
 
     def test_skips_kill_when_already_shut_off(self, dv: DestroyVM):
         with patch.object(dv, "is_vm_defined", side_effect=[True, False]), \
@@ -186,6 +188,55 @@ class TestForceUndefine:
             dv.force_undefine_vm()
         calls = [c.args[0] for c in execute.call_args_list]
         assert "destroy" not in calls
+
+    def test_flags_passed_as_separate_args(self, dv: DestroyVM):
+        """Regression for issue #85 item 25: flags must be separate
+        args, not one re-split string."""
+        with patch.object(dv, "is_vm_defined", side_effect=[True, False]), \
+             patch.object(dv, "is_vm_shut_off", return_value=True), \
+             patch.object(dv, "execute", return_value=_result()) as execute:
+            assert dv.force_undefine_vm() is True
+        undefine = [c for c in execute.call_args_list
+                    if c.args[0] == "undefine"][0]
+        assert undefine.args[1] == "vm01"
+        for flag in ("--remove-all-storage", "--wipe-storage",
+                     "--delete-storage-volume-snapshots",
+                     "--snapshots-metadata"):
+            assert flag in undefine.args
+
+    def test_falls_back_to_plain_undefine_on_failure(self, dv: DestroyVM):
+        """Regression for issue #85 item 25: when the rich undefine
+        fails (old libvirt, storage already gone), retry with plain
+        undefine --snapshots-metadata so the domain stays removable."""
+        calls = []
+
+        def fake_execute(*args, **kwargs):
+            calls.append((args, kwargs))
+            if args[0] == "undefine" and "--remove-all-storage" in args:
+                return _result(ok=False, stderr="unsupported flag")
+            return _result()
+
+        with patch.object(dv, "is_vm_defined", side_effect=[True, False]), \
+             patch.object(dv, "is_vm_shut_off", return_value=True), \
+             patch.object(dv, "execute", side_effect=fake_execute):
+            assert dv.force_undefine_vm() is True
+        undefines = [args for args, _ in calls if args[0] == "undefine"]
+        assert len(undefines) == 2
+        assert undefines[1] == ("undefine", "vm01", "--snapshots-metadata")
+        # rich form ran with warn=True so its failure could be handled
+        rich_kwargs = [kw for args, kw in calls
+                       if args[0] == "undefine"
+                       and "--remove-all-storage" in args][0]
+        assert rich_kwargs.get("warn") is True
+
+    def test_no_fallback_when_rich_undefine_succeeds(self, dv: DestroyVM):
+        with patch.object(dv, "is_vm_defined", side_effect=[True, False]), \
+             patch.object(dv, "is_vm_shut_off", return_value=True), \
+             patch.object(dv, "execute", return_value=_result()) as execute:
+            assert dv.force_undefine_vm() is True
+        undefines = [c for c in execute.call_args_list
+                     if c.args[0] == "undefine"]
+        assert len(undefines) == 1
 
 
 class TestRemove:
@@ -228,7 +279,8 @@ class TestRemove:
             assert dv.remove() is True
         calls = [c.args[0] for c in execute.call_args_list]
         assert "destroy" in calls  # force-killed the paused domain
-        assert any("undefine" in c and "--snapshots-metadata" in c for c in calls)
+        assert any(c.args[0] == "undefine" and "--snapshots-metadata" in c.args
+                   for c in execute.call_args_list)
 
     def test_never_issues_per_snapshot_snapshot_delete(self, dv: DestroyVM):
         with patch.object(dv, "is_vm_running", return_value=False), \
@@ -238,4 +290,5 @@ class TestRemove:
             assert dv.remove() is True
         commands = [c.args[0] for c in execute.call_args_list]
         assert not any(c.startswith("snapshot-delete") for c in commands)
-        assert any("--snapshots-metadata" in c for c in commands)
+        assert any("--snapshots-metadata" in c.args
+                   for c in execute.call_args_list)


### PR DESCRIPTION
Refs #85

**Item 25** — `destroy_vm.py`: `force_undefine_vm` ran `undefine --remove-all-storage --wipe-storage --delete-storage-volume-snapshots --snapshots-metadata` as one string relying on shell re-splitting; `--delete-storage-volume-snapshots` requires recent libvirt (older → whole undefine fails, VM unkillable); `--remove-all-storage` errors when files are already gone (normal on second call).

Fix: flags passed as separate args; rich form runs with `warn=True`; on failure it retries plain `undefine --snapshots-metadata` so the domain is always removable.

Tests: fallback path taken on rich-form failure (and rich form ran with `warn=True`), no fallback on success, flags as separate args; existing `TestRemove` assertions updated to the separate-args call shape.