### PR TITLE
fix: share one docker-exec wrap and error on missing runtime container (#85 item 9)

### DIFF
--- a/src/boxman/providers/libvirt/commands.py
+++ b/src/boxman/providers/libvirt/commands.py
@@ -5,6 +5,8 @@ from typing import Any
 import invoke
 
 from boxman import log
+from boxman.exceptions import ConfigError
+from boxman.runtime.docker_compose import docker_exec_wrap
 from boxman.utils.shell import run as _shell_run
 
 
@@ -53,9 +55,11 @@ class LibVirtCommandBase:
         #: str: The runtime environment ('local', 'docker-compose', etc.)
         self.runtime = self.provider_config.get('runtime', 'local')
 
-        #: str: The docker-compose container name for remote execution
-        self.runtime_container = self.provider_config.get(
-            'runtime_container', 'boxman-libvirt-default')
+        #: str | None: The docker-compose container name for remote
+        #: execution. No default: under a docker-compose runtime a missing
+        #: container name is a hard error (see _wrap_for_runtime), not a
+        #: silent fall-back that would exec into the wrong container.
+        self.runtime_container = self.provider_config.get('runtime_container')
 
         #: List[str]: Commands that should never get sudo prepended
         self.sudo_skip_commands: list[str] = self.provider_config.get(
@@ -267,9 +271,17 @@ class LibVirtCommandBase:
         if self.runtime == 'local':
             return command
         elif self.runtime == 'docker-compose':
-            # escape single quotes in the command for safe shell wrapping
-            escaped = command.replace("'", "'\\''")
-            return f"docker exec --user root {self.runtime_container} bash -c '{escaped}'"
+            if not self.runtime_container:
+                # No silent fall-back to a guessed container name: exec'ing
+                # into the wrong container is worse than failing loudly. The
+                # manager is responsible for injecting 'runtime_container'
+                # (via the runtime's inject_into_provider_config) before
+                # provider commands run.
+                raise ConfigError(
+                    "runtime is 'docker-compose' but no 'runtime_container' "
+                    "was injected into the provider config — cannot wrap "
+                    f"command for execution: {command}")
+            return docker_exec_wrap(command, self.runtime_container)
         else:
             raise ValueError(f"unsupported runtime: {self.runtime}")
 

--- a/src/boxman/runtime/docker_compose.py
+++ b/src/boxman/runtime/docker_compose.py
@@ -23,6 +23,19 @@ from boxman.runtime.base import RuntimeBase
 from boxman.utils.shell import run as _shell_run
 
 
+def docker_exec_wrap(command: str, container: str) -> str:
+    """
+    Wrap *command* in a ``docker exec --user root <container> bash -c '…'``
+    invocation, escaping single quotes for the shell round-trip.
+
+    This is the single shared implementation of the docker-exec wrapping —
+    used by both :meth:`DockerComposeRuntime.wrap_command` and
+    ``LibVirtCommandBase._wrap_for_runtime`` so the two paths cannot drift.
+    """
+    escaped = command.replace("'", "'\\''")
+    return f"docker exec --user root {container} bash -c '{escaped}'"
+
+
 class DockerComposeRuntime(RuntimeBase):
 
     def __init__(self, config: dict[str, Any] | None = None):
@@ -105,8 +118,7 @@ class DockerComposeRuntime(RuntimeBase):
 
     def wrap_command(self, command: str) -> str:
         """Wrap *command* in a ``docker exec`` invocation."""
-        escaped = command.replace("'", "'\\''")
-        return f"docker exec --user root {self.container_name} bash -c '{escaped}'"
+        return docker_exec_wrap(command, self.container_name)
 
     def inject_into_provider_config(
         self, provider_config: dict[str, Any]

--- a/tests/test_libvirt_commands.py
+++ b/tests/test_libvirt_commands.py
@@ -153,3 +153,65 @@ class TestCallSiteAudit:
                           return_value=_result(stdout=blklist)):
             args = sm._cdrom_diskspec_args("vm01")
         assert args == ["--diskspec", "hdc,snapshot=no"]
+
+
+class TestSharedDockerExecWrap:
+    """One docker-exec wrap implementation shared by the runtime and the
+    libvirt command layer (#85 item 9)."""
+
+    def test_both_paths_produce_identical_output(self):
+        from boxman.runtime.docker_compose import (
+            DockerComposeRuntime,
+            docker_exec_wrap,
+        )
+        cmd = "virsh -c qemu:///system domstate 'vm 01'"
+        container = "boxman-libvirt-proj"
+
+        rt = DockerComposeRuntime(config={"runtime_container": container})
+        via_runtime = rt.wrap_command(cmd)
+
+        v = VirshCommand(provider_config={
+            "runtime": "docker-compose",
+            "runtime_container": container,
+        })
+        via_command_layer = v._wrap_for_runtime(cmd)
+
+        assert via_runtime == via_command_layer == docker_exec_wrap(cmd, container)
+        expected_escaped = cmd.replace("'", "'\\''")
+        assert via_runtime == (
+            f"docker exec --user root {container} bash -c '{expected_escaped}'"
+        )
+
+    def test_single_quotes_escaped_identically(self):
+        from boxman.runtime.docker_compose import (
+            DockerComposeRuntime,
+            docker_exec_wrap,
+        )
+        cmd = "echo 'a' && echo 'b'"
+        rt = DockerComposeRuntime(config={"runtime_container": "c"})
+        v = VirshCommand(provider_config={
+            "runtime": "docker-compose", "runtime_container": "c"})
+        assert rt.wrap_command(cmd) == v._wrap_for_runtime(cmd) \
+            == docker_exec_wrap(cmd, "c")
+
+    def test_missing_container_is_hard_error(self):
+        # used to silently fall back to 'boxman-libvirt-default', exec'ing
+        # into the wrong container
+        import pytest
+
+        from boxman.exceptions import ConfigError
+        v = VirshCommand(provider_config={"runtime": "docker-compose"})
+        with pytest.raises(ConfigError, match="runtime_container"):
+            v._wrap_for_runtime("virsh list --all")
+
+    def test_missing_container_raises_through_execute(self):
+        import pytest
+
+        from boxman.exceptions import ConfigError
+        v = VirshCommand(provider_config={"runtime": "docker-compose"})
+        with pytest.raises(ConfigError):
+            v.execute("list", "--all")
+
+    def test_local_runtime_needs_no_container(self):
+        v = VirshCommand(provider_config={"runtime": "local"})
+        assert v._wrap_for_runtime("virsh list") == "virsh list"


### PR DESCRIPTION
Refs #85 (item 9, execution half).

`DockerComposeRuntime.wrap_command` and `LibVirtCommandBase._wrap_for_runtime` carried byte-identical copies of the docker-exec wrapping. They now share a single module-level `docker_exec_wrap(command, container)` in `boxman.runtime.docker_compose`.

Also, when runtime is docker-compose but no `runtime_container` was injected, `_wrap_for_runtime` silently fell back to `boxman-libvirt-default` — exec'ing into the wrong container without any indication. This is now a hard `ConfigError` with a message pointing at the missing injection.

**Not in this PR (owned by G1b):** the manager.py half of item 9 — applying `update_provider_config_with_runtime` in the verb flows that skip it, so `runtime_container` is always injected before provider commands run. Until that lands, a verb flow that fails to inject will fail loudly here instead of silently targeting the wrong container.

**Tests:** 5 new tests in `tests/test_libvirt_commands.py` — identical wrap output from both paths (incl. single-quote escaping), missing container raises `ConfigError` through both `_wrap_for_runtime` and `execute`, local runtime unaffected. Full unit suite: 1818 passed. Ruff: no new violations (B904s in commands.py pre-existing; the unused `import invoke` in docker_compose.py is removed in the item-21 PR).