### PR TITLE
fix: dead error branches after execute() without warn=True (#85 item 38, G2 files)

### DIFF
--- a/src/boxman/providers/libvirt/clone_vm.py
+++ b/src/boxman/providers/libvirt/clone_vm.py
@@ -103,7 +103,7 @@ class CloneVM:
         try:
             vm_name = self.new_vm_name
             # use virsh domiflist to get the network interfaces
-            result = self.virsh.execute("domiflist", vm_name)
+            result = self.virsh.execute("domiflist", vm_name, warn=True)
             if not result.ok:
                 self.logger.error(f"Failed to get interface list for VM {vm_name}")
                 return False

--- a/src/boxman/providers/libvirt/disk.py
+++ b/src/boxman/providers/libvirt/disk.py
@@ -53,7 +53,7 @@ class DiskManager(VirshCommand):
             cmd_executor = LibVirtCommandBase(
                 provider_config=self.provider_config,
                 override_config_use_sudo=False)
-            result = cmd_executor.execute_shell(cmd)
+            result = cmd_executor.execute_shell(cmd, warn=True)
 
             if not result.ok:
                 self.logger.error(f"failed to create disk image: {result.stderr}")
@@ -103,7 +103,8 @@ class DiskManager(VirshCommand):
 
             # Attach the disk
             attachment_args = ["--persistent"] if persistent else []
-            result = self.execute("attach-device", self.vm_name, temp_path, *attachment_args)
+            result = self.execute("attach-device", self.vm_name, temp_path,
+                                  *attachment_args, warn=True)
 
             # Clean up the temporary file
             os.unlink(temp_path)
@@ -231,7 +232,7 @@ class DiskManager(VirshCommand):
             cmd_executor = LibVirtCommandBase(
                 provider_config=self.provider_config,
                 override_config_use_sudo=False)
-            result = cmd_executor.execute_shell(cmd)
+            result = cmd_executor.execute_shell(cmd, warn=True)
 
             if not result.ok:
                 self.logger.error(f"failed to resize disk image: {result.stderr}")
@@ -257,7 +258,7 @@ class DiskManager(VirshCommand):
         try:
             result = self.execute(
                 'blockresize', self.vm_name,
-                target_dev, f"--size={new_size_mb}M")
+                target_dev, f"--size={new_size_mb}M", warn=True)
 
             if not result.ok:
                 self.logger.error(

--- a/src/boxman/providers/libvirt/virsh_edit.py
+++ b/src/boxman/providers/libvirt/virsh_edit.py
@@ -322,7 +322,7 @@ class VirshEdit:
         try:
             result = self.virsh.execute(
                 'setvcpus', domain_name, str(vcpu_count),
-                '--live', '--config')
+                '--live', '--config', warn=True)
             if not result.ok:
                 self.logger.error(
                     f"failed to hot-set vCPUs for {domain_name}: {result.stderr}")
@@ -355,7 +355,7 @@ class VirshEdit:
             memory_kib = memory_mb * 1024
             result = self.virsh.execute(
                 'setmem', domain_name, str(memory_kib),
-                '--live', '--config')
+                '--live', '--config', warn=True)
             if not result.ok:
                 self.logger.error(
                     f"failed to hot-set memory for {domain_name}: {result.stderr}")
