### PR TITLE
fix: shell quoting + XML escaping in net.py/network.xml.j2 (#85 item 6)

### DIFF
--- a/src/boxman/assets/network.xml.j2
+++ b/src/boxman/assets/network.xml.j2
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <network>
-  <name>{{ name }}</name>
+  {# the environment has no autoescape, so every config-derived value is
+     escaped explicitly -- a name holding an & or a quote would otherwise
+     produce XML that libvirt rejects at net-define #}
+  <name>{{ name|e }}</name>
   <uuid>{{ uuid_val }}</uuid>
   <forward mode='{{ forward_mode }}'/>
-  <bridge name='{{ bridge_name }}' stp='{{ bridge_stp }}' delay='{{ bridge_delay }}'/>
+  <bridge name='{{ bridge_name|e }}' stp='{{ bridge_stp }}' delay='{{ bridge_delay }}'/>
   <mac address='{{ mac_address }}'/>
-  <ip address='{{ ip_address }}' netmask='{{ netmask }}'>
+  <ip address='{{ ip_address|e }}' netmask='{{ netmask|e }}'>
   {% if (dhcp_range_start and dhcp_range_end) or dhcp_hosts %}
     <dhcp>
     {% if dhcp_range_start and dhcp_range_end %}
-      <range start='{{ dhcp_range_start }}' end='{{ dhcp_range_end }}'/>
+      <range start='{{ dhcp_range_start|e }}' end='{{ dhcp_range_end|e }}'/>
     {% endif %}
     {# <range> first, then <host>: libvirt accepts either order but emits and
        documents this one, so a dumpxml diff stays readable. the attributes are

--- a/src/boxman/providers/libvirt/net.py
+++ b/src/boxman/providers/libvirt/net.py
@@ -1,6 +1,7 @@
 import ipaddress
 import os
 import re
+import shlex
 import sys
 import tempfile
 import uuid
@@ -1003,8 +1004,10 @@ class Network(VirshCommand):
             return True
 
         try:
-            br_name = self.bridge_name
-            self.logger.info(f"removing route isolation rules for bridge {br_name}")
+            # shlex.quote: the bridge name comes from the config and is
+            # interpolated into a shell string below
+            br_name = shlex.quote(self.bridge_name)
+            self.logger.info(f"removing route isolation rules for bridge {self.bridge_name}")
 
             # no embedded 'sudo': execute_shell routes that decision through
             # _should_use_sudo_for_command, so use_sudo: false is honoured
@@ -1049,9 +1052,11 @@ class Network(VirshCommand):
             return True  # Nothing to do for non-route networks
 
         try:
-            bridge_name = self.bridge_name
+            # shlex.quote: the bridge name comes from the config and is
+            # interpolated into a shell string below
+            bridge_name = shlex.quote(self.bridge_name)
             self.logger.info(
-                f"configuring complete isolation for routed network with bridge {bridge_name}")
+                f"configuring complete isolation for routed network with bridge {self.bridge_name}")
 
             # 1. allow vm-to-vm communication on the same bridge. No embedded
             # 'sudo' here or below: execute_shell routes that decision through

--- a/tests/test_libvirt_net.py
+++ b/tests/test_libvirt_net.py
@@ -583,3 +583,86 @@ class TestRouteIsolationRules:
                    return_value=_result()) as run:
             net.execute_shell("iptables -C INPUT -i virbr9 -j DROP", warn=True)
         assert run.call_args.args[0].startswith(expected_prefix)
+
+
+class TestShellQuoting:
+    """Config-derived values interpolated into shell strings are quoted.
+
+    Regression tests for issue #85 item 6 (net.py part): the bridge name
+    comes from the configuration and used to land in the iptables command
+    strings verbatim.
+    """
+
+    @staticmethod
+    def _net(bridge_name: str) -> Network:
+        return Network(name="routed-net",
+                       info={"mode": "route", "bridge": {"name": bridge_name}},
+                       assign_new_bridge=True,
+                       provider_config={"use_sudo": False})
+
+    def test_apply_quotes_a_bridge_name_with_metacharacters(self):
+        net = self._net("virbr 9;touch /tmp/x")
+        seen = []
+        with patch.object(
+                net, "_ensure_rule",
+                side_effect=lambda cls, chk, act, present=True:
+                    seen.append((chk, act)) or True):
+            assert net.apply_route_iptables_rule() is True
+        assert seen
+        for check_cmd, action_cmd in seen:
+            assert "'virbr 9;touch /tmp/x'" in check_cmd
+            assert "'virbr 9;touch /tmp/x'" in action_cmd
+
+    def test_remove_quotes_a_bridge_name_with_metacharacters(self):
+        net = self._net("virbr 9;touch /tmp/x")
+        seen = []
+        with patch.object(
+                net, "_ensure_rule",
+                side_effect=lambda cls, chk, act, present=True:
+                    seen.append((chk, act)) or True):
+            assert net.remove_route_iptables_rule() is True
+        assert seen
+        for check_cmd, action_cmd in seen:
+            assert "'virbr 9;touch /tmp/x'" in check_cmd
+            assert "'virbr 9;touch /tmp/x'" in action_cmd
+
+    def test_a_plain_bridge_name_is_left_unquoted(self):
+        net = self._net("virbr9")
+        seen = []
+        with patch.object(
+                net, "_ensure_rule",
+                side_effect=lambda cls, chk, act, present=True:
+                    seen.append(chk) or True):
+            assert net.apply_route_iptables_rule() is True
+        assert seen
+        for check_cmd in seen:
+            # shlex.quote leaves a shell-safe name untouched
+            assert "virbr9" in check_cmd
+            assert "'" not in check_cmd
+
+
+class TestXmlEscaping:
+    """The network template has no autoescape; config values need |e.
+
+    Regression tests for issue #85 item 6 (network.xml.j2 part).
+    """
+
+    @staticmethod
+    def _net(name: str, bridge_name: str = "virbr9") -> Network:
+        return Network(name=name,
+                       info={"mode": "nat", "bridge": {"name": bridge_name},
+                             "ip": {"address": "10.5.3.1",
+                                    "netmask": "255.255.255.0"}},
+                       assign_new_bridge=True,
+                       provider_config={"use_sudo": False})
+
+    def test_name_with_xml_metacharacters_stays_well_formed(self):
+        net = self._net("net&<x>")
+        root = ET.fromstring(net.generate_xml())   # must parse
+        assert root.findtext("name") == "net&<x>"
+
+    def test_bridge_name_with_a_quote_cannot_break_out_of_the_attribute(self):
+        net = self._net("demo-net", bridge_name="virbr0' onload='x")
+        root = ET.fromstring(net.generate_xml())   # must parse
+        assert root.find("bridge").get("name") == "virbr0' onload='x"
+        assert "onload" not in root.find("bridge").attrib


### PR DESCRIPTION
Refs #85 (item 6, net.py part only — commands.py's build_command belongs to another group).

**Problem:** the bridge name (config-derived) was interpolated verbatim into the route-isolation iptables command strings, and `network.xml.j2` rendered `name`/`bridge_name`/`ip_address`/`netmask`/DHCP range without `|e` in a Jinja environment with no autoescape (only the DHCP host attributes were escaped).

**Fix:**
- `shlex.quote()` on the bridge name in `apply_route_iptables_rule()`/`remove_route_iptables_rule()`, matching the established pattern in `direct_vm.py`. Plain names like `virbr9` are untouched by the quote.
- Added `|e` to all config-derived values in `network.xml.j2`.
- Note: the other shell strings this item listed (NAT masquerade / `ip route get 8.8.8.8`, old net.py:1043/1164 etc.) no longer exist — item 14 (#93) removed boxman's NAT rules along with them.

**Tests:** new `TestShellQuoting` (a bridge name with spaces/metachars yields a single-quoted token in every rule command; a plain name stays unquoted) and `TestXmlEscaping` (a network name with `&<` and a bridge name with a quote produce well-formed XML that parses back to the original values, no attribute breakout). 143 passed across `tests/test_libvirt_net.py` + `tests/test_net_reconcile.py`; ruff shows no new violations vs `origin/polish`.