### PR TITLE
fix: libvirt pre-checks use the libvirt block in mixed projects (#85 item 11)

### DIFF
--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -200,6 +200,26 @@ class BoxmanManager:
         cluster = ((self.config or {}).get('clusters') or {}).get(cluster_name) or {}
         return cluster.get('provider') or primary_provider_type(self.config)
 
+    def _has_libvirt_clusters(self) -> bool:
+        """
+        Whether this project has any clusters that resolve to the libvirt
+        provider. Projects without a ``provider:`` section default to
+        libvirt (see :func:`primary_provider_type`).
+
+        Used to skip libvirt-only virsh probes in projects that have no
+        libvirt clusters at all (e.g. a pure docker-compose project).
+        """
+        config = self.config or {}
+        clusters = config.get('clusters') or {}
+        if not clusters:
+            return False
+        if not (config.get('provider') or {}):
+            return True
+        return any(
+            self.provider_type_for_cluster(name) == 'libvirt'
+            for name in clusters
+        )
+
     def session_for_cluster(self, cluster_name: str) -> "ProviderSession":
         """
         Return the provider session that manages *cluster_name*.
@@ -1655,13 +1675,15 @@ class BoxmanManager:
         #: keys of the templates whose build failed, reported to the caller
         failed: list[str] = []
 
-        # determine provider config
-        provider_type = list(config.get('provider', {}).keys())[0] if 'provider' in config else 'libvirt'
-        provider_config = config.get('provider', {}).get(provider_type, {})
+        # determine provider config — templates are libvirt-only, so resolve
+        # the libvirt block explicitly: in a mixed project the first key of
+        # ``provider:`` may be a different provider, and probing/creating on
+        # that config would target the wrong hypervisor.
+        provider_config = config.get('provider', {}).get('libvirt', {})
 
         # merge app-level provider config as defaults
         if self.app_config and 'providers' in self.app_config:
-            app_provider = self.app_config['providers'].get(provider_type, {})
+            app_provider = self.app_config['providers'].get('libvirt', {})
             provider_config = merge_provider_configs(app_provider, provider_config)
 
         # inject runtime settings
@@ -4160,13 +4182,15 @@ class BoxmanManager:
         expected = self._get_project_vm_names()
         if not expected:
             return []
+        if not self._has_libvirt_clusters():
+            return []
 
-        # Resolve provider config so VirshCommand uses the right
-        # runtime / URI / sudo settings.
-        provider_type = primary_provider_type(self.config)
-        provider_config = self.config.get('provider', {}).get(provider_type, {})
+        # Resolve the libvirt provider config explicitly — these probes are
+        # libvirt-only, so in a mixed project the first key of ``provider:``
+        # (primary_provider_type) may point at the wrong hypervisor.
+        provider_config = self.config.get('provider', {}).get('libvirt', {})
         if self.app_config and 'providers' in self.app_config:
-            app_prov = self.app_config['providers'].get(provider_type, {})
+            app_prov = self.app_config['providers'].get('libvirt', {})
             provider_config = merge_provider_configs(app_prov, provider_config)
         if hasattr(self, 'runtime_instance'):
             provider_config = self.runtime_instance.inject_into_provider_config(
@@ -4192,10 +4216,15 @@ class BoxmanManager:
         project = self.config.get("project", "")
         prj_prefix = f"bprj__{project}__bprj_"
 
-        provider_type = primary_provider_type(self.config)
-        provider_config = self.config.get('provider', {}).get(provider_type, {})
+        if not self._has_libvirt_clusters():
+            return []
+
+        # Resolve the libvirt provider config explicitly — see
+        # _find_existing_project_vms for why primary_provider_type is wrong
+        # here in mixed projects.
+        provider_config = self.config.get('provider', {}).get('libvirt', {})
         if self.app_config and 'providers' in self.app_config:
-            app_prov = self.app_config['providers'].get(provider_type, {})
+            app_prov = self.app_config['providers'].get('libvirt', {})
             provider_config = merge_provider_configs(app_prov, provider_config)
         if hasattr(self, 'runtime_instance'):
             provider_config = self.runtime_instance.inject_into_provider_config(
@@ -4226,11 +4255,15 @@ class BoxmanManager:
         expected = set(self._get_project_vm_names())
         if not expected:
             return {}
+        if not self._has_libvirt_clusters():
+            return {}
 
-        provider_type = primary_provider_type(self.config)
-        provider_config = self.config.get('provider', {}).get(provider_type, {})
+        # Resolve the libvirt provider config explicitly — see
+        # _find_existing_project_vms for why primary_provider_type is wrong
+        # here in mixed projects.
+        provider_config = self.config.get('provider', {}).get('libvirt', {})
         if self.app_config and 'providers' in self.app_config:
-            app_prov = self.app_config['providers'].get(provider_type, {})
+            app_prov = self.app_config['providers'].get('libvirt', {})
             provider_config = merge_provider_configs(app_prov, provider_config)
         if hasattr(self, 'runtime_instance'):
             provider_config = self.runtime_instance.inject_into_provider_config(

--- a/tests/test_libvirt_probe_config.py
+++ b/tests/test_libvirt_probe_config.py
@@ -1,0 +1,156 @@
+"""
+Regression tests for libvirt-only virsh probes in mixed projects
+(#85 item 11).
+
+``_find_existing_project_vms`` / ``_find_all_existing_project_vms`` /
+``_get_vm_states`` / ``_create_templates_impl`` used to build their
+one-off ``VirshCommand`` from ``primary_provider_type(config)`` — the
+first key of the ``provider:`` block. A mixed project listing
+docker-compose first made these helpers interrogate the wrong
+hypervisor. They now resolve the ``libvirt`` block explicitly and skip
+entirely when the project has no libvirt clusters.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from boxman.manager import BoxmanManager
+
+pytestmark = pytest.mark.unit
+
+
+MIXED_DC_FIRST_CONFIG = {
+    'project': 'mixed',
+    'provider': {
+        'docker-compose': {'project_name': 'should-not-leak'},
+        'libvirt': {'uri': 'qemu+ssh://hv.example/system'},
+    },
+    'clusters': {
+        'web': {'provider': 'docker-compose', 'workdir': '/tmp/x'},
+        'compute': {
+            'provider': 'libvirt',
+            'workdir': '/tmp/y',
+            'vms': {'node01': {}},
+        },
+    },
+}
+
+DC_ONLY_CONFIG = {
+    'version': '2.0',
+    'project': 'dconly',
+    'provider': {
+        'docker-compose': {'project_name': 'dconly'},
+    },
+    'clusters': {
+        'web': {'provider': 'docker-compose', 'workdir': '/tmp/x'},
+    },
+}
+
+APP_CONFIG = {
+    'providers': {
+        'libvirt': {'use_sudo': True},
+        'docker-compose': {'compose_cmd': 'docker compose'},
+    },
+}
+
+
+@pytest.fixture
+def mgr() -> BoxmanManager:
+    with patch("boxman.manager.BoxmanCache"):
+        m = BoxmanManager()
+    m.app_config = APP_CONFIG
+    return m
+
+
+def _virsh_result(stdout: str = "", ok: bool = True) -> MagicMock:
+    r = MagicMock(name="virsh.Result")
+    r.stdout = stdout
+    r.ok = ok
+    return r
+
+
+class TestMixedProjectUsesLibvirtBlock:
+
+    def test_find_existing_project_vms_uses_libvirt_config(
+        self, mgr: BoxmanManager
+    ):
+        mgr.config = MIXED_DC_FIRST_CONFIG
+        virsh = MagicMock()
+        virsh.execute.return_value = _virsh_result(
+            "bprj__mixed__bprj_compute_node01\n")
+
+        with patch("boxman.manager.VirshCommand", return_value=virsh) as ctor:
+            found = mgr._find_existing_project_vms()
+
+        assert found == ["bprj__mixed__bprj_compute_node01"]
+        provider_config = ctor.call_args.kwargs["provider_config"]
+        # the libvirt block was used, not the first (docker-compose) key
+        assert provider_config["uri"] == "qemu+ssh://hv.example/system"
+        assert "project_name" not in provider_config
+        # app-level libvirt defaults were merged in
+        assert provider_config["use_sudo"] is True
+
+    def test_get_vm_states_uses_libvirt_config(self, mgr: BoxmanManager):
+        mgr.config = MIXED_DC_FIRST_CONFIG
+        virsh = MagicMock()
+        virsh.execute.return_value = _virsh_result(
+            " Id   Name                              State\n"
+            "----------------------------------------------\n"
+            " 3    bprj__mixed__bprj_compute_node01   running\n")
+
+        with patch("boxman.manager.VirshCommand", return_value=virsh) as ctor:
+            states = mgr._get_vm_states()
+
+        assert states == {"bprj__mixed__bprj_compute_node01": "running"}
+        provider_config = ctor.call_args.kwargs["provider_config"]
+        assert provider_config["uri"] == "qemu+ssh://hv.example/system"
+
+    def test_create_templates_probe_uses_libvirt_config(
+        self, mgr: BoxmanManager, tmp_path: Path
+    ):
+        config = dict(MIXED_DC_FIRST_CONFIG)
+        config["templates"] = {"tpl1": {"name": "rocky-template"}}
+        mgr.config = config
+        virsh = MagicMock()
+        # the template already exists -> early return before any build
+        virsh.execute.return_value = _virsh_result("rocky-template\n")
+
+        # _create_templates_impl imports VirshCommand lazily inside the
+        # function, so patch the source module, not boxman.manager
+        with patch("boxman.providers.libvirt.commands.VirshCommand",
+                   return_value=virsh) as ctor, \
+             patch("boxman.providers.libvirt.cloudinit.CloudInitTemplate") as tpl:
+            failed = mgr._create_templates_impl()
+
+        assert failed == ["tpl1"]
+        tpl.assert_not_called()
+        provider_config = ctor.call_args.kwargs["provider_config"]
+        assert provider_config["uri"] == "qemu+ssh://hv.example/system"
+        assert provider_config["use_sudo"] is True
+
+
+class TestDcOnlyProjectSkipsProbes:
+
+    def test_find_existing_project_vms_skips_virsh(self, mgr: BoxmanManager):
+        mgr.config = DC_ONLY_CONFIG
+        with patch("boxman.manager.VirshCommand") as ctor:
+            assert mgr._find_existing_project_vms() == []
+        ctor.assert_not_called()
+
+    def test_find_all_existing_project_vms_skips_virsh(
+        self, mgr: BoxmanManager
+    ):
+        mgr.config = DC_ONLY_CONFIG
+        with patch("boxman.manager.VirshCommand") as ctor:
+            assert mgr._find_all_existing_project_vms() == []
+        ctor.assert_not_called()
+
+    def test_get_vm_states_skips_virsh(self, mgr: BoxmanManager):
+        mgr.config = DC_ONLY_CONFIG
+        with patch("boxman.manager.VirshCommand") as ctor:
+            assert mgr._get_vm_states() == {}
+        ctor.assert_not_called()


### PR DESCRIPTION
Refs #85 (item 11).

## Problem
Four libvirt-specific helpers built their one-off `VirshCommand` from `primary_provider_type(config)` — the first key of the `provider:` block: `_create_templates_impl`, `_find_existing_project_vms`, `_find_all_existing_project_vms`, `_get_vm_states`. A mixed project listing docker-compose first made these interrogate the wrong hypervisor.

## Fix
- All four resolve `config['provider'].get('libvirt')` explicitly (merged with app-level `providers.libvirt` and runtime-injected as before).
- New `BoxmanManager._has_libvirt_clusters()`; the three VM-find helpers return empty without touching virsh when the project has no libvirt clusters (a pure docker-compose project has no libvirt to talk to).

## Tests
- New `tests/test_libvirt_probe_config.py`: dc-first mixed project — the probes build VirshCommand from the libvirt block (app-level libvirt defaults merged, dc keys absent); dc-only project — the probes skip virsh entirely.
- Full unit suite: 1827 passed. Ruff: no new violations (manager.py retains its ~24 pre-existing).