@@ -385,7 +385,7 @@ class VirshEdit:
         try:
             result = self.virsh.execute(
                 'setvcpus', domain_name, str(max_vcpus),
-                '--maximum', '--config')
+                '--maximum', '--config', warn=True)
             if not result.ok:
                 self.logger.error(
                     f"failed to update max vCPUs for {domain_name}: "
@@ -418,7 +418,7 @@ class VirshEdit:
             memory_kib = max_memory_mb * 1024
             result = self.virsh.execute(
                 'setmaxmem', domain_name, str(memory_kib),
-                '--config')
+                '--config', warn=True)
             if not result.ok:
                 self.logger.error(
                     f"failed to update max memory for {domain_name}: "

--- a/tests/test_libvirt_clone_vm.py
+++ b/tests/test_libvirt_clone_vm.py
@@ -149,6 +149,14 @@ class TestRemoveNetworkInterfaces:
         with patch.object(clone.virsh, "execute", return_value=_result(ok=False)):
             assert clone.remove_network_interfaces() is False
 
+    def test_domiflist_called_with_warn_true(self, clone: CloneVM):
+        """Issue #85 item 38: without warn=True a failed domiflist raises
+        and the graceful 'return False' branch is dead code."""
+        with patch.object(clone.virsh, "execute",
+                          return_value=_result(ok=False)) as execute:
+            assert clone.remove_network_interfaces() is False
+        assert execute.call_args.kwargs.get("warn") is True
+
     def test_detach_failure_is_logged_but_loop_continues(
         self, clone: CloneVM, captured_logs
     ):

--- a/tests/test_libvirt_disk.py
+++ b/tests/test_libvirt_disk.py
@@ -1,22 +1,37 @@
 """
 Unit tests for boxman.providers.libvirt.disk.DiskManager.
 
-Currently pins the attach_only flag from issue #85 item 23: when the
-image file already exists (leftover from a failed earlier run),
-``configure_from_disk_config`` must skip ``qemu-img create`` and only
-attach the existing file.
+Covers:
+- the attach_only flag from issue #85 item 23: when the image file
+  already exists (leftover from a failed earlier run),
+  ``configure_from_disk_config`` must skip ``qemu-img create`` and only
+  attach the existing file.
+- the issue #85 item 38 fixes: the ``if not result.ok`` failure
+  branches must be reachable — commands run with ``warn=True`` and a
+  failed command returns False instead of raising RuntimeError.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from boxman.providers.libvirt.disk import DiskManager
 
 pytestmark = pytest.mark.unit
+
+
+def _result(stdout: str = "", ok: bool = True, stderr: str = "",
+            return_code: int = 0) -> MagicMock:
+    r = MagicMock(name="invoke.Result")
+    r.stdout = stdout
+    r.stderr = stderr
+    r.ok = ok
+    r.failed = not ok
+    r.return_code = return_code
+    return r
 
 
 @pytest.fixture
@@ -52,3 +67,42 @@ class TestConfigureFromDiskConfig:
         create.assert_not_called()
         attach.assert_called_once()
         assert (tmp_path / "vm01_data.qcow2").read_bytes() == b"x"
+
+
+class TestDeadErrorBranches:
+    """Issue #85 item 38: each method must run its command with
+    warn=True so the not-ok branch is live, and return False on
+    failure instead of raising RuntimeError."""
+
+    def test_create_disk_failure_returns_false(self, dm: DiskManager,
+                                               tmp_path: Path):
+        with patch("boxman.providers.libvirt.disk.LibVirtCommandBase"
+                   ) as cmd_cls:
+            cmd_cls.return_value.execute_shell.return_value = _result(
+                ok=False, stderr="x")
+            assert dm.create_disk(str(tmp_path / "d.qcow2"), 1024) is False
+        assert cmd_cls.return_value.execute_shell.call_args.kwargs.get(
+            "warn") is True
+
+    def test_attach_disk_failure_returns_false(self, dm: DiskManager):
+        with patch.object(dm, "execute",
+                          return_value=_result(ok=False, stderr="x")) as exe:
+            assert dm.attach_disk("/tmp/d.qcow2", "vdb") is False
+        assert exe.call_args.kwargs.get("warn") is True
+
+    def test_resize_disk_offline_failure_returns_false(
+            self, dm: DiskManager, tmp_path: Path):
+        with patch("boxman.providers.libvirt.disk.LibVirtCommandBase"
+                   ) as cmd_cls:
+            cmd_cls.return_value.execute_shell.return_value = _result(
+                ok=False, stderr="x")
+            assert dm.resize_disk_offline(
+                str(tmp_path / "d.qcow2"), 2048) is False
+        assert cmd_cls.return_value.execute_shell.call_args.kwargs.get(
+            "warn") is True
+
+    def test_resize_disk_online_failure_returns_false(self, dm: DiskManager):
+        with patch.object(dm, "execute",
+                          return_value=_result(ok=False, stderr="x")) as exe:
+            assert dm.resize_disk_online("vdb", 2048) is False
+        assert exe.call_args.kwargs.get("warn") is True

--- a/tests/test_libvirt_virsh_edit.py
+++ b/tests/test_libvirt_virsh_edit.py
@@ -1,0 +1,72 @@
+"""
+Unit tests for boxman.providers.libvirt.virsh_edit.VirshEdit.
+
+Currently pins the issue #85 item 38 fixes: the ``if not result.ok``
+failure branches in the hot-update helpers must be reachable — the
+virsh calls are made with ``warn=True`` and a failed command returns
+False instead of raising RuntimeError.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from boxman.providers.libvirt.virsh_edit import VirshEdit
+
+pytestmark = pytest.mark.unit
+
+
+def _result(stdout: str = "", ok: bool = True, stderr: str = "",
+            return_code: int = 0) -> MagicMock:
+    r = MagicMock(name="invoke.Result")
+    r.stdout = stdout
+    r.stderr = stderr
+    r.ok = ok
+    r.failed = not ok
+    r.return_code = return_code
+    return r
+
+
+@pytest.fixture
+def ve() -> VirshEdit:
+    return VirshEdit(provider_config={"use_sudo": False,
+                                      "uri": "qemu:///system"})
+
+
+class TestDeadErrorBranches:
+    """Issue #85 item 38: each helper must pass warn=True so its
+    not-ok branch is live, and must return False on failure."""
+
+    def test_hot_set_vcpus_failure_returns_false(self, ve: VirshEdit):
+        with patch.object(ve.virsh, "execute",
+                          return_value=_result(ok=False, stderr="x")) as exe:
+            assert ve.hot_set_vcpus("vm01", 4) is False
+        assert exe.call_args.kwargs.get("warn") is True
+
+    def test_hot_set_memory_failure_returns_false(self, ve: VirshEdit):
+        with patch.object(ve.virsh, "execute",
+                          return_value=_result(ok=False, stderr="x")) as exe:
+            assert ve.hot_set_memory("vm01", 1024) is False
+        assert exe.call_args.kwargs.get("warn") is True
+
+    def test_update_max_vcpus_failure_returns_false(self, ve: VirshEdit):
+        with patch.object(ve.virsh, "execute",
+                          return_value=_result(ok=False, stderr="x")) as exe:
+            assert ve.update_max_vcpus("vm01", 8) is False
+        assert exe.call_args.kwargs.get("warn") is True
+
+    def test_update_max_memory_failure_returns_false(self, ve: VirshEdit):
+        with patch.object(ve.virsh, "execute",
+                          return_value=_result(ok=False, stderr="x")) as exe:
+            assert ve.update_max_memory("vm01", 4096) is False
+        assert exe.call_args.kwargs.get("warn") is True
+
+    def test_hot_set_vcpus_success_returns_true(self, ve: VirshEdit):
+        with patch.object(ve.virsh, "execute", return_value=_result()):
+            assert ve.hot_set_vcpus("vm01", 4) is True
+
+    def test_hot_set_memory_success_returns_true(self, ve: VirshEdit):
+        with patch.object(ve.virsh, "execute", return_value=_result()):
+            assert ve.hot_set_memory("vm01", 1024) is True


### PR DESCRIPTION
Refs #85

**Item 38 (G2 part)** — any `execute(...)`/`execute_shell(...)` without `warn=True` raises on failure, making the following `if not result.ok: return False` unreachable. Fixed in G2-owned files only, by passing `warn=True` (each method's documented contract is "return False on failure", and the specific stderr logging in the branch is preserved):

- `disk.py`: `create_disk`, `attach_disk`, `resize_disk_offline`, `resize_disk_online`
- `virsh_edit.py`: `hot_set_vcpus`, `hot_set_memory`, `update_max_vcpus`, `update_max_memory`
- `clone_vm.py`: `remove_network_interfaces` (`domiflist`)

The cdrom.py sites belong to another group and are not touched here.

Tests: `tests/test_libvirt_virsh_edit.py` (new) pins warn=True + False-on-failure for the four hot-update helpers; `tests/test_libvirt_disk.py` gains failure-path tests for the four disk methods; `tests/test_libvirt_clone_vm.py` pins warn=True on the domiflist call.