### PR TITLE
fix: boxman ps honors boxman.yml and the runtime; one _virsh() probe helper (#85 item 7)

### DIFF
--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -220,6 +220,31 @@ class BoxmanManager:
             for name in clusters
         )
 
+    def _libvirt_provider_config(self) -> dict[str, Any]:
+        """
+        Resolve the libvirt provider config for a one-off virsh probe:
+        the project's ``provider.libvirt`` block merged over app-level
+        (boxman.yml) ``providers.libvirt`` defaults, with runtime
+        metadata injected.
+        """
+        provider_config = (
+            (self.config or {}).get('provider', {}).get('libvirt', {}))
+        if self.app_config and 'providers' in self.app_config:
+            app_prov = self.app_config['providers'].get('libvirt', {})
+            provider_config = merge_provider_configs(app_prov, provider_config)
+        if hasattr(self, 'runtime_instance'):
+            provider_config = self.runtime_instance.inject_into_provider_config(
+                provider_config)
+        return provider_config
+
+    def _virsh(self) -> "VirshCommand":
+        """
+        Build a one-off VirshCommand for a libvirt probe, using the config
+        from :meth:`_libvirt_provider_config` so app-level settings and the
+        runtime (local host vs. container) are honored.
+        """
+        return VirshCommand(provider_config=self._libvirt_provider_config())
+
     def session_for_cluster(self, cluster_name: str) -> "ProviderSession":
         """
         Return the provider session that manages *cluster_name*.
@@ -1675,20 +1700,9 @@ class BoxmanManager:
         #: keys of the templates whose build failed, reported to the caller
         failed: list[str] = []
 
-        # determine provider config — templates are libvirt-only, so resolve
-        # the libvirt block explicitly: in a mixed project the first key of
-        # ``provider:`` may be a different provider, and probing/creating on
-        # that config would target the wrong hypervisor.
-        provider_config = config.get('provider', {}).get('libvirt', {})
-
-        # merge app-level provider config as defaults
-        if self.app_config and 'providers' in self.app_config:
-            app_provider = self.app_config['providers'].get('libvirt', {})
-            provider_config = merge_provider_configs(app_provider, provider_config)
-
-        # inject runtime settings
-        if hasattr(self, 'runtime_instance'):
-            provider_config = self.runtime_instance.inject_into_provider_config(provider_config)
+        # determine provider config — templates are libvirt-only, so the
+        # libvirt block is resolved explicitly (app-merged + runtime-injected)
+        provider_config = self._libvirt_provider_config()
 
         self.logger.info(f"resolved provider config for templates: {provider_config}")
 
@@ -1700,7 +1714,6 @@ class BoxmanManager:
 
         # --- Pre-check: detect already-existing templates ----------------
         # Build a temporary VirshCommand to query existing VMs once.
-        from boxman.providers.libvirt.commands import VirshCommand
         _virsh = VirshCommand(provider_config=provider_config)
         _existing_vms: set = set()
         result = _virsh.execute("list", "--all", "--name", hide=True, warn=True)
@@ -2382,16 +2395,7 @@ class BoxmanManager:
             elif self.provider is not None:
                 # fallback: try virsh list
                 try:
-                    from boxman.providers.libvirt.commands import VirshCommand
-                    provider_type = primary_provider_type(self.config)
-                    provider_config = self.config.get('provider', {}).get(provider_type, {})
-                    if self.app_config and 'providers' in self.app_config:
-                        app_prov = self.app_config['providers'].get(provider_type, {})
-                        provider_config = merge_provider_configs(app_prov, provider_config)
-                    if hasattr(self, 'runtime_instance'):
-                        provider_config = self.runtime_instance.inject_into_provider_config(provider_config)
-                    virsh = VirshCommand(provider_config=provider_config)
-                    result = virsh.execute("list", "--all", "--name", hide=True, warn=True)
+                    result = self._virsh().execute("list", "--all", "--name", hide=True, warn=True)
                     if result.ok:
                         vm_list = [v.strip() for v in result.stdout.strip().split("\n") if v.strip()]
                         exists = tpl_vm_name in vm_list
@@ -4185,19 +4189,7 @@ class BoxmanManager:
         if not self._has_libvirt_clusters():
             return []
 
-        # Resolve the libvirt provider config explicitly — these probes are
-        # libvirt-only, so in a mixed project the first key of ``provider:``
-        # (primary_provider_type) may point at the wrong hypervisor.
-        provider_config = self.config.get('provider', {}).get('libvirt', {})
-        if self.app_config and 'providers' in self.app_config:
-            app_prov = self.app_config['providers'].get('libvirt', {})
-            provider_config = merge_provider_configs(app_prov, provider_config)
-        if hasattr(self, 'runtime_instance'):
-            provider_config = self.runtime_instance.inject_into_provider_config(
-                provider_config)
-
-        virsh = VirshCommand(provider_config=provider_config)
-        result = virsh.execute("list", "--all", "--name", hide=True, warn=True)
+        result = self._virsh().execute("list", "--all", "--name", hide=True, warn=True)
         if not result.ok:
             self.logger.warning("could not query existing VMs via virsh")
             return []
@@ -4219,19 +4211,7 @@ class BoxmanManager:
         if not self._has_libvirt_clusters():
             return []
 
-        # Resolve the libvirt provider config explicitly — see
-        # _find_existing_project_vms for why primary_provider_type is wrong
-        # here in mixed projects.
-        provider_config = self.config.get('provider', {}).get('libvirt', {})
-        if self.app_config and 'providers' in self.app_config:
-            app_prov = self.app_config['providers'].get('libvirt', {})
-            provider_config = merge_provider_configs(app_prov, provider_config)
-        if hasattr(self, 'runtime_instance'):
-            provider_config = self.runtime_instance.inject_into_provider_config(
-                provider_config)
-
-        virsh = VirshCommand(provider_config=provider_config)
-        result = virsh.execute("list", "--all", "--name", hide=True, warn=True)
+        result = self._virsh().execute("list", "--all", "--name", hide=True, warn=True)
         if not result.ok:
             self.logger.warning("could not query existing VMs via virsh")
             return []
@@ -4258,20 +4238,8 @@ class BoxmanManager:
         if not self._has_libvirt_clusters():
             return {}
 
-        # Resolve the libvirt provider config explicitly — see
-        # _find_existing_project_vms for why primary_provider_type is wrong
-        # here in mixed projects.
-        provider_config = self.config.get('provider', {}).get('libvirt', {})
-        if self.app_config and 'providers' in self.app_config:
-            app_prov = self.app_config['providers'].get('libvirt', {})
-            provider_config = merge_provider_configs(app_prov, provider_config)
-        if hasattr(self, 'runtime_instance'):
-            provider_config = self.runtime_instance.inject_into_provider_config(
-                provider_config)
-
-        virsh = VirshCommand(provider_config=provider_config)
         # Use the table output to get both name and state
-        result = virsh.execute("list", "--all", hide=True, warn=True)
+        result = self._virsh().execute("list", "--all", hide=True, warn=True)
         if not result.ok:
             self.logger.warning("could not query VM states via virsh")
             return {}
@@ -6125,17 +6093,11 @@ class BoxmanManager:
                 print("No VMs or containers defined in configuration")
             return
 
-        # Query virsh for VM states — only when there are libvirt VMs (a
-        # dc-only project has no libvirt to talk to).
+        # Query virsh for VM states — only when the project has libvirt
+        # clusters (a dc-only project has no libvirt to talk to).
         vm_info: dict[str, tuple[str, str]] = {}
-        if vm_list:
-            provider_type = primary_provider_type(cls.config)
-            provider_config = cls.config.get("provider", {}).get(provider_type, {})
-            if cls.app_config and "providers" in cls.app_config:
-                app_prov = cls.app_config["providers"].get(provider_type, {})
-                provider_config = merge_provider_configs(app_prov, provider_config)
-            virsh = VirshCommand(provider_config=provider_config)
-            result = virsh.execute("list", "--all", hide=True, warn=True)
+        if vm_list and cls._has_libvirt_clusters():
+            result = cls._virsh().execute("list", "--all", hide=True, warn=True)
             if result.ok:
                 for line in result.stdout.strip().splitlines():
                     line = line.strip()

--- a/src/boxman/scripts/app.py
+++ b/src/boxman/scripts/app.py
@@ -398,6 +398,18 @@ def _main():
             if not manager.config:
                 log.error("no project config found (conf.yml)")
                 sys.exit(1)
+            # same load/merge/inject path as the other verbs so ps honors
+            # boxman.yml (uri, sudo lists) and the resolved runtime
+            boxman_config = load_boxman_config(os.path.expanduser(args.boxman_conf))
+            manager.load_app_config(boxman_config)
+            manager.runtime = args.runtime or boxman_config.get('runtime', 'local')
+            # scope the runtime container to this project (as the full
+            # session path does) so ps targets the right container
+            if manager.runtime_instance.name == 'docker-compose':
+                manager.runtime_instance.project_dir = os.path.abspath(
+                    os.path.dirname(args.conf))
+                if 'project' in manager.config:
+                    manager.runtime_instance.project_name = manager.config['project']
             args.func(manager, args)
         sys.exit(0)
 

--- a/tests/test_libvirt_probe_config.py
+++ b/tests/test_libvirt_probe_config.py
@@ -119,9 +119,9 @@ class TestMixedProjectUsesLibvirtBlock:
         # the template already exists -> early return before any build
         virsh.execute.return_value = _virsh_result("rocky-template\n")
 
-        # _create_templates_impl imports VirshCommand lazily inside the
-        # function, so patch the source module, not boxman.manager
-        with patch("boxman.providers.libvirt.commands.VirshCommand",
+        # the pre-check probe builds its VirshCommand from boxman.manager's
+        # top-level import (via _libvirt_provider_config)
+        with patch("boxman.manager.VirshCommand",
                    return_value=virsh) as ctor, \
              patch("boxman.providers.libvirt.cloudinit.CloudInitTemplate") as tpl:
             failed = mgr._create_templates_impl()

--- a/tests/test_ps.py
+++ b/tests/test_ps.py
@@ -1,0 +1,119 @@
+"""
+Regression tests for ``boxman ps`` config/runtime handling (#85 item 7).
+
+ps used to construct ``BoxmanManager(config=args.conf)`` without loading
+boxman.yml and without setting the runtime, and built its VirshCommand
+from only the project provider block — so app-level settings (uri, sudo
+lists) and the docker-compose runtime were ignored. ps now goes through
+the same load/merge/inject path as the other verbs.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from boxman.scripts.app import main
+
+pytestmark = pytest.mark.unit
+
+
+PROJECT_CONFIG = {
+    'project': 'demo',
+    'clusters': {
+        'cluster_1': {
+            'workdir': '/tmp/boxman-test-ps',
+            'vms': {'node01': {}},
+        },
+    },
+}
+
+APP_CONFIG_LOCAL = {
+    'runtime': 'local',
+    'providers': {
+        'libvirt': {
+            'uri': 'qemu+ssh://hv.example/system',
+            'use_sudo': True,
+        },
+    },
+}
+
+APP_CONFIG_DC_RUNTIME = {
+    'runtime': 'docker-compose',
+    'providers': {
+        'libvirt': {
+            'uri': 'qemu+ssh://hv.example/system',
+        },
+    },
+}
+
+
+def _run_cli(argv: list[str]) -> int:
+    """Invoke ``main()`` with *argv``, returning the exit code."""
+    with patch.object(sys, "argv", ["boxman"] + argv):
+        try:
+            main()
+            return 0
+        except SystemExit as exc:
+            return exc.code if isinstance(exc.code, int) else 0
+
+
+@pytest.fixture
+def conf_yml(tmp_path: Path) -> Path:
+    path = tmp_path / "conf.yml"
+    path.write_text(yaml.safe_dump(PROJECT_CONFIG))
+    return path
+
+
+def _empty_virsh_list() -> MagicMock:
+    r = MagicMock(name="virsh.Result")
+    r.stdout = " Id   Name   State\n------------------\n"
+    r.ok = True
+    return r
+
+
+def _run_ps(conf_yml: Path, app_config: dict) -> dict:
+    """Run ``boxman ps`` with mocked boxman.yml; return the provider_config
+    the VirshCommand was built with."""
+    captured: dict = {}
+    virsh = MagicMock()
+    virsh.execute.return_value = _empty_virsh_list()
+
+    def fake_virsh(provider_config=None, **_kwargs):
+        captured["provider_config"] = provider_config
+        return virsh
+
+    with patch("boxman.manager.BoxmanCache"), \
+         patch("boxman.scripts.app.load_boxman_config",
+               return_value=app_config), \
+         patch("boxman.manager.VirshCommand", side_effect=fake_virsh):
+        code = _run_cli(["--conf", str(conf_yml), "ps"])
+
+    assert code == 0
+    return captured
+
+
+class TestPsHonorsBoxmanYml:
+
+    def test_ps_uses_app_level_uri(self, conf_yml: Path):
+        captured = _run_ps(conf_yml, APP_CONFIG_LOCAL)
+        provider_config = captured["provider_config"]
+        assert provider_config["uri"] == "qemu+ssh://hv.example/system"
+        assert provider_config["use_sudo"] is True
+        assert provider_config["runtime"] == "local"
+
+
+class TestPsDockerComposeRuntime:
+
+    def test_ps_targets_the_runtime_container(self, conf_yml: Path):
+        captured = _run_ps(conf_yml, APP_CONFIG_DC_RUNTIME)
+        provider_config = captured["provider_config"]
+        assert provider_config["runtime"] == "docker-compose"
+        # the container is scoped to the project name from conf.yml
+        assert provider_config["runtime_container"] == "boxman-libvirt-demo"
+        # boxman.yml uri still applies inside the container
+        assert provider_config["uri"] == "qemu+ssh://hv.example/system"


### PR DESCRIPTION
Refs #85 (item 7).

## Problem
`boxman ps` constructed `BoxmanManager(config=args.conf)` without `load_boxman_config`/`load_app_config` and never set `manager.runtime`; `BoxmanManager.ps` then built its `VirshCommand` from only the project provider block. App-level settings (uri, sudo lists) and the docker-compose runtime were silently ignored — ps always probed the local/default libvirt.

## Fix
- The ps handler in app.py now loads boxman.yml, calls `load_app_config`, resolves the runtime (CLI flag over boxman.yml default) and, for the docker-compose runtime, scopes the container to the project (`project_dir`/`project_name`) exactly like the full session path. ps stays a read-only probe: it does not `ensure_ready()` the runtime.
- `BoxmanManager.ps` only queries virsh when the project has libvirt clusters (via item 11's `_has_libvirt_clusters()`) — previously the guard was `if vm_list:`, which also fired for dc-only projects.

## Consolidation
The "resolve provider config for a one-off virsh query" block was copy-pasted 5–6×. It now lives in `BoxmanManager._libvirt_provider_config()` / `_virsh()`, used by `ps`, `_create_templates_impl`, `_find_existing_project_vms`, `_find_all_existing_project_vms`, `_get_vm_states` and the `ensure_templates_exist` virsh fallback.

## Tests
- New `tests/test_ps.py`: ps honors the boxman.yml uri/sudo settings (local runtime); under the docker-compose runtime the probe config carries `runtime` + the project-scoped `runtime_container` (i.e. commands are wrapped with `docker exec` into the right container).
- One item-11 test updated: `_create_templates_impl` no longer lazy-imports VirshCommand, so the patch target moved to `boxman.manager.VirshCommand`.
- Full unit suite: 1829 passed. Ruff: no new violations.