### PR TITLE
fix: app-level provider settings reach non-libvirt sessions (#85 item 10)

### DIFF
--- a/src/boxman/scripts/app.py
+++ b/src/boxman/scripts/app.py
@@ -614,33 +614,31 @@ def _main():
                 except ConfigError as exc:
                     log.error(str(exc))
                     sys.exit(2)
-            if _ptype == 'libvirt':
-                # merge runtime metadata into the provider config from boxman.yml
-                provider_conf_with_runtime = manager.get_provider_config_with_runtime(
-                    boxman_config.get('providers', {}).get(_ptype, {})
-                )
-                # Enrich the project config with runtime-aware provider
-                # settings. App-level (boxman.yml) settings serve as
-                # DEFAULTS; project-level (conf.yml) settings always take
-                # precedence. The libvirt block is built unconditionally so
-                # a project without a ``provider:`` section (now defaulted
-                # to libvirt by primary_provider_type) still inherits the
-                # runtime URI/sudo defaults instead of silently falling back
-                # to a local qemu:///system.
-                enriched_config = manager.config.copy()
-                existing_provider = enriched_config.get('provider') or {}
-                project_provider = (existing_provider.get(_ptype) or {}).copy()
-                # Start from app-level defaults, then overlay project-level on
-                # top via the shared sudo-list-aware merge
-                merged_provider = merge_provider_configs(
-                    provider_conf_with_runtime, project_provider)
-                enriched_config['provider'] = {
-                    **existing_provider,
-                    _ptype: merged_provider,
-                }
-                session_config = enriched_config
-            else:
-                session_config = manager.config
+            # merge runtime metadata into the provider config from boxman.yml
+            provider_conf_with_runtime = manager.get_provider_config_with_runtime(
+                boxman_config.get('providers', {}).get(_ptype, {})
+            )
+            # Enrich the project config with runtime-aware provider
+            # settings — for EVERY provider type, so app-level
+            # (boxman.yml) settings serve as DEFAULTS and project-level
+            # (conf.yml) settings always take precedence. The provider
+            # block is built unconditionally so a project without a
+            # ``provider:`` section (defaulted to libvirt by
+            # primary_provider_type) still inherits the runtime URI/sudo
+            # defaults instead of silently falling back to a local
+            # qemu:///system.
+            enriched_config = manager.config.copy()
+            existing_provider = enriched_config.get('provider') or {}
+            project_provider = (existing_provider.get(_ptype) or {}).copy()
+            # Start from app-level defaults, then overlay project-level on
+            # top via the shared sudo-list-aware merge
+            merged_provider = merge_provider_configs(
+                provider_conf_with_runtime, project_provider)
+            enriched_config['provider'] = {
+                **existing_provider,
+                _ptype: merged_provider,
+            }
+            session_config = enriched_config
 
             try:
                 session = create_session(_ptype, session_config)

--- a/tests/test_provider_config_merge.py
+++ b/tests/test_provider_config_merge.py
@@ -129,3 +129,64 @@ class TestShowConfMerge:
         assert merged["sudo_skip_commands"] == ["ls", "virsh"]
         assert merged["use_sudo"] is True
         assert merged["uri"] == "qemu+ssh://hypervisor.example/system"
+
+
+DC_APP_CONFIG = {
+    'runtime': 'local',
+    'providers': {
+        'docker-compose': {
+            'project_name': 'app_level_default',
+            'compose_cmd': 'docker compose',
+        },
+    },
+}
+
+DC_PROJECT_CONFIG = {
+    'version': '2.0',
+    'project': 'dc_demo',
+    'provider': {
+        'docker-compose': {
+            'project_name': 'dc_demo',
+        },
+    },
+    'clusters': {
+        'web': {
+            'provider': 'docker-compose',
+            'workdir': '/tmp/boxman-test-dc-merge',
+        },
+    },
+}
+
+
+class TestNonLibvirtSessionMerge:
+    """App-level provider settings must reach non-libvirt sessions too
+    (#85 item 10): previously the app->runtime->project merge only ran
+    under ``if _ptype == 'libvirt'``, so ``providers.docker-compose.*``
+    in boxman.yml was silently ignored."""
+
+    def test_docker_compose_session_sees_app_level_keys(self, tmp_path: Path):
+        conf_yml = tmp_path / "conf.yml"
+        conf_yml.write_text(yaml.safe_dump(DC_PROJECT_CONFIG))
+        captured: dict[str, dict] = {}
+
+        def fake_create_session(provider_type, config):
+            captured[provider_type] = config
+            return MagicMock(name=f"session-{provider_type}")
+
+        with patch("boxman.manager.BoxmanCache"), \
+             patch("boxman.scripts.app.load_boxman_config",
+                   return_value=DC_APP_CONFIG), \
+             patch("boxman.scripts.app.create_session",
+                   side_effect=fake_create_session), \
+             patch("boxman.manager.BoxmanManager.provision",
+                   return_value=None):
+            code = _run_cli(["--conf", str(conf_yml), "provision"])
+
+        assert code == 0
+        merged = captured["docker-compose"]["provider"]["docker-compose"]
+        # app-level keys are no longer dropped
+        assert merged["compose_cmd"] == "docker compose"
+        # project-level scalar still wins
+        assert merged["project_name"] == "dc_demo"
+        # runtime metadata was injected
+        assert merged["runtime"] == "local"


### PR DESCRIPTION
Refs #85 (item 10). Builds on #110 (item 8).

## Problem
The app.py session-creation loop only ran the boxman.yml → runtime-injection → project merge under `if _ptype == 'libvirt'`. For docker-compose / virtualbox providers the session got the project config verbatim, so `providers.docker-compose.*` in boxman.yml was silently ignored.

## Fix
The unified merge path (item 8's `merge_provider_configs` + runtime injection) now runs for every provider type in the session-creation loop.

## Tests
- New `TestNonLibvirtSessionMerge` in `tests/test_provider_config_merge.py`: a docker-compose project provisioned through the real app.py path (boxman.yml / create_session / verb mocked) sees app-level keys, project scalars still win, runtime metadata is injected.
- Full unit suite: 1816 passed. Ruff: no new violations.