### PR TITLE
fix: shell quoting + XML escaping in cloudinit/cdrom (#85 item 6, cloudinit/cdrom part)

### DIFF
--- a/src/boxman/providers/libvirt/cdrom.py
+++ b/src/boxman/providers/libvirt/cdrom.py
@@ -1,8 +1,19 @@
 import os
 import tempfile
 from typing import Any
+from xml.sax.saxutils import escape
 
 from .commands import VirshCommand
+
+
+def _xml_attr(value: str) -> str:
+    """
+    Escape a value for use inside a single-quoted XML attribute.
+
+    Mirrors ``net_reconcile._attr``: a source path or target name holding an
+    ``&`` or a quote would otherwise produce XML that libvirt cannot parse.
+    """
+    return escape(str(value), {"'": '&apos;', '"': '&quot;'})
 
 
 class CDROMManager(VirshCommand):
@@ -84,7 +95,7 @@ class CDROMManager(VirshCommand):
             # Generate XML for the device to detach (source not needed for detach)
             bus = self._bus_for_target(target_dev)
             xml_content = f"""<disk type='file' device='cdrom'>
-  <target dev='{target_dev}' bus='{bus}'/>
+  <target dev='{_xml_attr(target_dev)}' bus='{bus}'/>
   <readonly/>
 </disk>"""
 
@@ -213,8 +224,8 @@ class CDROMManager(VirshCommand):
         bus = self._bus_for_target(target_dev)
         return f"""<disk type='file' device='cdrom'>
   <driver name='qemu' type='raw'/>
-  <source file='{source_path}'/>
-  <target dev='{target_dev}' bus='{bus}'/>
+  <source file='{_xml_attr(source_path)}'/>
+  <target dev='{_xml_attr(target_dev)}' bus='{bus}'/>
   <readonly/>
 </disk>"""
 

--- a/src/boxman/providers/libvirt/cloudinit.py
+++ b/src/boxman/providers/libvirt/cloudinit.py
@@ -186,10 +186,12 @@ class CloudInitTemplate:
         network_config_path = os.path.join(nocloud_dir, "network-config")
         network_flag = ""
         if os.path.exists(network_config_path):
-            network_flag = f' --network-config="{network_config_path}"'
+            network_flag = f" --network-config={shlex.quote(network_config_path)}"
 
         result = self.virsh.execute_shell(
-            f'cloud-localds{network_flag} "{seed_iso_path}" "{nocloud_dir}/user-data" "{nocloud_dir}/meta-data"',
+            f"cloud-localds{network_flag} {shlex.quote(seed_iso_path)} "
+            f"{shlex.quote(os.path.join(nocloud_dir, 'user-data'))} "
+            f"{shlex.quote(os.path.join(nocloud_dir, 'meta-data'))}",
             hide=not is_verbose(logging.DEBUG), warn=True,
         )
         if result.ok:
@@ -199,12 +201,13 @@ class CloudInitTemplate:
         # Fallback: include network-config in the ISO if present
         extra_files = ""
         if os.path.exists(network_config_path):
-            extra_files = f' "{network_config_path}"'
+            extra_files = f" {shlex.quote(network_config_path)}"
 
         for tool in ("genisoimage", "mkisofs", "xorrisofs"):
             result = self.virsh.execute_shell(
-                f'{tool} -output "{seed_iso_path}" -volid cidata -joliet -rock '
-                f'"{nocloud_dir}/user-data" "{nocloud_dir}/meta-data"{extra_files}',
+                f"{tool} -output {shlex.quote(seed_iso_path)} -volid cidata -joliet -rock "
+                f"{shlex.quote(os.path.join(nocloud_dir, 'user-data'))} "
+                f"{shlex.quote(os.path.join(nocloud_dir, 'meta-data'))}{extra_files}",
                 hide=not is_verbose(logging.DEBUG), warn=True,
             )
             if result.ok:
@@ -466,7 +469,7 @@ class CloudInitTemplate:
         """Sparse-copy a local file; falls back to shutil.copy2."""
         self.logger.info(f"copying image {src} -> {dst}")
         result = self.virsh.execute_shell(
-            f'rsync --sparse --progress "{src}" "{dst}"',
+            f'rsync --sparse --progress {shlex.quote(src)} {shlex.quote(dst)}',
             hide=not is_verbose(logging.DEBUG), warn=True,
         )
         if result.ok:
@@ -511,7 +514,7 @@ class CloudInitTemplate:
 
         # Try wget first (handles redirects, proxies, SSL better)
         result = _shell_run(
-            f'wget --progress=dot:mega -O "{dst_path}" "{url}"',
+            f'wget --progress=dot:mega -O {shlex.quote(dst_path)} {shlex.quote(url)}',
             hide=not is_verbose(logging.DEBUG), warn=True,
         )
         if result.ok and os.path.isfile(dst_path) and os.path.getsize(dst_path) > 0:
@@ -520,7 +523,7 @@ class CloudInitTemplate:
 
         # Try curl as second fallback
         result = _shell_run(
-            f'curl -L --progress-bar -o "{dst_path}" "{url}"',
+            f'curl -L --progress-bar -o {shlex.quote(dst_path)} {shlex.quote(url)}',
             hide=not is_verbose(logging.DEBUG), warn=True,
         )
         if result.ok and os.path.isfile(dst_path) and os.path.getsize(dst_path) > 0:
@@ -987,20 +990,20 @@ class CloudInitTemplate:
             if self.virt_install.use_sudo:
                 parts.append("sudo")
             parts.append(self.virt_install.command_path)
-            parts.append(f"--connect={self.virt_install.uri}")
-            parts.append(f"--name={self.template_name}")
+            parts.append(f"--connect={shlex.quote(self.virt_install.uri)}")
+            parts.append(f"--name={shlex.quote(self.template_name)}")
             parts.append(f"--memory={self.memory}")
             parts.append(f"--vcpus={self.vcpus}")
-            parts.append(f"--os-variant={self.os_variant}")
+            parts.append(f"--os-variant={shlex.quote(self.os_variant)}")
             parts.append("--import")
-            parts.append(f"--disk=path={dst_image_path},format={self.disk_format},bus=virtio,discard=unmap")
-            parts.append(f"--disk=path={seed_iso_path},device=cdrom")
+            parts.append(f"--disk=path={shlex.quote(dst_image_path)},format={self.disk_format},bus=virtio,discard=unmap")
+            parts.append(f"--disk=path={shlex.quote(seed_iso_path)},device=cdrom")
 
             # Use bridge device directly if resolved, otherwise fall back to network name
             if bridge_device:
-                parts.append(f"--network=bridge={bridge_device},model=virtio")
+                parts.append(f"--network=bridge={shlex.quote(bridge_device)},model=virtio")
             else:
-                parts.append(f"--network=network={self.network},model=virtio")
+                parts.append(f"--network=network={shlex.quote(self.network)},model=virtio")
 
             parts.append("--graphics=vnc")
             parts.append("--video=virtio")

--- a/tests/test_libvirt_cdrom.py
+++ b/tests/test_libvirt_cdrom.py
@@ -229,3 +229,32 @@ class TestGetAttachedCDROMs:
     def test_empty_on_execute_failure(self, cd: CDROMManager):
         with patch.object(cd, "execute", return_value=_result(ok=False)):
             assert cd.get_attached_cdroms() == []
+
+
+class TestXmlEscaping:
+    # device XML interpolates paths/names into attributes — a value holding
+    # & or a quote must be escaped or libvirt cannot parse it (#85 item 6)
+
+    def test_source_path_is_escaped(self, cd: CDROMManager):
+        xml = cd._generate_cdrom_xml("/tmp/a&b's.iso", "hdc")
+        assert "file='/tmp/a&amp;b&apos;s.iso'" in xml
+
+    def test_target_is_escaped(self, cd: CDROMManager):
+        xml = cd._generate_cdrom_xml("/tmp/foo.iso", 'hd"c')
+        assert "dev='hd&quot;c'" in xml
+
+    def test_detach_target_is_escaped(self, cd: CDROMManager):
+        written = {}
+
+        def capture(*args, **kwargs):
+            written["xml"] = Path(args[2]).read_text()
+            return _result()
+
+        with patch.object(cd, "execute", side_effect=capture):
+            assert cd.detach_cdrom("hd&c") is True
+        assert "dev='hd&amp;c'" in written["xml"]
+
+    def test_plain_values_are_left_untouched(self, cd: CDROMManager):
+        xml = cd._generate_cdrom_xml("/tmp/foo.iso", "hdc")
+        assert "file='/tmp/foo.iso'" in xml
+        assert "dev='hdc'" in xml

--- a/tests/test_libvirt_cloudinit.py
+++ b/tests/test_libvirt_cloudinit.py
@@ -14,6 +14,7 @@ Part of Phase 1.2 of the review plan
 from __future__ import annotations
 
 import os
+import shlex
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -542,3 +543,102 @@ class TestCreateTemplateSafeguards:
                 patch(self.SHELL_RUN, return_value=_result()):
             assert t.create_template() is True
         t._verify_dhcp_on_network.assert_not_called()
+
+
+class TestShellQuoting:
+    """
+    Paths and names interpolated into shell command strings must be
+    shlex-quoted (#85 item 6): a space or quote in a workdir, ISO path or
+    template name must not split or break the command.
+    """
+
+    SHELL_RUN = "boxman.providers.libvirt.cloudinit._shell_run"
+
+    def test_seed_iso_paths_are_quoted(self, tmp_path: Path):
+        t = _make_template(tmp_path)
+        nocloud = tmp_path / "no cloud"
+        nocloud.mkdir()
+        seed = str(tmp_path / "se'ed.iso")
+        with patch.object(t.virsh, "execute_shell",
+                          return_value=_result(ok=True)) as shell:
+            assert t.build_seed_iso(str(nocloud), seed) is True
+        cmd = shell.call_args.args[0]
+        assert shlex.quote(seed) in cmd
+        assert shlex.quote(str(nocloud / "user-data")) in cmd
+        assert shlex.quote(str(nocloud / "meta-data")) in cmd
+
+    def test_seed_iso_fallback_paths_are_quoted(self, tmp_path: Path):
+        t = _make_template(tmp_path)
+        nocloud = tmp_path / "no cloud"
+        nocloud.mkdir()
+        calls: list[str] = []
+
+        def fake(cmd, *_a, **_kw):
+            calls.append(cmd)
+            return _result(ok="genisoimage" in cmd)  # cloud-localds fails
+
+        with patch.object(t.virsh, "execute_shell", side_effect=fake):
+            assert t.build_seed_iso(str(nocloud), str(tmp_path / "s.iso")) is True
+        genisoimage = next(c for c in calls if "genisoimage" in c)
+        assert shlex.quote(str(nocloud / "user-data")) in genisoimage
+
+    def test_rsync_paths_are_quoted(self, tmp_path: Path):
+        t = _make_template(tmp_path)
+        with patch.object(t.virsh, "execute_shell",
+                          return_value=_result(ok=True)) as shell:
+            assert t._copy_local("/tmp/a b.qcow2", "/tmp/c d.qcow2") is True
+        cmd = shell.call_args.args[0]
+        assert shlex.quote("/tmp/a b.qcow2") in cmd
+        assert shlex.quote("/tmp/c d.qcow2") in cmd
+
+    def test_wget_command_quotes_dst_and_url(self, tmp_path: Path):
+        t = _make_template(tmp_path)
+        with patch(self.SHELL_RUN, return_value=_result(ok=True)) as run, \
+                patch("boxman.providers.libvirt.cloudinit.os.path.isfile",
+                      return_value=True), \
+                patch("boxman.providers.libvirt.cloudinit.os.path.getsize",
+                      return_value=10):
+            assert t._download_image(
+                "http://x/y iso.qcow2", "/tmp/d st.img") is True
+        cmd = run.call_args.args[0]
+        assert cmd.startswith("wget ")
+        assert f"-O {shlex.quote('/tmp/d st.img')}" in cmd
+        assert shlex.quote("http://x/y iso.qcow2") in cmd
+
+    def test_curl_command_quotes_dst_and_url(self, tmp_path: Path):
+        t = _make_template(tmp_path)
+        calls: list[str] = []
+
+        def fake_run(cmd, **_kw):
+            calls.append(cmd)
+            return _result(ok="curl" in cmd)
+
+        with patch(self.SHELL_RUN, side_effect=fake_run), \
+                patch("boxman.providers.libvirt.cloudinit.os.path.isfile",
+                      return_value=True), \
+                patch("boxman.providers.libvirt.cloudinit.os.path.getsize",
+                      return_value=10):
+            assert t._download_image(
+                "http://x/y iso.qcow2", "/tmp/d st.img") is True
+        curl = next(c for c in calls if c.startswith("curl "))
+        assert f"-o {shlex.quote('/tmp/d st.img')}" in curl
+        assert shlex.quote("http://x/y iso.qcow2") in curl
+
+    def test_virt_install_command_quotes_name_and_paths(self, tmp_path: Path):
+        t = _make_template(tmp_path, template_name="my tmpl")
+        t._check_vm_exists = MagicMock(return_value=False)
+        t._resolve_bridge = MagicMock(return_value="virbr0")
+        t._verify_dhcp_on_network = MagicMock(return_value=True)
+        t.copy_base_image = MagicMock(return_value=True)
+        t.prepare_nocloud_dir = MagicMock(return_value="/nocloud")
+        t.build_seed_iso = MagicMock(return_value=True)
+        t.verify_and_shutdown = MagicMock(return_value=True)
+        with patch.object(t.virsh, "execute", return_value=_result()), \
+                patch(self.SHELL_RUN, return_value=_result()) as run:
+            assert t.create_template() is True
+        cmd = run.call_args.args[0]
+        assert "--name='my tmpl'" in cmd
+        dst_image = os.path.join(t.workdir, "my tmpl", "my tmpl.qcow2")
+        assert f"path={shlex.quote(dst_image)}" in cmd
+        seed = os.path.join(t.workdir, "my tmpl", "seed.iso")
+        assert f"path={shlex.quote(seed)}" in cmd


### PR DESCRIPTION
Refs #85 (item 6 — cloudinit/cdrom part only; `commands.py` central fix is owned by another group and intentionally untouched).

**cloudinit.py** — replaced double-quoted interpolations with `shlex.quote` (pattern from `direct_vm.py:108,124`):
- `build_seed_iso`: cloud-localds / genisoimage seed-ISO, user-data, meta-data, network-config paths
- `_copy_local`: rsync src/dst
- `_download_image`: wget/curl dst path + URL
- `create_template` virt-install parts: `--connect` uri, `--name`, `--os-variant`, both `--disk=path=…`, `--network` bridge/network

A workdir, URL or template name with spaces/quotes no longer splits or breaks these commands.

**cdrom.py** — new module-level `_xml_attr()` (mirrors `net_reconcile._attr`, saxutils `escape` with quote mapping) applied to `source_path`/`target_dev` in the attach XML and `target_dev` in the detach XML, so `&`/quotes in values cannot produce unparseable libvirt XML.

Tests: `TestShellQuoting` (6 tests: seed ISO primary+fallback, rsync, wget, curl, virt-install name/disk paths) and `TestXmlEscaping` (4 tests incl. detach XML captured mid-execute). 81 passed across both touched test files; no new ruff violations.

Deferred (noted for the central `commands.py` fix): `cloudinit.py` `_resize_disk_image` (`qemu-img resize` path) is the same class of site but was outside this item's listed lines.