### PR TITLE
fix: quote command values centrally in build_command (#85 item 6)

### DIFF
--- a/src/boxman/providers/libvirt/cloudinit.py
+++ b/src/boxman/providers/libvirt/cloudinit.py
@@ -597,8 +597,11 @@ class CloudInitTemplate:
         override, sudo, and runtime wrapping all apply — a raw string would
         silently hit the default local libvirt daemon.
         """
+        # the payload is passed raw: VirshCommand.build_command quotes
+        # every value centrally (shlex.quote), so a pre-quoted payload
+        # would end up double-quoted
         return self.virsh.execute(
-            "qemu-agent-command", self.template_name, shlex.quote(payload),
+            "qemu-agent-command", self.template_name, payload,
             hide=True, warn=True)
 
     def _wait_cloudinit_fallback(self, seconds: int | None = None) -> None:

--- a/src/boxman/providers/libvirt/commands.py
+++ b/src/boxman/providers/libvirt/commands.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 from typing import Any
 
 import invoke
@@ -72,6 +73,14 @@ class LibVirtCommandBase:
         """
         Build a complete command string with options.
 
+        Every positional argument and every keyword VALUE is passed through
+        :func:`shlex.quote`, so callers must pass raw values — pre-quoted
+        values would end up quoted twice. (``shlex.quote`` is a no-op for
+        values that need no quoting, e.g. ``--size=50M``.) Callers that need
+        actual shell constructs (pipes, redirects, ``&&``) must use
+        :meth:`execute_shell` instead — that path is intentionally NOT
+        quoted.
+
         Args:
             *args: Positional arguments for the command
             **kwargs: Keyword arguments that will be converted to command options
@@ -89,7 +98,7 @@ class LibVirtCommandBase:
             command_parts.append(self.command_path)
 
         # Add positional arguments
-        command_parts.extend([str(arg) for arg in args])
+        command_parts.extend([shlex.quote(str(arg)) for arg in args])
 
         # Add keyword arguments as options
         for key, value in kwargs.items():
@@ -99,14 +108,14 @@ class LibVirtCommandBase:
                 # Skip False or None values
                 continue
             else:
-                command_parts.append(f"--{key.replace('_', '-')}={value}")
+                command_parts.append(
+                    f"--{key.replace('_', '-')}={shlex.quote(str(value))}")
 
         return " ".join(command_parts)
 
     def execute(self, *args,
                 hide: bool = True,
                 warn: bool = False,
-                capture: bool = True,
                 **kwargs) -> invoke.runners.Result:
         """
         Execute a command.
@@ -115,7 +124,6 @@ class LibVirtCommandBase:
             *args: Positional arguments for the command
             hide: Whether to hide command output
             warn: Whether to warn instead of raising exceptions
-            capture: Whether to capture command output
             **kwargs: Keyword arguments to be passed as command options
 
         Returns:
@@ -290,6 +298,11 @@ class VirshCommand(LibVirtCommandBase):  # Fixed missing closing parenthesis:
         """
         Build a complete virsh command string with options.
 
+        Positional arguments, keyword values, and the connection URI are
+        quoted centrally via :func:`shlex.quote` (see
+        :meth:`LibVirtCommandBase.build_command`) — callers must pass raw
+        values, never pre-quoted ones.
+
         Args:
             cmd: The virsh subcommand to execute (like list, start, define, etc.)
             *args: Positional arguments for the command
@@ -304,13 +317,13 @@ class VirshCommand(LibVirtCommandBase):  # Fixed missing closing parenthesis:
             command_parts.append("sudo")
 
         # add the virsh command with connection URI
-        command_parts.append(f"{self.command_path} -c {self.uri}")
+        command_parts.append(f"{self.command_path} -c {shlex.quote(self.uri)}")
 
         # add the actual virsh subcommand
         command_parts.append(cmd)
 
         # add positional arguments
-        command_parts.extend([str(arg) for arg in args])
+        command_parts.extend([shlex.quote(str(arg)) for arg in args])
 
         # add keyword arguments as options
         for key, value in kwargs.items():
@@ -320,7 +333,8 @@ class VirshCommand(LibVirtCommandBase):  # Fixed missing closing parenthesis:
                 # skip False or None values
                 continue
             else:
-                command_parts.append(f"--{key.replace('_', '-')}={value}")
+                command_parts.append(
+                    f"--{key.replace('_', '-')}={shlex.quote(str(value))}")
 
         return " ".join(command_parts)
 

--- a/src/boxman/providers/libvirt/snapshot.py
+++ b/src/boxman/providers/libvirt/snapshot.py
@@ -123,6 +123,11 @@ class SnapshotManager:
         reintroducing the problem for the next revert.  Passing
         --diskspec <target>,snapshot=no prevents that overlay from being
         created so the cdrom stays at the raw ISO permanently.
+
+        Each flag is returned as two separate tokens (``--diskspec`` and the
+        spec) — a single ``"--diskspec <spec>"`` token only worked because
+        command building used to join parts without quoting; with central
+        quoting it would reach virsh as one literal argument.
         """
         result = self.virsh.execute("domblklist", vm_name, "--details", warn=True)
         if not result.ok:
@@ -132,7 +137,7 @@ class SnapshotManager:
             parts = line.split()
             # domblklist --details columns: Type  Device  Target  Source
             if len(parts) >= 3 and parts[1] == 'cdrom':
-                args.append(f"--diskspec {parts[2]},snapshot=no")
+                args.extend(["--diskspec", f"{parts[2]},snapshot=no"])
         return args
 
     def create_snapshot(self,
@@ -182,11 +187,15 @@ class SnapshotManager:
             # Exclude cdroms from the snapshot so no new qcow2 overlay is
             # created for them (they stay at the raw ISO after this call).
             cdrom_args = self._cdrom_diskspec_args(vm_name)
+            # separate tokens for every flag and value: build_command quotes
+            # each token centrally, so "--domain vm01" as one token would
+            # reach virsh as a single literal argument, and a pre-quoted
+            # description would be quoted twice
             result = self.virsh.execute(
                 "snapshot-create-as",
-                f"--domain {vm_name}",
-                f"--name {snapshot_name}",
-                f"--description '{description}'",
+                "--domain", vm_name,
+                "--name", snapshot_name,
+                "--description", description,
                 "--atomic",
                 f"--memspec={mem_path}",
                 *cdrom_args)

--- a/tests/test_libvirt_commands.py
+++ b/tests/test_libvirt_commands.py
@@ -1,0 +1,155 @@
+"""
+Tests for central shell quoting in ``LibVirtCommandBase.build_command``
+(#85 item 6).
+
+Every positional argument and keyword VALUE that flows through
+``build_command`` is quoted exactly once with ``shlex.quote``. Call sites
+must therefore pass raw values (never pre-quoted), and anything needing
+real shell constructs (pipes, redirects, ``&&``) must go through
+``execute_shell``, which is intentionally not quoted.
+"""
+
+from __future__ import annotations
+
+import shlex
+from unittest.mock import MagicMock, patch
+
+from boxman.providers.libvirt.commands import (
+    LibVirtCommandBase,
+    VirshCommand,
+    VirtCloneCommand,
+    VirtInstallCommand,
+)
+
+SHELL_RUN = "boxman.providers.libvirt.commands._shell_run"
+
+
+def _result(stdout: str = "", ok: bool = True, stderr: str = "") -> MagicMock:
+    r = MagicMock(name="invoke.Result")
+    r.stdout = stdout
+    r.stderr = stderr
+    r.ok = ok
+    r.failed = not ok
+    r.return_code = 0
+    return r
+
+
+class TestBuildCommandQuoting:
+
+    def test_value_with_spaces_is_single_token(self):
+        cmd = VirshCommand().build_command("snapshot-create-as", "--domain",
+                                           "vm 01")
+        tokens = shlex.split(cmd)
+        assert "vm 01" in tokens
+        # exactly one layer of quoting: the raw value survives a round-trip
+        assert tokens == ["virsh", "-c", "qemu:///system",
+                          "snapshot-create-as", "--domain", "vm 01"]
+
+    def test_value_with_quotes_and_metachars_round_trips(self):
+        nasty = 'a"b\'c;d|e&&f>g$(h)`i`'
+        cmd = VirshCommand().build_command("dumpxml", nasty)
+        assert shlex.split(cmd)[-1] == nasty
+        # quoted exactly once — the quoted form appears verbatim
+        assert shlex.quote(nasty) in cmd
+        assert shlex.quote(shlex.quote(nasty)) not in cmd
+
+    def test_kwarg_value_is_quoted(self):
+        cmd = LibVirtCommandBase().build_command(file="/tmp/a b/c.qcow2")
+        assert cmd == f"--file={shlex.quote('/tmp/a b/c.qcow2')}"
+        # shlex.quote only quotes when needed, so flags stay untouched
+        assert LibVirtCommandBase().build_command(size="50M") == "--size=50M"
+
+    def test_kwarg_true_false_none_semantics_unchanged(self):
+        cmd = LibVirtCommandBase().build_command(
+            auto_clone=True, skip=False, missing=None)
+        assert cmd == "--auto-clone"
+
+    def test_safe_tokens_are_not_quoted(self):
+        # quoting must be a no-op for ordinary values so existing command
+        # strings (and their tests) stay byte-identical
+        cmd = VirshCommand().build_command("domstate", "vm01", "--details")
+        assert cmd == "virsh -c qemu:///system domstate vm01 --details"
+
+    def test_uri_is_quoted(self):
+        v = VirshCommand(provider_config={"uri": "qemu+ssh://user@host/system"})
+        assert f"-c {shlex.quote(v.uri)}" in v.build_command("list")
+
+    def test_sudo_prefix_unchanged(self):
+        v = VirshCommand(provider_config={"use_sudo": True})
+        assert v.build_command("list").startswith("sudo virsh -c ")
+
+    def test_virt_install_uri_kwarg_quoted_once(self):
+        v = VirtInstallCommand(provider_config={"uri": "qemu:///system"})
+        assert v.build_command() == "virt-install --connect=qemu:///system"
+
+    def test_virt_clone_kwarg_value_with_space(self):
+        v = VirtCloneCommand()
+        cmd = v.build_command(original="src vm", name="new vm")
+        tokens = shlex.split(cmd)
+        assert "--original=src vm" in tokens
+        assert "--name=new vm" in tokens
+
+
+class TestExecutePassesQuotedCommandToShell:
+
+    def test_execute_quotes_before_shell_run(self):
+        v = VirshCommand()
+        with patch(SHELL_RUN, return_value=_result()) as run:
+            v.execute("change-media", "vm01", "hd c", "/iso/a b.iso")
+        command = run.call_args.args[0]
+        tokens = shlex.split(command)
+        assert tokens[:4] == ["virsh", "-c", "qemu:///system", "change-media"]
+        assert "vm01" in tokens
+        assert "hd c" in tokens
+        assert "/iso/a b.iso" in tokens
+
+
+class TestCallSiteAudit:
+    """Pin the call-site fixes that central quoting required (#85 item 6)."""
+
+    def test_agent_command_payload_not_double_quoted(self, tmp_path):
+        # cloudinit._agent_command used to shlex.quote() the payload itself;
+        # with central quoting that produced a double-quoted token
+        from boxman.providers.libvirt.cloudinit import CloudInitTemplate
+        t = CloudInitTemplate(
+            template_name="tpl",
+            image_path=str(tmp_path / "base.qcow2"),
+            workdir=str(tmp_path / "workdir"),
+            provider_config={"use_sudo": False, "uri": "qemu:///system"},
+        )
+        payload = '{"execute":"guest-exec","arguments":{"path":"/bin/cat"}}'
+        with patch(SHELL_RUN, return_value=_result()) as run:
+            t._agent_command(payload)
+        command = run.call_args.args[0]
+        assert shlex.split(command)[-1] == payload
+        assert shlex.quote(shlex.quote(payload)) not in command
+
+    def test_snapshot_create_as_description_round_trips(self, tmp_path):
+        # snapshot.create_snapshot used to pre-quote the description and
+        # pass "--domain <vm>" as one token; both break under central quoting
+        from boxman.providers.libvirt.snapshot import SnapshotManager
+        sm = SnapshotManager({"use_sudo": False, "uri": "qemu:///system"})
+        description = "taken before 'big' upgrade; rm -rf /"
+        with patch.object(sm, "_flatten_cdrom_overlays"), \
+             patch.object(sm, "_cdrom_diskspec_args", return_value=[]), \
+             patch(SHELL_RUN, return_value=_result()) as run:
+            assert sm.create_snapshot(
+                "vm01", str(tmp_path), "snap1", description) is True
+        command = run.call_args.args[0]
+        tokens = shlex.split(command)
+        assert tokens[:4] == ["virsh", "-c", "qemu:///system",
+                              "snapshot-create-as"]
+        assert description in tokens
+
+    def test_cdrom_diskspec_args_are_separate_tokens(self):
+        from boxman.providers.libvirt.snapshot import SnapshotManager
+        sm = SnapshotManager({"use_sudo": False})
+        blklist = (
+            "Type   Device  Target  Source\n"
+            "file   cdrom   hdc     /iso/seed.iso\n"
+            "file   disk    vda     /vms/vm.qcow2\n"
+        )
+        with patch.object(sm.virsh, "execute",
+                          return_value=_result(stdout=blklist)):
+            args = sm._cdrom_diskspec_args("vm01")
+        assert args == ["--diskspec", "hdc,snapshot=no"]

--- a/tests/test_libvirt_snapshot.py
+++ b/tests/test_libvirt_snapshot.py
@@ -82,19 +82,22 @@ class TestCreateSnapshot:
             assert sm.create_snapshot("vm01", str(tmp_path), "snap1", "desc") is True
         args = execute.call_args.args
         assert args[0] == "snapshot-create-as"
-        assert any("--domain vm01" in a for a in args)
-        assert any("--name snap1" in a for a in args)
-        assert any("--atomic" in a for a in args)
-        assert any("--memspec=" in a and "snap1.raw" in a for a in args)
+        # flags and values are passed as separate tokens — build_command
+        # quotes each token centrally, so "--domain vm01" as a single token
+        # would reach virsh as one literal argument
+        assert "--domain" in args and "vm01" in args
+        assert "--name" in args and "snap1" in args
+        assert "--atomic" in args
+        assert any(a.startswith("--memspec=") and "snap1.raw" in a for a in args)
 
     def test_includes_cdrom_diskspec_args(self, sm: SnapshotManager, tmp_path: Path):
         with patch.object(sm, "_flatten_cdrom_overlays"), \
              patch.object(sm, "_cdrom_diskspec_args",
-                          return_value=["--diskspec hdc,snapshot=no"]), \
+                          return_value=["--diskspec", "hdc,snapshot=no"]), \
              patch.object(sm.virsh, "execute", return_value=_result()) as execute:
             sm.create_snapshot("vm01", str(tmp_path), "s", "d")
         args = execute.call_args.args
-        assert "--diskspec hdc,snapshot=no" in args
+        assert "--diskspec" in args and "hdc,snapshot=no" in args
 
     def test_command_failure_returns_false(self, sm: SnapshotManager, tmp_path: Path):
         with patch.object(sm, "_flatten_cdrom_overlays"), \


### PR DESCRIPTION
Refs #85 (item 6, central part).

`LibVirtCommandBase.build_command` did `" ".join(command_parts)` with zero quoting — any VM name/path/description with spaces or shell metacharacters was split or interpreted by the shell.

**Fix:** `shlex.quote` every positional argument, keyword VALUE, and the virsh connection URI at the `build_command` layer. `shlex.quote` is a no-op for values that need no quoting, so flags like `--size=50M` are byte-identical.

**Call-site audit (a) — pre-quoted values (would now double-quote):**
- `cloudinit._agent_command` quoted the guest-agent payload itself → per-site quote removed; the payload now gets exactly one layer centrally.
- All other per-site `shlex.quote` users (cloudinit seed-ISO/rsync/wget/virt-install parts, net.py iptables bridge names, snapshot `rm -f`, direct_vm/iso_boot_vm parts) interpolate into raw shell strings for `execute_shell`/`_shell_run` — that path is intentionally NOT centrally quoted, so they keep their quoting.

**Call-site audit (b) — shell constructs / multi-token args:**
- `snapshot.create_snapshot` passed `--domain <vm>`, `--name <snap>`, and a pre-quoted `--description '<desc>'` as single tokens; `_cdrom_diskspec_args` emitted `--diskspec <spec>` single tokens. These only worked because of the unquoted join — now passed as separate tokens with raw values.
- No `execute()` call site passes intentional shell constructs (pipes, `&&`, redirects, command substitution) — verified by grep; no rerouting through `execute_shell` was needed.

**Audit (c):** `execute()`'s `capture=True` parameter was accepted and silently ignored; no caller used it (src or tests) → removed.

**Tests:** new `tests/test_libvirt_commands.py` (13 tests: one-layer quoting round-trips for spaces/quotes/metachars, kwarg semantics unchanged, URI quoted, sudo prefix unchanged, call-site pins for `_agent_command`, `create_snapshot` description, diskspec tokens). Updated two assertions in `tests/test_libvirt_snapshot.py` that asserted the old multi-token arg form. Full unit suite: 1813 passed.