### PR TITLE
fix: raise on provision/up/snapshot failure paths instead of exit 0 (#85 item 3)

### DIFF
--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -18,7 +18,7 @@ from boxman.utils.shell import run
 from boxman import log
 from boxman.loggers.logger import suppressed
 from boxman.config_cache import BoxmanCache
-from boxman.exceptions import ConfigError
+from boxman.exceptions import ConfigError, ProvisionError, SnapshotError
 from boxman.image_cache import ImageCache
 from boxman.netlab import ContainerlabManager, shared_bridges
 from boxman.providers import PROVIDERS, primary_provider_type
@@ -4254,11 +4254,10 @@ class BoxmanManager:
             summary = "; ".join(reasons)
 
             if not force:
-                cls.logger.error(
+                raise ProvisionError(
                     f"cannot provision — {summary}. "
                     f"Use --force to deprovision first and re-provision."
                 )
-                return
 
             cls.logger.warning(
                 f"state will be deprovisioned first (--force): {summary}"
@@ -4269,8 +4268,7 @@ class BoxmanManager:
         try:
             cls.register_project_in_cache()
         except RuntimeError as exc:
-            cls.logger.error(str(exc))
-            return
+            raise ProvisionError(str(exc)) from exc
 
         # Expand any `base_image: oci://…` references into implicit templates
         # before template build / cloning (the clone path needs a VM name).
@@ -4284,22 +4282,19 @@ class BoxmanManager:
                 "for create-templates)..."
             )
             if cls._create_templates_impl(requested=None, force=True):
-                cls.logger.error(
+                raise ProvisionError(
                     "aborting: not every template could be rebuilt")
-                return
         else:
             # Auto-create any template VMs that are referenced as base_image
             # but do not yet exist.
             if not cls.ensure_templates_exist():
-                cls.logger.error(
+                raise ProvisionError(
                     "aborting: not every template could be created")
-                return
 
         try:
             cls.validate_base_images()
         except ValueError as exc:
-            cls.logger.error(str(exc))
-            return
+            raise ConfigError(str(exc)) from exc
 
         cls.provision_files()
 
@@ -4429,8 +4424,7 @@ class BoxmanManager:
                         "no existing project state found, running full provision...")
                     cls.provision(cls, cli_args)
                 return
-            cls.logger.error("no VMs defined in configuration")
-            return
+            raise ConfigError("no VMs defined in configuration")
 
         vm_states = cls._get_vm_states()
         existing_names = set(vm_states.keys())
@@ -4448,12 +4442,11 @@ class BoxmanManager:
             force = getattr(cli_args, 'force', False)
             names_str = ", ".join(f"'{v}'" for v in sorted(missing))
             if not force:
-                cls.logger.error(
+                raise ProvisionError(
                     f"partial infrastructure state: the following VM(s) are "
                     f"missing: {names_str}. Use --force to deprovision and "
                     f"re-provision everything."
                 )
-                return
             else:
                 cls.logger.warning(
                     f"partial state detected (missing: {names_str}). "
@@ -5282,7 +5275,8 @@ class BoxmanManager:
         if all_ok:
             cls.logger.info("all snapshots verified successfully")
         else:
-            cls.logger.error("one or more snapshots failed verification — check errors above")
+            raise SnapshotError(
+                "one or more snapshots failed verification — check errors above")
         cls._exit_if_dc_failed(dc_failed, 'take')
 
     @staticmethod
@@ -5362,9 +5356,8 @@ class BoxmanManager:
             if not snap_name:
                 snap_name = cls.session_for_vm(full_vm_name).get_latest_snapshot(full_vm_name)
                 if snap_name is None:
-                    cls.logger.error(
+                    raise SnapshotError(
                         f"no snapshot found for {full_vm_name}, aborting restore")
-                    return
                 cls.logger.info(
                     f"resolved latest snapshot for {full_vm_name}: '{snap_name}'")
             vm_targets.append((full_vm_name, snap_name))
@@ -5383,9 +5376,8 @@ class BoxmanManager:
                         f"snapshot invalid: {full_vm_name} / '{snap_name}': {err}")
 
         if abort:
-            cls.logger.error(
+            raise SnapshotError(
                 "aborting restore — one or more snapshots have errors (see above)")
-            return
 
         # ── 3. Everything validated: mutate. Containers first (fast, coarse),
         #      then the parallel VM restores below. A dc failure is reported

--- a/tests/test_docker_compose_provider.py
+++ b/tests/test_docker_compose_provider.py
@@ -33,7 +33,12 @@ import pytest
 import yaml
 
 from boxman.abstract.providers import ProviderSession
-from boxman.exceptions import ConfigError, ProvisionError, RuntimeUnavailable
+from boxman.exceptions import (
+    ConfigError,
+    ProvisionError,
+    RuntimeUnavailable,
+    SnapshotError,
+)
 from boxman.manager import BoxmanManager
 from boxman.providers import create_session
 from boxman.providers.docker_compose.compose_generator import ComposeGenerator
@@ -1372,7 +1377,8 @@ class TestSnapshotDcWiring:
             BoxmanManager, "_select_vm_targets",
             staticmethod(lambda cls, a: [("node01", "vms", "node01", "/w")]),
         ):
-            BoxmanManager.snapshot_restore(m, args)
+            with pytest.raises(SnapshotError, match="aborting restore"):
+                BoxmanManager.snapshot_restore(m, args)
         # dc snapshot was validated, but never recreated
         sess.validate_snapshot_cluster.assert_called_once()
         sess.snapshot_restore_cluster.assert_not_called()

--- a/tests/test_failure_exit_codes.py
+++ b/tests/test_failure_exit_codes.py
@@ -1,0 +1,152 @@
+"""
+Regression tests for #85 item 3: failure paths in ``provision``, ``up``,
+``snapshot take`` and ``snapshot restore`` must raise (so the CLI exits
+non-zero via the BoxmanError → exit 2 mapping in app.py) instead of logging
+an error and returning 0.
+"""
+
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+import boxman.manager
+from boxman.exceptions import ConfigError, ProvisionError, SnapshotError
+from boxman.manager import BoxmanManager
+
+pytestmark = pytest.mark.unit
+
+
+def _manager():
+    mgr = BoxmanManager.__new__(BoxmanManager)
+    mgr.config = {
+        "project": "demo",
+        "clusters": {
+            "cluster_1": {
+                "workdir": "/tmp/ws/c1",
+                "vms": {"service01": {}, "node01": {}},
+            },
+        },
+    }
+    mgr.provider = MagicMock()
+    mgr.logger = MagicMock()
+    mgr.cache = MagicMock()
+    mgr.cache.projects = {}
+    return mgr
+
+
+@pytest.fixture
+def no_existing_state(monkeypatch):
+    """No live VMs, no cache entry, cache registration succeeds."""
+    monkeypatch.setattr(
+        BoxmanManager, "_find_existing_project_vms", lambda cls: [])
+    monkeypatch.setattr(
+        BoxmanManager, "register_project_in_cache", lambda cls: None)
+
+
+class _FakeProcess:
+    """Stand-in for multiprocessing.Process — runs nothing, joins cleanly."""
+
+    def __init__(self, target=None, args=()):
+        self.target = target
+        self.args = args
+
+    def start(self):
+        pass
+
+    def join(self):
+        pass
+
+
+class TestProvisionFailuresRaise:
+
+    def test_existing_state_without_force(self, monkeypatch):
+        mgr = _manager()
+        monkeypatch.setattr(
+            BoxmanManager, "_find_existing_project_vms", lambda cls: ["vm1"])
+        with pytest.raises(ProvisionError, match="cannot provision"):
+            BoxmanManager.provision(mgr, types.SimpleNamespace(force=False))
+
+    def test_cache_registration_conflict(self, monkeypatch, no_existing_state):
+        mgr = _manager()
+
+        def _conflict(cls):
+            raise RuntimeError("project already registered")
+
+        monkeypatch.setattr(
+            BoxmanManager, "register_project_in_cache", _conflict)
+        with pytest.raises(ProvisionError, match="already registered"):
+            BoxmanManager.provision(mgr, types.SimpleNamespace(force=False))
+
+    def test_template_rebuild_failure(self, monkeypatch, no_existing_state):
+        mgr = _manager()
+        monkeypatch.setattr(
+            BoxmanManager, "_create_templates_impl",
+            lambda cls, requested=None, force=False: ["failed-template"])
+        ns = types.SimpleNamespace(force=False, rebuild_templates=True)
+        with pytest.raises(ProvisionError, match="could be rebuilt"):
+            BoxmanManager.provision(mgr, ns)
+
+    def test_ensure_templates_failure(self, monkeypatch, no_existing_state):
+        mgr = _manager()
+        monkeypatch.setattr(
+            BoxmanManager, "ensure_templates_exist", lambda cls: False)
+        ns = types.SimpleNamespace(force=False, rebuild_templates=False)
+        with pytest.raises(ProvisionError, match="could be created"):
+            BoxmanManager.provision(mgr, ns)
+
+    def test_validate_base_images_failure(self, monkeypatch, no_existing_state):
+        mgr = _manager()
+        monkeypatch.setattr(
+            BoxmanManager, "ensure_templates_exist", lambda cls: True)
+
+        def _invalid(cls):
+            raise ValueError("base image 'x' not found")
+
+        monkeypatch.setattr(BoxmanManager, "validate_base_images", _invalid)
+        ns = types.SimpleNamespace(force=False, rebuild_templates=False)
+        with pytest.raises(ConfigError, match="base image 'x' not found"):
+            BoxmanManager.provision(mgr, ns)
+
+
+class TestUpFailuresRaise:
+
+    def test_no_vms_defined(self):
+        mgr = _manager()
+        mgr.config = {"project": "demo", "clusters": {}}
+        with pytest.raises(ConfigError, match="no VMs defined"):
+            BoxmanManager.up(mgr, types.SimpleNamespace())
+
+    def test_partial_state_without_force(self, monkeypatch):
+        mgr = _manager()
+        monkeypatch.setattr(
+            BoxmanManager, "_get_vm_states",
+            lambda cls: {"bprj__demo__bprj_cluster_1_service01": "running"})
+        with pytest.raises(ProvisionError, match="partial infrastructure state"):
+            BoxmanManager.up(mgr, types.SimpleNamespace(force=False))
+
+
+class TestSnapshotFailuresRaise:
+
+    def test_take_failed_verification(self, monkeypatch):
+        mgr = _manager()
+        monkeypatch.setattr(boxman.manager, "Process", _FakeProcess)
+        mgr.provider.validate_snapshot.return_value = (False, ["corrupt"])
+        ns = types.SimpleNamespace(
+            snapshot_name="s1", snapshot_descr="", vms="all", cluster=None)
+        with pytest.raises(SnapshotError, match="failed verification"):
+            BoxmanManager.snapshot_take(mgr, ns)
+
+    def test_restore_no_snapshot_found(self):
+        mgr = _manager()
+        mgr.provider.get_latest_snapshot.return_value = None
+        ns = types.SimpleNamespace(snapshot_name=None, vms="all", cluster=None)
+        with pytest.raises(SnapshotError, match="no snapshot found"):
+            BoxmanManager.snapshot_restore(mgr, ns)
+
+    def test_restore_validation_abort(self):
+        mgr = _manager()
+        mgr.provider.validate_snapshot.return_value = (False, ["bad chain"])
+        ns = types.SimpleNamespace(snapshot_name="s1", vms="all", cluster=None)
+        with pytest.raises(SnapshotError, match="aborting restore"):
+            BoxmanManager.snapshot_restore(mgr, ns)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from boxman.exceptions import ProvisionError
 from boxman.manager import BoxmanManager
 from boxman.providers.libvirt.cdrom import CDROMManager
 from boxman.providers.libvirt.commands import LibVirtCommandBase
@@ -488,7 +489,8 @@ class TestProvisionForceClearsStaleCacheEntry:
              patch.object(mgr, "deprovision") as deprov, \
              patch.object(mgr, "register_project_in_cache") as register, \
              patch.object(mgr.__class__, "provider", MagicMock()):
-            BoxmanManager.provision(mgr, args)
+            with pytest.raises(ProvisionError, match="cannot provision"):
+                BoxmanManager.provision(mgr, args)
 
         # Must not proceed to deprovision or register
         deprov.assert_not_called()


### PR DESCRIPTION
Refs #85 (item 3).

These failure paths logged an error and bare-`return`ed, falling through `args.func(manager, args)` to exit 0:

- `provision`: pre-existing state without --force, cache-registration conflict, template rebuild failure, `ensure_templates_exist` failure, `validate_base_images` failure
- `up`: no VMs defined, partial state without --force
- `snapshot take`: post-take verification failure
- `snapshot restore`: validation abort, no-snapshot-found

**Fix:** raise `ProvisionError`/`ConfigError`/`SnapshotError` from `boxman.exceptions`; `app.py main()` already maps `BoxmanError` to a clean `log.error` + exit 2.

**Tests:** new `tests/test_failure_exit_codes.py` (unit) — every listed path raises. Two existing tests asserted the old log-and-return behavior and were updated to expect the raise (`test_regressions.py::test_without_force_errors_with_clear_message`, `test_docker_compose_provider.py::test_restore_defers_dc_until_vm_prevalidation_passes`). Full unit suite: 1728 passed. Ruff: no new violations.

**Deferred (same bug class, not in item scope):** `snapshot_restore`'s dc-only `dc_abort` early-return paths (~line 5336-5353) still log + return 0 when a container snapshot is invalid but no VM is selected; `update()` (~line 6686) has the same template/validate pattern.