### PR TITLE
fix: never rewrite a user-supplied compose file in place (#85 item 21)

### DIFF
--- a/src/boxman/runtime/docker_compose.py
+++ b/src/boxman/runtime/docker_compose.py
@@ -10,12 +10,12 @@ directory next to the project's ``conf.yml``.
 import hashlib
 import os
 import re
+import shlex
 import shutil
 import sys
 import time
 from typing import Any
 
-import invoke
 import yaml as pyyaml
 
 from boxman import log
@@ -104,13 +104,45 @@ class DockerComposeRuntime(RuntimeBase):
     def _compose_base_cmd(self, compose_path: str, compose_dir: str) -> str:
         """
         Return the base ``docker compose`` command with project scoping.
+
+        For a user-supplied compose file (anything outside the boxman-owned
+        ``.boxman/runtime/docker`` directory), the bind-mount override and
+        the ``.env`` file that :meth:`ensure_ready` wrote into ``.boxman``
+        are merged in via a second ``-f`` and ``--env-file`` — the user's
+        file and directory are never modified.
         """
-        return (
+        cmd = (
             f"docker compose "
             f"-p {self._compose_project_name} "
-            f"-f {compose_path} "
-            f"--project-directory {compose_dir}"
+            f"-f {shlex.quote(compose_path)}"
         )
+        if not self._is_boxman_owned_compose(compose_path):
+            override = self._bind_mount_override_path()
+            if os.path.isfile(override):
+                cmd += f" -f {shlex.quote(override)}"
+            env_file = os.path.join(self._get_local_runtime_dir(), ".env")
+            if os.path.isfile(env_file):
+                cmd += f" --env-file {shlex.quote(env_file)}"
+        cmd += f" --project-directory {shlex.quote(compose_dir)}"
+        return cmd
+
+    def _is_boxman_owned_compose(self, compose_path: str) -> bool:
+        """
+        Whether *compose_path* is the boxman-deployed copy (inside
+        ``.boxman/runtime/docker``) rather than a user-supplied file.
+        Only the boxman-owned copy may be mutated in place.
+        """
+        runtime_dir = os.path.abspath(self._get_local_runtime_dir())
+        return os.path.abspath(compose_path).startswith(runtime_dir + os.sep)
+
+    def _bind_mount_override_path(self) -> str:
+        """
+        Path of the compose override file that carries the injected
+        bind-mount volumes for user-supplied compose files. Lives in
+        ``.boxman`` — never next to the user's compose file.
+        """
+        return os.path.join(
+            self._get_local_runtime_dir(), "docker-compose.boxman.override.yml")
 
     @property
     def name(self) -> str:
@@ -190,6 +222,52 @@ class DockerComposeRuntime(RuntimeBase):
         with open(compose_path, "w") as fobj:
             pyyaml.dump(compose, fobj, default_flow_style=False, sort_keys=False)
 
+    def _write_bind_mount_override(
+        self, compose_path: str, bind_dirs: list[str]
+    ) -> str | None:
+        """
+        Write a compose override file carrying the bind-mount volumes for
+        a user-supplied compose file, and return its path.
+
+        The user's compose file is only READ (to find the first service
+        name and to dedup volumes already present) — boxman never rewrites
+        a user-owned file in place (the previous in-place injection
+        destroyed comments/formatting via the pyyaml round-trip). The
+        override is merged with a second ``-f`` (see
+        :meth:`_compose_base_cmd`); compose appends the volumes of the
+        same-named service.
+        """
+        with open(compose_path) as fobj:
+            compose = pyyaml.safe_load(fobj)
+
+        services = (compose or {}).get("services", {})
+        if not services:
+            self.logger.warning("no services found in docker-compose.yml")
+            return None
+
+        service_name = next(iter(services))
+
+        # collect existing host-side mount sources for dedup
+        existing_sources = set()
+        for vol in services[service_name].get("volumes", []) or []:
+            if isinstance(vol, str) and ":" in vol:
+                existing_sources.add(vol.split(":")[0])
+
+        added = [f"{d}:{d}" for d in bind_dirs if d not in existing_sources]
+
+        override_path = self._bind_mount_override_path()
+        os.makedirs(os.path.dirname(override_path), exist_ok=True)
+        with open(override_path, "w") as fobj:
+            pyyaml.dump(
+                {"services": {service_name: {"volumes": added}}},
+                fobj, default_flow_style=False, sort_keys=False)
+
+        self.logger.info(
+            f"wrote {len(added)} bind-mount(s) for service "
+            f"'{service_name}' to override file {override_path} "
+            f"(user compose file {compose_path} left untouched)")
+        return override_path
+
     # ------------------------------------------------------------------
     # lifecycle
     # ------------------------------------------------------------------
@@ -201,13 +279,21 @@ class DockerComposeRuntime(RuntimeBase):
         compose_dir = os.path.dirname(compose_path)
         abs_project_dir = os.path.abspath(self.project_dir or os.getcwd())
 
-        # Collect directories to bind-mount and inject them into the
-        # docker-compose.yml before starting.
+        # Collect directories to bind-mount and make them visible inside
+        # the container before starting.
         bind_dirs = self._collect_bind_mount_dirs(abs_project_dir)
-        self._inject_bind_mounts_into_compose(compose_path, bind_dirs)
-
-        # Always rewrite .env with the current paths
-        self._write_env_file(compose_dir, abs_project_dir)
+        if self._is_boxman_owned_compose(compose_path):
+            # boxman owns this copy — mutate it in place and drop the
+            # .env next to it
+            self._inject_bind_mounts_into_compose(compose_path, bind_dirs)
+            self._write_env_file(compose_dir, abs_project_dir)
+        else:
+            # user-supplied compose file — never rewrite it (or drop a
+            # .env) in the user's directory; merge via override + env
+            # files kept in .boxman
+            self._write_bind_mount_override(compose_path, bind_dirs)
+            self._write_env_file(
+                self._get_local_runtime_dir(), abs_project_dir)
 
         # Log the compose file so the user can see what will be started
         self._log_compose_file(compose_path)
@@ -735,10 +821,12 @@ class DockerComposeRuntime(RuntimeBase):
         )
 
     def _write_env_file(self, runtime_dir: str,
-                        abs_project_dir: str = None) -> None:
+                        abs_project_dir: str = None) -> str:
         """
-        Write a ``.env`` file in *runtime_dir* with absolute paths.
+        Write a ``.env`` file in *runtime_dir* with absolute paths and
+        return its path.
         """
