### PR TITLE
fix: one provider-config merge for CLI/session/probes (#85 item 8)

### DIFF
--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -21,7 +21,7 @@ from boxman.config_cache import BoxmanCache
 from boxman.exceptions import ConfigError, ProvisionError, SnapshotError
 from boxman.image_cache import ImageCache
 from boxman.netlab import ContainerlabManager, shared_bridges
-from boxman.providers import PROVIDERS, primary_provider_type
+from boxman.providers import PROVIDERS, merge_provider_configs, primary_provider_type
 from boxman.providers.libvirt import net_reconcile
 from boxman.abstract.providers import ProviderSession
 from boxman.providers.libvirt.commands import VirshCommand
@@ -549,40 +549,6 @@ class BoxmanManager:
             A new dict with ``runtime`` and related keys injected.
         """
         return self.runtime_instance.inject_into_provider_config(provider_config)
-
-    @staticmethod
-    def _merge_provider_configs(global_config: dict[str, Any],
-                                local_config: dict[str, Any]) -> dict[str, Any]:
-        """
-        Merge global (app-level) and local (project-level) provider configs.
-
-        Scalar keys: local overrides global (standard dict.update behaviour).
-
-        ``sudo_skip_commands`` / ``force_sudo_commands``: per-command merging.
-        If a command appears in a local list it is removed from the opposite
-        global list so that the local setting wins.  Commands that only appear
-        in the global lists are preserved.
-        """
-        merged = global_config.copy()
-        # pull out the sudo command lists before the scalar update clobbers them
-        g_skip = set(global_config.get('sudo_skip_commands', []))
-        g_force = set(global_config.get('force_sudo_commands', []))
-        l_skip = set(local_config.get('sudo_skip_commands', []))
-        l_force = set(local_config.get('force_sudo_commands', []))
-
-        # scalar overrides
-        merged.update(local_config)
-
-        # per-command merge: local wins over global for any given command
-        all_local = l_skip | l_force
-        final_skip = (g_skip - all_local) | l_skip
-        final_force = (g_force - all_local) | l_force
-        # if a command ended up in both after merge, force wins
-        final_skip -= final_force
-
-        merged['sudo_skip_commands'] = sorted(final_skip)
-        merged['force_sudo_commands'] = sorted(final_force)
-        return merged
 
     def load_config(self, config_path: str) -> dict[str, Any]:
         """
@@ -1696,7 +1662,7 @@ class BoxmanManager:
         # merge app-level provider config as defaults
         if self.app_config and 'providers' in self.app_config:
             app_provider = self.app_config['providers'].get(provider_type, {})
-            provider_config = self._merge_provider_configs(app_provider, provider_config)
+            provider_config = merge_provider_configs(app_provider, provider_config)
 
         # inject runtime settings
         if hasattr(self, 'runtime_instance'):
@@ -2399,7 +2365,7 @@ class BoxmanManager:
                     provider_config = self.config.get('provider', {}).get(provider_type, {})
                     if self.app_config and 'providers' in self.app_config:
                         app_prov = self.app_config['providers'].get(provider_type, {})
-                        provider_config = self._merge_provider_configs(app_prov, provider_config)
+                        provider_config = merge_provider_configs(app_prov, provider_config)
                     if hasattr(self, 'runtime_instance'):
                         provider_config = self.runtime_instance.inject_into_provider_config(provider_config)
                     virsh = VirshCommand(provider_config=provider_config)
@@ -4201,7 +4167,7 @@ class BoxmanManager:
         provider_config = self.config.get('provider', {}).get(provider_type, {})
         if self.app_config and 'providers' in self.app_config:
             app_prov = self.app_config['providers'].get(provider_type, {})
-            provider_config = self._merge_provider_configs(app_prov, provider_config)
+            provider_config = merge_provider_configs(app_prov, provider_config)
         if hasattr(self, 'runtime_instance'):
             provider_config = self.runtime_instance.inject_into_provider_config(
                 provider_config)
@@ -4230,7 +4196,7 @@ class BoxmanManager:
         provider_config = self.config.get('provider', {}).get(provider_type, {})
         if self.app_config and 'providers' in self.app_config:
             app_prov = self.app_config['providers'].get(provider_type, {})
-            provider_config = self._merge_provider_configs(app_prov, provider_config)
+            provider_config = merge_provider_configs(app_prov, provider_config)
         if hasattr(self, 'runtime_instance'):
             provider_config = self.runtime_instance.inject_into_provider_config(
                 provider_config)
@@ -4265,7 +4231,7 @@ class BoxmanManager:
         provider_config = self.config.get('provider', {}).get(provider_type, {})
         if self.app_config and 'providers' in self.app_config:
             app_prov = self.app_config['providers'].get(provider_type, {})
-            provider_config = self._merge_provider_configs(app_prov, provider_config)
+            provider_config = merge_provider_configs(app_prov, provider_config)
         if hasattr(self, 'runtime_instance'):
             provider_config = self.runtime_instance.inject_into_provider_config(
                 provider_config)
@@ -6134,7 +6100,7 @@ class BoxmanManager:
             provider_config = cls.config.get("provider", {}).get(provider_type, {})
             if cls.app_config and "providers" in cls.app_config:
                 app_prov = cls.app_config["providers"].get(provider_type, {})
-                provider_config = BoxmanManager._merge_provider_configs(app_prov, provider_config)
+                provider_config = merge_provider_configs(app_prov, provider_config)
             virsh = VirshCommand(provider_config=provider_config)
             result = virsh.execute("list", "--all", hide=True, warn=True)
             if result.ok:

--- a/src/boxman/providers/__init__.py
+++ b/src/boxman/providers/__init__.py
@@ -67,6 +67,45 @@ def create_session(provider_type: str, config: dict[str, Any]) -> "ProviderSessi
     return factory(config)
 
 
+def merge_provider_configs(global_config: dict[str, Any],
+                           local_config: dict[str, Any]) -> dict[str, Any]:
+    """
+    Merge global (app-level) and local (project-level) provider configs.
+
+    This is the single merge implementation used by every code path that
+    combines boxman.yml ``providers:`` settings with a project's
+    ``provider:`` block (CLI session creation, ``show_conf``, and the
+    manager's one-off virsh probes).
+
+    Scalar keys: local overrides global (standard dict.update behaviour).
+
+    ``sudo_skip_commands`` / ``force_sudo_commands``: per-command merging.
+    If a command appears in a local list it is removed from the opposite
+    global list so that the local setting wins.  Commands that only appear
+    in the global lists are preserved.
+    """
+    merged = global_config.copy()
+    # pull out the sudo command lists before the scalar update clobbers them
+    g_skip = set(global_config.get('sudo_skip_commands', []))
+    g_force = set(global_config.get('force_sudo_commands', []))
+    l_skip = set(local_config.get('sudo_skip_commands', []))
+    l_force = set(local_config.get('force_sudo_commands', []))
+
+    # scalar overrides
+    merged.update(local_config)
+
+    # per-command merge: local wins over global for any given command
+    all_local = l_skip | l_force
+    final_skip = (g_skip - all_local) | l_skip
+    final_force = (g_force - all_local) | l_force
+    # if a command ended up in both after merge, force wins
+    final_skip -= final_force
+
+    merged['sudo_skip_commands'] = sorted(final_skip)
+    merged['force_sudo_commands'] = sorted(final_force)
+    return merged
+
+
 def primary_provider_type(config: dict[str, Any] | None) -> str:
     """
     Return the project's primary provider type.

--- a/src/boxman/providers/libvirt/session.py
+++ b/src/boxman/providers/libvirt/session.py
@@ -38,39 +38,16 @@ class LibVirtSession:
         #: logging.Logger: the logger instance
         self.logger = log
 
-        # get provider config from the project configuration — these are
-        # authoritative and must never be overridden by app-level defaults.
-        self._project_provider_config = config.get('provider', {}).get('libvirt', {})
-
-        #: Dict[str, Any]: the base provider config (may be enriched with
-        #: app-level or runtime settings, but project-level keys always win
-        #: via the property).
-        self._provider_config_base = self._project_provider_config.copy()
+        #: Dict[str, Any]: the effective provider config. The CLI hands the
+        #: session an already-merged dict (app-level defaults + runtime
+        #: injection, overlaid by project-level settings via
+        #: :func:`boxman.providers.merge_provider_configs`), so no further
+        #: precedence handling happens here.
+        self.provider_config = dict(
+            (config.get('provider', {}) or {}).get('libvirt', {}) or {})
 
         #: the boxman manager instance (mainly to get access to the cache)
         self.manager = None
-
-    @property
-    def provider_config(self) -> dict[str, Any]:
-        """
-        Return the effective provider config.
-
-        Project-level settings (from conf.yml) always take precedence
-        over app-level (boxman.yml) or runtime-injected values.
-        """
-        merged = self._provider_config_base.copy()
-        merged.update(self._project_provider_config)
-        return merged
-
-    @provider_config.setter
-    def provider_config(self, value: dict[str, Any]) -> None:
-        """
-        Set the base provider config.
-
-        The getter will overlay project-level settings on top, so
-        project-level keys like ``use_sudo`` can never be overridden.
-        """
-        self._provider_config_base = value
 
     @property
     def uri(self) -> str:
@@ -78,7 +55,7 @@ class LibVirtSession:
 
     @uri.setter
     def uri(self, value: str) -> None:
-        self._provider_config_base['uri'] = value
+        self.provider_config['uri'] = value
 
     @property
     def use_sudo(self) -> bool:
@@ -86,27 +63,25 @@ class LibVirtSession:
 
     @use_sudo.setter
     def use_sudo(self, value: bool) -> None:
-        self._provider_config_base['use_sudo'] = value
+        self.provider_config['use_sudo'] = value
 
     def update_provider_config(self, new_config: dict[str, Any]) -> None:
         """
-        Update provider_config with *new_config*, but project-level settings
-        always win (enforced by the property getter).
+        Update provider_config with *new_config* (plain last-write-wins).
+
+        Precedence between app-level and project-level settings is resolved
+        upstream by :func:`boxman.providers.merge_provider_configs` before
+        the session is built; this is only used for runtime metadata
+        injection, which never carries project keys.
 
         Args:
-            new_config: Additional config keys (e.g. from boxman.yml providers
-                        section or runtime injection).
+            new_config: Additional config keys (e.g. runtime injection).
         """
-        merged = self._provider_config_base.copy()
-        merged.update(new_config)
-        self._provider_config_base = merged
+        self.provider_config.update(new_config)
 
     def update_provider_config_with_runtime(self) -> None:
         """
         Enrich provider_config with runtime metadata from the manager.
-
-        Project-level provider settings always take precedence over
-        app-level (boxman.yml) settings and runtime defaults.
         """
         if self.manager is None:
             return
@@ -115,7 +90,6 @@ class LibVirtSession:
         enriched = self.manager.get_provider_config_with_runtime(
             self.provider_config
         )
-        # Merge, ensuring project-level keys win
         self.update_provider_config(enriched)
 
     def import_image(self,

--- a/src/boxman/scripts/app.py
+++ b/src/boxman/scripts/app.py
@@ -16,7 +16,7 @@ from boxman import log
 from boxman.abstract.providers import ProviderSession as Session
 from boxman.exceptions import BoxmanError, ConfigError
 from boxman.manager import BoxmanManager
-from boxman.providers import create_session, primary_provider_type
+from boxman.providers import create_session, merge_provider_configs, primary_provider_type
 from boxman.providers.libvirt.import_image import ImageImporter
 from boxman.loggers.logger import set_quiet, set_verbosity, suppressed
 from boxman.scripts.cli_parser import parse_args, resolve_verbosity
@@ -425,8 +425,8 @@ def _main():
             boxman_config.get('providers', {}).get(provider_type, {})
         )
         project_provider = manager.config.get('provider', {}).get(provider_type, {})
-        merged_provider = provider_conf_with_runtime.copy()
-        merged_provider.update(project_provider)
+        merged_provider = merge_provider_configs(
+            provider_conf_with_runtime, project_provider)
         args.func(manager, args, merged_provider=merged_provider)
         sys.exit(0)
 
@@ -630,9 +630,10 @@ def _main():
                 enriched_config = manager.config.copy()
                 existing_provider = enriched_config.get('provider') or {}
                 project_provider = (existing_provider.get(_ptype) or {}).copy()
-                # Start from app-level defaults, then overlay project-level on top
-                merged_provider = provider_conf_with_runtime.copy()
-                merged_provider.update(project_provider)
+                # Start from app-level defaults, then overlay project-level on
+                # top via the shared sudo-list-aware merge
+                merged_provider = merge_provider_configs(
+                    provider_conf_with_runtime, project_provider)
                 enriched_config['provider'] = {
                     **existing_provider,
                     _ptype: merged_provider,

--- a/tests/test_libvirt_clone_vm.py
+++ b/tests/test_libvirt_clone_vm.py
@@ -194,8 +194,7 @@ class TestCloneVmIsoBootDispatch:
 
     def _make_session(self):
         session = LibVirtSession.__new__(LibVirtSession)
-        session._provider_config_base = {"uri": "qemu:///system", "use_sudo": False}
-        session._project_provider_config = {}
+        session.provider_config = {"uri": "qemu:///system", "use_sudo": False}
         return session
 
     @patch("boxman.providers.libvirt.session.IsoBootVM")

--- a/tests/test_libvirt_session.py
+++ b/tests/test_libvirt_session.py
@@ -2,7 +2,8 @@
 Unit tests for boxman.providers.libvirt.session.LibVirtSession.
 
 Focus on the high-value surface:
-  - Project-level config precedence (provider_config property)
+  - Effective provider config (plain attribute; precedence is resolved
+    upstream by boxman.providers.merge_provider_configs)
   - uri / use_sudo property delegation + setters
   - update_provider_config_with_runtime
   - destroy_disks filesystem cleanup including snapshot leftovers
@@ -45,8 +46,9 @@ def _session(provider: dict | None = None) -> LibVirtSession:
 
 
 class TestConfigPrecedence:
-    """Project-level config must always win over base config — this guards
-    the explicit design in LibVirtSession.provider_config."""
+    """The session holds an already-merged provider config (precedence is
+    resolved upstream by boxman.providers.merge_provider_configs); updates
+    here are plain last-write-wins."""
 
     def test_defaults_on_empty_provider(self):
         s = _session({})
@@ -57,13 +59,12 @@ class TestConfigPrecedence:
         assert s.provider_config["uri"] == "qemu:///system"
         assert s.provider_config["use_sudo"] is True
 
-    def test_project_wins_over_base_via_update(self):
-        s = _session({"use_sudo": True})   # project says True
-        s.update_provider_config({"use_sudo": False})   # app tries to override
-        # Project wins
-        assert s.provider_config["use_sudo"] is True
+    def test_update_is_last_write_wins(self):
+        s = _session({"use_sudo": True})
+        s.update_provider_config({"use_sudo": False})
+        assert s.provider_config["use_sudo"] is False
 
-    def test_base_fills_in_for_missing_project_keys(self):
+    def test_update_fills_in_missing_keys(self):
         s = _session({"use_sudo": True})
         s.update_provider_config({"uri": "qemu:///custom"})
         assert s.provider_config["uri"] == "qemu:///custom"
@@ -89,12 +90,11 @@ class TestUriAndUseSudoProperties:
         s.use_sudo = True
         assert s.use_sudo is True
 
-    def test_project_use_sudo_wins_over_setter(self):
-        """If project said False, we cannot flip it to True via the setter."""
+    def test_use_sudo_setter_overrides_project_value(self):
+        """The setter writes straight into the effective config."""
         s = _session({"use_sudo": False})
-        s.use_sudo = True    # sets base only
-        # Project still wins
-        assert s.use_sudo is False
+        s.use_sudo = True
+        assert s.use_sudo is True
 
 
 class TestUpdateProviderConfigWithRuntime:
@@ -104,18 +104,19 @@ class TestUpdateProviderConfigWithRuntime:
         s.update_provider_config_with_runtime()
         assert s.provider_config["uri"] == "qemu:///system"
 
-    def test_delegates_to_manager_and_preserves_project_keys(self):
+    def test_delegates_to_manager_and_applies_runtime_keys(self):
         s = _session({"use_sudo": True})
         manager = MagicMock()
+        # get_provider_config_with_runtime derives from the session's own
+        # config and adds runtime metadata on top
         manager.get_provider_config_with_runtime.return_value = {
-            "use_sudo": False, "runtime": "docker-compose",
+            "use_sudo": True, "runtime": "docker-compose",
         }
         s.manager = manager
 
         s.update_provider_config_with_runtime()
         # Runtime was applied
         assert s.provider_config["runtime"] == "docker-compose"
-        # Project-level use_sudo still wins
         assert s.provider_config["use_sudo"] is True
 
 

--- a/tests/test_manager_core.py
+++ b/tests/test_manager_core.py
@@ -2,12 +2,14 @@
 Unit tests for selected BoxmanManager core methods.
 
 Targets the pure / easily isolated methods of the 4122-LOC manager.py:
-  - ``_merge_provider_configs`` (static, sudo-lists merging)
   - ``_canonical_runtime_name`` (static)
   - ``collect_workdirs`` (config-only, no I/O beyond path resolution)
   - ``fetch_value`` (classmethod — env/file/literal resolution)
   - ``get_global_authorized_keys`` (uses fetch_value)
   - ``runtime`` / ``runtime_instance`` / ``get_provider_config_with_runtime``
+
+Also covers ``boxman.providers.merge_provider_configs`` (sudo-lists
+merging), the single provider-config merge used by the CLI and manager.
 
 The orchestration surface (provision, up, down, snapshot_*, etc.) is
 left to integration tests.
@@ -25,6 +27,7 @@ from unittest.mock import patch
 import pytest
 
 from boxman.manager import BoxmanManager
+from boxman.providers import merge_provider_configs
 
 
 pytestmark = pytest.mark.unit
@@ -45,7 +48,7 @@ class TestMergeProviderConfigs:
     """
 
     def test_scalars_local_overrides_global(self):
-        merged = BoxmanManager._merge_provider_configs(
+        merged = merge_provider_configs(
             {"uri": "qemu:///system", "use_sudo": True},
             {"use_sudo": False},
         )
@@ -53,12 +56,12 @@ class TestMergeProviderConfigs:
         assert merged["use_sudo"] is False
 
     def test_empty_configs_yield_empty_sudo_lists(self):
-        merged = BoxmanManager._merge_provider_configs({}, {})
+        merged = merge_provider_configs({}, {})
         assert merged["sudo_skip_commands"] == []
         assert merged["force_sudo_commands"] == []
 
     def test_sudo_lists_union(self):
-        merged = BoxmanManager._merge_provider_configs(
+        merged = merge_provider_configs(
             {"sudo_skip_commands": ["ls"], "force_sudo_commands": ["virsh"]},
             {"sudo_skip_commands": ["cat"], "force_sudo_commands": ["virt-install"]},
         )
@@ -66,7 +69,7 @@ class TestMergeProviderConfigs:
         assert merged["force_sudo_commands"] == ["virsh", "virt-install"]
 
     def test_local_skip_wins_over_global_force(self):
-        merged = BoxmanManager._merge_provider_configs(
+        merged = merge_provider_configs(
             {"force_sudo_commands": ["virsh"]},
             {"sudo_skip_commands": ["virsh"]},
         )
@@ -74,7 +77,7 @@ class TestMergeProviderConfigs:
         assert "virsh" not in merged["force_sudo_commands"]
 
     def test_local_force_wins_over_global_skip(self):
-        merged = BoxmanManager._merge_provider_configs(
+        merged = merge_provider_configs(
             {"sudo_skip_commands": ["virsh"]},
             {"force_sudo_commands": ["virsh"]},
         )
@@ -84,7 +87,7 @@ class TestMergeProviderConfigs:
     def test_does_not_mutate_inputs(self):
         g = {"sudo_skip_commands": ["ls"]}
         l = {"sudo_skip_commands": ["cat"]}
-        BoxmanManager._merge_provider_configs(g, l)
+        merge_provider_configs(g, l)
         assert g == {"sudo_skip_commands": ["ls"]}
         assert l == {"sudo_skip_commands": ["cat"]}
 

--- a/tests/test_provider_config_merge.py
+++ b/tests/test_provider_config_merge.py
@@ -1,0 +1,131 @@
+"""
+Regression tests for the unified provider-config merge (#85 item 8).
+
+``boxman.providers.merge_provider_configs`` is now the single merge used
+by the CLI session-creation path, ``boxman conf`` (show_conf) and the
+manager's one-off virsh probes. These tests drive the real app.py paths
+(with boxman.yml / create_session / the verb itself mocked out) and assert
+the sudo-list union/eviction semantics end to end:
+
+  - a project-level ``sudo_skip_commands`` entry evicts the command from
+    the app-level ``force_sudo_commands`` list (previously the CLI path
+    wholesale-replaced the app list with the project list, or vice versa);
+  - commands that only appear in app-level lists are preserved;
+  - scalar project keys win, app-level scalars fill in.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from boxman.scripts.app import main
+
+pytestmark = pytest.mark.unit
+
+
+APP_CONFIG = {
+    'runtime': 'local',
+    'providers': {
+        'libvirt': {
+            'uri': 'qemu+ssh://hypervisor.example/system',
+            'use_sudo': False,
+            'force_sudo_commands': ['virsh', 'qemu-img'],
+            'sudo_skip_commands': ['ls'],
+        },
+    },
+}
+
+PROJECT_CONFIG = {
+    'project': 'demo',
+    'provider': {
+        'libvirt': {
+            'use_sudo': True,
+            'sudo_skip_commands': ['virsh'],
+        },
+    },
+    'clusters': {
+        'cluster_1': {
+            'workdir': '/tmp/boxman-test-merge',
+            'vms': {'node01': {}},
+        },
+    },
+}
+
+
+def _run_cli(argv: list[str]) -> int:
+    """Invoke ``main()`` with *argv*, returning the exit code."""
+    with patch.object(sys, "argv", ["boxman"] + argv):
+        try:
+            main()
+            return 0
+        except SystemExit as exc:
+            return exc.code if isinstance(exc.code, int) else 0
+
+
+@pytest.fixture
+def conf_yml(tmp_path: Path) -> Path:
+    path = tmp_path / "conf.yml"
+    path.write_text(yaml.safe_dump(PROJECT_CONFIG))
+    return path
+
+
+class TestSessionCreationMerge:
+    """The provision-path session must receive the sudo-list-aware merge."""
+
+    def test_session_config_uses_unified_merge(self, conf_yml: Path):
+        captured: dict[str, dict] = {}
+
+        def fake_create_session(provider_type, config):
+            captured[provider_type] = config
+            return MagicMock(name=f"session-{provider_type}")
+
+        with patch("boxman.manager.BoxmanCache"), \
+             patch("boxman.scripts.app.load_boxman_config",
+                   return_value=APP_CONFIG), \
+             patch("boxman.scripts.app.create_session",
+                   side_effect=fake_create_session), \
+             patch("boxman.manager.BoxmanManager.provision",
+                   return_value=None):
+            code = _run_cli(["--conf", str(conf_yml), "provision"])
+
+        assert code == 0
+        merged = captured["libvirt"]["provider"]["libvirt"]
+
+        # eviction: project skips 'virsh' -> gone from the app force list
+        assert merged["force_sudo_commands"] == ["qemu-img"]
+        # union: app-level 'ls' preserved, project-level 'virsh' added
+        assert merged["sudo_skip_commands"] == ["ls", "virsh"]
+        # scalars: project wins, app fills in
+        assert merged["use_sudo"] is True
+        assert merged["uri"] == "qemu+ssh://hypervisor.example/system"
+        # runtime metadata was injected before the merge
+        assert merged["runtime"] == "local"
+
+
+class TestShowConfMerge:
+    """``boxman conf`` must report the same merged provider config."""
+
+    def test_show_conf_uses_unified_merge(self, conf_yml: Path):
+        captured: dict = {}
+
+        def fake_show_conf(manager, args, merged_provider=None):
+            captured["merged_provider"] = merged_provider
+
+        with patch("boxman.manager.BoxmanCache"), \
+             patch("boxman.scripts.app.load_boxman_config",
+                   return_value=APP_CONFIG), \
+             patch("boxman.manager.BoxmanManager.show_conf",
+                   side_effect=fake_show_conf):
+            code = _run_cli(["--conf", str(conf_yml), "conf"])
+
+        assert code == 0
+        merged = captured["merged_provider"]
+        assert merged["force_sudo_commands"] == ["qemu-img"]
+        assert merged["sudo_skip_commands"] == ["ls", "virsh"]
+        assert merged["use_sudo"] is True
+        assert merged["uri"] == "qemu+ssh://hypervisor.example/system"


### PR DESCRIPTION
Refs #85 (item 8).

## Problem
Three divergent provider-config merges existed:
- `BoxmanManager._merge_provider_configs` (sudo-list aware, "local wins")
- the app.py session-creation path and `show_conf` (plain `dict.update`)
- a third overlay in `LibVirtSession.provider_config`

Consequences: a project-level `force_sudo_commands` wholesale replaced the app-level list instead of unioning, and a project-level `sudo_skip_commands` entry did not evict the command from the app-level `force_sudo_commands` list on the CLI path.

## Fix
- `boxman.providers.merge_provider_configs` is now the single merge implementation (moved verbatim from `BoxmanManager._merge_provider_configs`, which is deleted).
- app.py session creation and `show_conf` use it; the manager's one-off virsh probes call the shared function.
- The `LibVirtSession.provider_config` overlay property is dropped: the CLI now hands the session an already-merged config, and `update_provider_config` is plain last-write-wins (only used for runtime-metadata injection, which carries no project keys).

## Tests
- New `tests/test_provider_config_merge.py` drives the real app.py session-creation and `conf` paths (boxman.yml / create_session / verb mocked) and asserts union + eviction semantics end to end.
- Existing `TestMergeProviderConfigs` re-pointed at the new home; libvirt-session tests updated for the dropped overlay.
- Full unit suite: 1802 passed. Ruff: no new violations.

## Deferred
The `VirtualBoxSession` keeps its own copy of the overlay (outside this group's file set; tracked by review item 34 on session-surface duplication).