### PR TITLE
fix: revive dead error branches in cdrom attach/detach (#85 item 38, cdrom part)

### DIFF
--- a/src/boxman/providers/libvirt/cdrom.py
+++ b/src/boxman/providers/libvirt/cdrom.py
@@ -63,7 +63,10 @@ class CDROMManager(VirshCommand):
                 temp_path = temp.name
 
             attachment_args = ["--persistent"] if persistent else []
-            result = self.execute("attach-device", self.vm_name, temp_path, *attachment_args)
+            # warn=True so a failed attach reaches the error branch below
+            # instead of raising out of execute (matches change_media)
+            result = self.execute("attach-device", self.vm_name, temp_path,
+                                  *attachment_args, warn=True)
 
             os.unlink(temp_path)
 
@@ -104,7 +107,10 @@ class CDROMManager(VirshCommand):
                 temp_path = temp.name
 
             detach_args = ["--persistent"] if persistent else []
-            result = self.execute("detach-device", self.vm_name, temp_path, *detach_args)
+            # warn=True so a failed detach reaches the error branch below
+            # instead of raising out of execute (matches change_media)
+            result = self.execute("detach-device", self.vm_name, temp_path,
+                                  *detach_args, warn=True)
 
             os.unlink(temp_path)
 

--- a/tests/test_libvirt_cdrom.py
+++ b/tests/test_libvirt_cdrom.py
@@ -143,8 +143,11 @@ class TestAttachCDROM:
         iso = tmp_path / "u.iso"
         iso.write_bytes(b"x")
         with patch.object(cd, "_find_next_available_target", return_value="hdc"), \
-             patch.object(cd, "execute", return_value=_result(ok=False, stderr="nope")):
+             patch.object(cd, "execute", return_value=_result(ok=False, stderr="nope")) as execute:
             assert cd.attach_cdrom(str(iso)) is False
+        # warn=True keeps the error branch live — without it execute raises
+        # and the `if not result.ok` check is dead code (#85 item 38)
+        assert execute.call_args.kwargs.get("warn") is True
 
     def test_cleans_up_temp_xml_on_exception(self, cd: CDROMManager, tmp_path: Path):
         """If execute raises, the temp XML file must still be removed."""
@@ -178,8 +181,11 @@ class TestDetachCDROM:
         assert args[0] == "detach-device"
 
     def test_failure_returns_false(self, cd: CDROMManager):
-        with patch.object(cd, "execute", return_value=_result(ok=False, stderr="x")):
+        with patch.object(cd, "execute", return_value=_result(ok=False, stderr="x")) as execute:
             assert cd.detach_cdrom("hdc") is False
+        # warn=True keeps the error branch live — without it execute raises
+        # and the `if not result.ok` check is dead code (#85 item 38)
+        assert execute.call_args.kwargs.get("warn") is True
 
 
 class TestChangeMedia:


### PR DESCRIPTION
Refs #85 (item 38, cdrom part).

`attach_cdrom` and `detach_cdrom` called `self.execute(...)` without `warn=True`, so a failed `attach-device`/`detach-device` raised `RuntimeError` out of `execute` and the following `if not result.ok:` branch was unreachable — the broad `except Exception` caught the raise and returned False instead.

Chose the `warn=True` variant (branch lives) over deleting the branch: it matches the intended contract already used by `change_media` in the same file (warn + `result.ok` check + specific error log), and it matches what the existing mocked tests assumed. Observable behavior is unchanged: failure still logs an error and returns False, and the temp XML is still unlinked first.

Tests: the existing failure tests now also assert `warn=True` is passed, guarding against the branch going dead again. 26 passed in `tests/test_libvirt_cdrom.py`; no new ruff violations.