+        os.makedirs(runtime_dir, exist_ok=True)
         abs_data_dir = os.path.abspath(os.path.join(runtime_dir, "data"))
         if abs_project_dir is None:
             abs_project_dir = os.path.abspath(self.project_dir or os.getcwd())
@@ -766,6 +854,7 @@ class DockerComposeRuntime(RuntimeBase):
             f"wrote .env: BOXMAN_PROJECT_DIR={abs_project_dir}, "
             f"BOXMAN_DATA_DIR={abs_data_dir}, "
             f"ports={ssh_port}/{tcp_port}/{tls_port}")
+        return env_path
 
     @staticmethod
     def _find_asset_source_dir() -> str | None:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2,6 +2,8 @@
 Tests for boxman.runtime – runtime factory, wrapping, and config injection.
 """
 
+import shlex
+
 import pytest
 from unittest.mock import patch, MagicMock
 from boxman.exceptions import BoxmanError, ConfigError
@@ -158,7 +160,143 @@ class TestDockerComposeRuntime:
         # should still be only 1 entry
         assert vols.count("/home/user/project:/home/user/project") == 1
 
-    @patch("boxman.runtime.docker_compose.invoke.run")
+    # ------------------------------------------------------------------
+    # #85 item 21 — a user-supplied compose file must never be rewritten
+    # in place; bind mounts go into an override file under .boxman
+    # ------------------------------------------------------------------
+    USER_COMPOSE = (
+        "# my own runtime — do not touch\n"
+        "services:\n"
+        "  libvirt:   # the one and only service\n"
+        "    image: qemu-libvirt:local\n"
+        "    volumes:\n"
+        "      - /sys/fs/cgroup:/sys/fs/cgroup:rw\n"
+    )
+
+    def _user_compose_setup(self, tmp_path):
+        """A runtime configured with a user-owned compose file."""
+        user_dir = tmp_path / "userstuff"
+        user_dir.mkdir()
+        compose_path = user_dir / "docker-compose.yml"
+        compose_path.write_text(self.USER_COMPOSE)
+        rt = DockerComposeRuntime(config={
+            "compose_file": str(compose_path),
+            "project_dir": str(tmp_path / "proj"),
+        })
+        return rt, compose_path
+
+    def test_user_compose_file_is_never_rewritten(self, tmp_path):
+        """ensure_ready leaves a user-supplied compose file byte-identical
+        and drops no .env next to it."""
+        rt, compose_path = self._user_compose_setup(tmp_path)
+
+        with patch.object(rt, "_container_is_running", return_value=True), \
+             patch.object(rt, "_project_dir_accessible", return_value=True), \
+             patch.object(rt, "_wait_for_libvirtd"), \
+             patch.object(rt, "_log_compose_file"):
+            rt.ensure_ready()
+
+        assert compose_path.read_text() == self.USER_COMPOSE
+        assert not (compose_path.parent / ".env").exists()
+
+    def test_user_compose_gets_override_file_in_boxman_dir(self, tmp_path):
+        """The bind mounts land in an override file under
+        .boxman/runtime/docker, named for compose override merging."""
+        rt, compose_path = self._user_compose_setup(tmp_path)
+
+        with patch.object(rt, "_container_is_running", return_value=True), \
+             patch.object(rt, "_project_dir_accessible", return_value=True), \
+             patch.object(rt, "_wait_for_libvirtd"), \
+             patch.object(rt, "_log_compose_file"):
+            rt.ensure_ready()
+
+        import yaml
+        override = tmp_path / "proj" / ".boxman" / "runtime" / "docker" / \
+            "docker-compose.boxman.override.yml"
+        assert override.is_file()
+        data = yaml.safe_load(override.read_text())
+        vols = data["services"]["libvirt"]["volumes"]
+        assert f"{tmp_path}/proj:{tmp_path}/proj" in vols
+        assert "/tmp:/tmp" in vols
+        # .env went into .boxman, not next to the user's file
+        assert (override.parent / ".env").is_file()
+
+    def test_override_merged_via_second_f_and_env_file(self, tmp_path):
+        """_compose_base_cmd merges the override with a second -f and
+        passes the .boxman .env via --env-file for user files."""
+        rt, compose_path = self._user_compose_setup(tmp_path)
+
+        with patch.object(rt, "_container_is_running", return_value=True), \
+             patch.object(rt, "_project_dir_accessible", return_value=True), \
+             patch.object(rt, "_wait_for_libvirtd"), \
+             patch.object(rt, "_log_compose_file"):
+            rt.ensure_ready()
+
+        cmd = rt._compose_base_cmd(str(compose_path), str(compose_path.parent))
+        override = rt._bind_mount_override_path()
+        assert f"-f {compose_path}" in cmd
+        assert f"-f {override}" in cmd
+        assert "--env-file" in cmd
+        # user's file is the first -f so its relative paths keep resolving
+        # against its own directory
+        assert cmd.index(f"-f {compose_path}") < cmd.index(f"-f {override}")
+
+    def test_boxman_owned_compose_still_mutated_in_place(self, tmp_path):
+        """The deployed copy under .boxman keeps the old in-place
+        injection + neighbouring .env behaviour."""
+        runtime_dir = tmp_path / "proj" / ".boxman" / "runtime" / "docker"
+        runtime_dir.mkdir(parents=True)
+        compose_path = runtime_dir / "docker-compose.yml"
+        compose_path.write_text(
+            "services:\n  boxman-libvirt:\n    image: test\n")
+
+        rt = DockerComposeRuntime(config={"project_dir": str(tmp_path / "proj")})
+        assert rt._is_boxman_owned_compose(str(compose_path))
+
+        with patch.object(rt, "get_compose_file_path",
+                          return_value=str(compose_path)), \
+             patch.object(rt, "_write_bind_mount_override") as override_mock, \
+             patch.object(rt, "_container_is_running", return_value=True), \
+             patch.object(rt, "_project_dir_accessible", return_value=True), \
+             patch.object(rt, "_wait_for_libvirtd"), \
+             patch.object(rt, "_log_compose_file"):
+            rt.ensure_ready()
+
+        override_mock.assert_not_called()
+        import yaml
+        data = yaml.safe_load(compose_path.read_text())
+        vols = data["services"]["boxman-libvirt"]["volumes"]
+        assert "/tmp:/tmp" in vols
+        assert (runtime_dir / ".env").is_file()
+
+    def test_compose_base_cmd_quotes_paths_with_spaces(self, tmp_path):
+        rt = DockerComposeRuntime(config={"project_dir": str(tmp_path)})
+        compose_dir = tmp_path / "my dir"
+        compose_dir.mkdir()
+        compose_path = compose_dir / "docker-compose.yml"
+        compose_path.write_text("services: {}\n")
+        cmd = rt._compose_base_cmd(str(compose_path), str(compose_dir))
+        tokens = shlex.split(cmd)
+        assert str(compose_path) in tokens
+        assert str(compose_dir) in tokens
+
+    def test_override_dedups_volumes_already_in_user_file(self, tmp_path):
+        rt, compose_path = self._user_compose_setup(tmp_path)
+        override_path = rt._write_bind_mount_override(
+            str(compose_path), ["/sys/fs/cgroup", "/data"])
+        import yaml
+        data = yaml.safe_load(open(override_path))
+        vols = data["services"]["libvirt"]["volumes"]
+        assert vols == ["/data:/data"]
+        assert compose_path.read_text() == self.USER_COMPOSE
+
+    def test_write_bind_mount_override_no_services(self, tmp_path):
+        compose_path = tmp_path / "docker-compose.yml"
+        compose_path.write_text("{}\n")
+        rt = DockerComposeRuntime(config={"project_dir": str(tmp_path)})
+        assert rt._write_bind_mount_override(str(compose_path), ["/x"]) is None
+
+    @patch("invoke.run")
     def test_ensure_ready_skips_compose_up_when_already_running(self, mock_run):
         rt = DockerComposeRuntime(config={"runtime_container": "ctr1"})
 
@@ -170,7 +308,7 @@ class TestDockerComposeRuntime:
         mock_run.side_effect = [mock_result_running, mock_result_running, mock_result_running, mock_result_virsh]
 
         with patch.object(rt, "get_compose_file_path", return_value="/tmp/docker-compose.yml"), \
-             patch.object(rt, "_inject_bind_mounts_into_compose"), \
+             patch.object(rt, "_write_bind_mount_override"), \
              patch.object(rt, "_write_env_file"), \
              patch.object(rt, "_log_compose_file"):
             rt.ensure_ready()
@@ -178,7 +316,7 @@ class TestDockerComposeRuntime:
         calls = [c.args[0] for c in mock_run.call_args_list]
         assert not any("compose" in c and "up" in c for c in calls)
 
-    @patch("boxman.runtime.docker_compose.invoke.run")
+    @patch("invoke.run")
     def test_ensure_ready_starts_compose_when_not_running(self, mock_run):
         rt = DockerComposeRuntime(config={
             "runtime_container": "ctr1",
@@ -187,7 +325,8 @@ class TestDockerComposeRuntime:
         })
 
         with patch.object(rt, "get_compose_file_path", return_value="/tmp/docker-compose.yml"), \
-             patch.object(rt, "_inject_bind_mounts_into_compose"), \
+             patch.object(rt, "_write_bind_mount_override"), \
+             patch.object(rt, "_write_env_file"), \
              patch.object(rt, "_log_compose_file"), \
              patch.object(rt, "verify_workdirs_accessible"):
             mock_not_running = MagicMock(ok=True, stdout="false\n")
@@ -204,7 +343,7 @@ class TestDockerComposeRuntime:
             calls = [c.args[0] for c in mock_run.call_args_list]
             assert any("compose" in c and "up" in c for c in calls)
 
-    @patch("boxman.runtime.docker_compose.invoke.run")
+    @patch("invoke.run")
     @patch("boxman.runtime.docker_compose.time.sleep")
     def test_ensure_ready_raises_on_timeout(self, mock_sleep, mock_run):
         rt = DockerComposeRuntime(config={
@@ -213,7 +352,8 @@ class TestDockerComposeRuntime:
         })
 
         with patch.object(rt, "get_compose_file_path", return_value="/tmp/docker-compose.yml"), \
-             patch.object(rt, "_inject_bind_mounts_into_compose"), \
+             patch.object(rt, "_write_bind_mount_override"), \
+             patch.object(rt, "_write_env_file"), \
              patch.object(rt, "_log_compose_file"):
             mock_not_running = MagicMock(ok=True, stdout="false\n")
             mock_compose_up = MagicMock(ok=True)
@@ -222,7 +362,7 @@ class TestDockerComposeRuntime:
             with pytest.raises(RuntimeError, match="did not start"):
                 rt.ensure_ready()
 
-    @patch("boxman.runtime.docker_compose.invoke.run")
+    @patch("invoke.run")
     def test_ensure_ready_checks_libvirtd_after_container_is_running(self, mock_run):
         rt = DockerComposeRuntime(config={"runtime_container": "ctr1"})
 
@@ -232,7 +372,7 @@ class TestDockerComposeRuntime:
         mock_run.side_effect = [mock_running, mock_dir_ok, mock_dir_ok, mock_virsh]
 
         with patch.object(rt, "get_compose_file_path", return_value="/tmp/docker-compose.yml"), \
-             patch.object(rt, "_inject_bind_mounts_into_compose"), \
+             patch.object(rt, "_write_bind_mount_override"), \
              patch.object(rt, "_write_env_file"), \
              patch.object(rt, "_log_compose_file"):
             rt.ensure_ready()
@@ -432,7 +572,7 @@ class TestDockerComposeRuntime:
             with pytest.raises(FileNotFoundError, match="cannot locate"):
                 rt.get_compose_file_path()
 
-    @patch("boxman.runtime.docker_compose.invoke.run")
+    @patch("invoke.run")
     def test_ensure_ready_passes_project_dir_to_compose(self, mock_run):
         """ensure_ready must pass BOXMAN_PROJECT_DIR so the container
         bind-mounts the project directory."""
@@ -444,7 +584,8 @@ class TestDockerComposeRuntime:
         rt.project_dir = "/home/user/my-project"
 
         with patch.object(rt, "get_compose_file_path", return_value="/tmp/docker-compose.yml"), \
-             patch.object(rt, "_inject_bind_mounts_into_compose"), \
+             patch.object(rt, "_write_bind_mount_override"), \
+             patch.object(rt, "_write_env_file"), \
              patch.object(rt, "_log_compose_file"), \
              patch.object(rt, "verify_workdirs_accessible"):
             mock_not_running = MagicMock(ok=True, stdout="false\n")
@@ -465,9 +606,10 @@ class TestDockerComposeRuntime:
             assert "HOST_UID" in env_kwarg
             assert "HOST_GID" in env_kwarg
 
-    @patch("boxman.runtime.docker_compose.invoke.run")
+    @patch("invoke.run")
     def test_ensure_ready_injects_workdirs_into_compose(self, mock_run):
-        """ensure_ready must inject workdirs as bind-mount volumes."""
+        """ensure_ready must pass workdirs as bind-mount volumes (to the
+        override file for a user-supplied compose file)."""
         rt = DockerComposeRuntime(config={
             "runtime_container": "ctr1",
             "compose_file": "/dev/null",
@@ -482,7 +624,8 @@ class TestDockerComposeRuntime:
             inject_calls.append(bind_dirs)
 
         with patch.object(rt, "get_compose_file_path", return_value="/tmp/docker-compose.yml"), \
-             patch.object(rt, "_inject_bind_mounts_into_compose", side_effect=mock_inject), \
+             patch.object(rt, "_write_bind_mount_override", side_effect=mock_inject), \
+             patch.object(rt, "_write_env_file"), \
              patch.object(rt, "_log_compose_file"), \
              patch.object(rt, "verify_workdirs_accessible"):
             mock_not_running = MagicMock(ok=True, stdout="false\n")
@@ -503,7 +646,7 @@ class TestDockerComposeRuntime:
 
 class TestVerifyWorkdirsAccessible:
 
-    @patch("boxman.runtime.docker_compose.invoke.run")
+    @patch("invoke.run")
     def test_passes_when_all_dirs_accessible(self, mock_run):
         rt = DockerComposeRuntime(config={"runtime_container": "ctr1"})
         mock_run.return_value = MagicMock(ok=True)
@@ -517,7 +660,7 @@ class TestVerifyWorkdirsAccessible:
         assert all("docker exec --user root ctr1" in c for c in calls)
         assert all("test -d" in c and "-w" in c for c in calls)
 
-    @patch("boxman.runtime.docker_compose.invoke.run")
+    @patch("invoke.run")
     def test_raises_listing_missing_dirs(self, mock_run):
         rt = DockerComposeRuntime(config={"runtime_container": "ctr1"})
         mock_run.side_effect = [
@@ -541,7 +684,7 @@ class TestVerifyWorkdirsAccessible:
         assert "/home/user/ok" not in msg
         assert "ctr1" in msg
 
-    @patch("boxman.runtime.docker_compose.invoke.run")
+    @patch("invoke.run")
     def test_defaults_to_collected_bind_mount_dirs(self, mock_run):
         rt = DockerComposeRuntime(config={"runtime_container": "ctr1"})
         rt.project_dir = "/home/user/my-project"
@@ -559,7 +702,7 @@ class TestVerifyWorkdirsAccessible:
 
 class TestDockerComposeDestroyRuntime:
 
-    @patch("boxman.runtime.docker_compose.invoke.run")
+    @patch("invoke.run")
     def test_destroy_runtime_cleans_data_dirs_inside_container(self, mock_run):
         """When the container is running, destroy_runtime should exec rm -rf
         inside it before running docker compose down."""
@@ -586,7 +729,7 @@ class TestDockerComposeDestroyRuntime:
         assert "down --volumes --remove-orphans" in calls[2]
         assert result == "/tmp/test-project/.boxman"
 
-    @patch("boxman.runtime.docker_compose.invoke.run")
+    @patch("invoke.run")
     def test_destroy_runtime_skips_cleanup_when_container_not_running(self, mock_run):
         """When the container is not running, destroy_runtime should skip
         the in-container cleanup and go straight to docker compose down."""
@@ -608,7 +751,7 @@ class TestDockerComposeDestroyRuntime:
         assert "down --volumes --remove-orphans" in calls[1]
         assert result == "/tmp/test-project/.boxman"
 
-    @patch("boxman.runtime.docker_compose.invoke.run")
+    @patch("invoke.run")
     def test_destroy_runtime_continues_if_cleanup_fails(self, mock_run):
         """If the in-container cleanup fails, destroy_runtime should still
         proceed with docker compose down."""
@@ -638,7 +781,7 @@ class TestDockerComposeDestroyRuntime:
         result = rt.destroy_runtime()
         assert result is None
 
-    @patch("boxman.runtime.docker_compose.invoke.run")
+    @patch("invoke.run")
     def test_plan_destroy_runtime_with_running_container(self, mock_run, tmp_path):
         """plan_destroy_runtime should list cleanup, compose down, and dir removal."""
         rt = DockerComposeRuntime(config={"runtime_container": "ctr1"})
@@ -665,7 +808,7 @@ class TestDockerComposeDestroyRuntime:
         assert str(boxman_dir) in plan["paths_to_delete"]
         assert plan["container_running"] is True
 
-    @patch("boxman.runtime.docker_compose.invoke.run")
+    @patch("invoke.run")
     def test_plan_destroy_runtime_container_not_running(self, mock_run, tmp_path):
         """When container is not running, plan should omit the exec cleanup."""
         rt = DockerComposeRuntime(config={"runtime_container": "ctr1"})
@@ -914,7 +1057,7 @@ class TestDockerComposeRuntimeBridgeConflict:
     used for bridge allocation.
     """
 
