### PR TITLE
fix: abort destroy cleanly when the confirmation prompt hits EOF (#85 item 16)

### DIFF
--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -4992,7 +4992,11 @@ class BoxmanManager:
 
         print()
         if not auto_accept:
-            answer = input("Proceed? [y/N] ").strip().lower()
+            try:
+                answer = input("Proceed? [y/N] ").strip().lower()
+            except EOFError:
+                print("No input available, aborted.")
+                return
             if answer not in ("y", "yes"):
                 print("Aborted.")
                 return

--- a/tests/test_destroy_prompt.py
+++ b/tests/test_destroy_prompt.py
@@ -1,0 +1,53 @@
+"""
+Regression test for #85 item 16: the ``destroy`` confirmation prompt must
+abort cleanly on EOF (CI / piped stdin) instead of dying with an EOFError
+traceback — same guard its siblings (destroy_runtime, _recreate_network,
+snapshot_collapse) already have.
+"""
+
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from boxman.manager import BoxmanManager
+
+pytestmark = pytest.mark.unit
+
+
+def _manager():
+    mgr = BoxmanManager.__new__(BoxmanManager)
+    mgr.config = {
+        "project": "demo",
+        "clusters": {
+            "cluster_1": {
+                "workdir": "/tmp/ws/c1",
+                "vms": {"node01": {}},
+            },
+        },
+    }
+    mgr.provider = MagicMock()
+    mgr.logger = MagicMock()
+    mgr.cache = MagicMock()
+    # Registered project → destroy gets past the "nothing to do" gate.
+    mgr.cache.projects = {"demo": {}}
+    mgr._runtime_instance = MagicMock()  # not a DockerComposeRuntime
+    mgr.config_path = "conf.yml"
+    return mgr
+
+
+def test_destroy_prompt_aborts_cleanly_on_eof(monkeypatch, capsys):
+    mgr = _manager()
+
+    def _eof_input(_prompt):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _eof_input)
+    ns = types.SimpleNamespace(auto_accept=False, templates=False)
+
+    # Must return cleanly, not raise EOFError.
+    BoxmanManager.destroy(mgr, ns)
+
+    assert "No input available, aborted." in capsys.readouterr().out
+    # Nothing destructive ran: the runtime was never started.
+    mgr._runtime_instance.ensure_ready.assert_not_called()

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -366,7 +366,7 @@ class TestDestroyReadsProjectCache:
     even when it was properly registered.
     """
 
-    def test_destroy_loads_cache_before_in_cache_check(self, tmp_path: Path):
+    def test_destroy_loads_cache_before_in_cache_check(self, tmp_path: Path, capsys):
         import json as _json
         import os as _os
 
@@ -388,11 +388,12 @@ class TestDestroyReadsProjectCache:
             args = MagicMock(auto_accept=False, templates=False)
 
             # Force EOF on the prompt so the test doesn't hang waiting
-            # for stdin; reaching the prompt proves the short-circuit
-            # did NOT fire.
-            with patch("builtins.input", side_effect=EOFError), \
-                 pytest.raises(EOFError):
+            # for stdin; the clean abort (instead of an EOFError
+            # traceback, #85 item 16) proves the short-circuit did NOT
+            # fire.
+            with patch("builtins.input", side_effect=EOFError):
                 BoxmanManager.destroy(mgr, args)
+            assert "No input available, aborted." in capsys.readouterr().out
 
         # The cache must have been loaded — .projects populated from disk
         assert mgr.cache.projects is not None


### PR DESCRIPTION
Refs #85 (item 16).

`destroy`'s `Proceed? [y/N]` prompt (manager.py ~4995) did an unprotected `input()` → `EOFError` traceback in CI / piped stdin. Siblings `destroy_runtime`, `_recreate_network` and `snapshot_collapse` already catch `EOFError`.

**Fix:** same guard — catch `EOFError`, print "No input available, aborted.", return (mirrors `destroy_runtime`).

**Tests:** new `tests/test_destroy_prompt.py` (unit) — feeds EOF via patched `input`, asserts clean abort and that the runtime was never started; verified it fails against the unfixed code. Updated `test_regressions.py::TestDestroyReadsProjectCache`, which used the propagating `EOFError` as its "prompt was reached" signal — it now asserts the clean-abort message. Full unit suite: 1796 passed; the 4 `test_update.py` failures are pre-existing on `origin/polish` (verified on a clean checkout — unrelated `warn=True` mismatch, another group's in-flight work). Ruff: no new violations.

**Not in scope:** `update`'s removed-VMs prompt (manager.py ~6731) has the same unprotected `input()` — same one-line guard applies.