-    @patch("boxman.runtime.docker_compose.invoke.run")
+    @patch("invoke.run")
     def test_brctl_show_sees_host_bridges_inside_container(self, mock_run):
         """Demonstrates that brctl show inside the container returns host bridges,
         which is why virsh net-list is used instead."""


### PR DESCRIPTION
Refs #85 (item 21).

**Problem:** when the docker-compose runtime used a user-owned compose file (config `compose_file` or `BOXMAN_COMPOSE_FILE`), `ensure_ready` rewrote that file in place — injecting volumes into only the FIRST service and re-dumping the whole YAML via `pyyaml.dump`, destroying comments/formatting — and dropped a `.env` next to it.

**Fix (override + second `-f` option):**
- In-place injection + neighbouring `.env` are now restricted to the boxman-deployed copy under `.boxman/runtime/docker` (detected via `_is_boxman_owned_compose`).
- For user-supplied files, `ensure_ready` writes `.boxman/runtime/docker/docker-compose.boxman.override.yml` (bind-mount volumes for the user's first service, deduplicated against existing volumes) and writes the `.env` into `.boxman/runtime/docker` instead of the user's directory.
- `_compose_base_cmd` merges them via a second `-f` (user file first, so its relative paths keep resolving against its own directory — the copy-into-.boxman alternative would have broken relative build contexts) and `--env-file`. `down`/`destroy` flows pick the same flags up automatically.
- Also: `shlex.quote` on `compose_path`/`compose_dir` in `_compose_base_cmd`; removed the unused `import invoke` (it only survived as a mock patch target — the 15 test patches now target `invoke.run` directly, identical semantics).

**Tests:** 7 new tests in `tests/test_runtime.py` — user file byte-identical after `ensure_ready` (comments/formatting preserved), no `.env` next to user file, override file written into `.boxman` with correct service/volumes, second `-f` + `--env-file` in the base command with the user file first, boxman-owned copy still mutated in place, path quoting with spaces, volume dedup. Existing `ensure_ready` tests updated to the new override path. Full unit suite: 1828 passed. Ruff: no new violations (3 pre-existing I001 in test_runtime.py untouched; pre-existing F401 fixed).