### PR TITLE
fix: runtime injection in snapshot/control verb flows (#85 item 9a)

### DIFF
--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -167,6 +167,21 @@ class BoxmanManager:
             self._sessions = {}
         return self._sessions
 
+    def _update_sessions_with_runtime(self) -> None:
+        """
+        Ensure every registered session's provider config carries the
+        runtime metadata (``runtime``, ``runtime_container``) so provider
+        commands are wrapped for the active runtime.
+
+        Call this at the start of every verb flow that drives provider
+        commands; without it a session built before the runtime was
+        resolved would run virsh on the local host instead of inside the
+        runtime container.
+        """
+        for _session in self._get_sessions().values():
+            if hasattr(_session, 'update_provider_config_with_runtime'):
+                _session.update_provider_config_with_runtime()
+
     def register_session(self, provider_type: str, session: "ProviderSession") -> None:
         """
         Register a live *session* for *provider_type*.
@@ -4270,9 +4285,7 @@ class BoxmanManager:
         # Ensure provider configs reflect runtime settings.
         # Project-level provider settings (from conf.yml) always take
         # precedence over app-level defaults (from boxman.yml).
-        for _session in cls._get_sessions().values():
-            if hasattr(_session, 'update_provider_config_with_runtime'):
-                _session.update_provider_config_with_runtime()
+        cls._update_sessions_with_runtime()
 
         # --- Pre-check: detect state that would block a clean provision ---
         # Block on either (a) live VMs from this project, or (b) a stale
@@ -4542,9 +4555,7 @@ class BoxmanManager:
         )
 
         # Ensure provider configs reflect runtime settings
-        for _session in cls._get_sessions().values():
-            if hasattr(_session, 'update_provider_config_with_runtime'):
-                _session.update_provider_config_with_runtime()
+        cls._update_sessions_with_runtime()
 
         # Shared bridges must exist before VMs attach to them on boot.
         cls.ensure_shared_bridges()
@@ -4650,9 +4661,7 @@ class BoxmanManager:
         ``boxman control save`` / ``boxman control suspend``.
         """
         # Ensure provider configs reflect runtime settings
-        for _session in cls._get_sessions().values():
-            if hasattr(_session, 'update_provider_config_with_runtime'):
-                _session.update_provider_config_with_runtime()
+        cls._update_sessions_with_runtime()
 
         vm_list = cls._control_vm_targets(cls, cli_args)
 
@@ -4702,9 +4711,7 @@ class BoxmanManager:
         # Ensure provider configs reflect runtime settings.
         # Project-level provider settings (from conf.yml) always take
         # precedence over app-level defaults (from boxman.yml).
-        for _session in cls._get_sessions().values():
-            if hasattr(_session, 'update_provider_config_with_runtime'):
-                _session.update_provider_config_with_runtime()
+        cls._update_sessions_with_runtime()
 
         # Tear down the containerlab lab first so its veths release any
         # shared bridges before we touch libvirt state.
@@ -5047,6 +5054,9 @@ class BoxmanManager:
         """
         List snapshots of the VMs and docker-compose clusters in the project.
         """
+        # Ensure provider configs reflect runtime settings
+        cls._update_sessions_with_runtime()
+
         for full_vm_name, cluster_name, _vm_name, _workdir in (
                 cls._select_vm_targets(cls, cli_args)):
             cls.session_for_cluster(cluster_name).snapshot_list(full_vm_name)
@@ -5260,6 +5270,9 @@ class BoxmanManager:
         Honours ``--cluster`` / ``--vms`` so a single cluster (or VM) can be
         snapshotted independently in a multi-cluster project.
         """
+        # Ensure provider configs reflect runtime settings
+        cls._update_sessions_with_runtime()
+
         # docker-compose clusters first (cluster-scoped, D3). Failures are
         # isolated per cluster so a dc cluster that isn't up can't stop the
         # VMs of a mixed project from being snapshotted.
@@ -5347,6 +5360,9 @@ class BoxmanManager:
         already recreated — a partial restore, despite the pre-validation
         contract above.
         """
+        # Ensure provider configs reflect runtime settings
+        cls._update_sessions_with_runtime()
+
         # ── 0. Resolve + validate docker-compose clusters (cluster-scoped,
         #      D3). Nothing is mutated here — the recreate happens in step 3
         #      once the VM snapshots have been validated too.
@@ -5480,6 +5496,9 @@ class BoxmanManager:
         Honours ``--cluster`` / ``--vms`` so a snapshot can be removed from a
         single cluster (or VM) in a multi-cluster project.
         """
+        # Ensure provider configs reflect runtime settings
+        cls._update_sessions_with_runtime()
+
         if not cli_args.snapshot_name:
             cls.logger.error("error: Snapshot name is required")
             return
@@ -5825,6 +5844,9 @@ class BoxmanManager:
         Suspend the machines: libvirt VMs → virsh suspend; docker-compose
         containers → ``docker compose pause``.
         """
+        # Ensure provider configs reflect runtime settings
+        cls._update_sessions_with_runtime()
+
         for vm_name, _ in cls._control_vm_targets(cls, cli_args):
             cls.session_for_vm(vm_name).suspend_vm(vm_name)
             cls.logger.info(f"vm {vm_name} suspended")
@@ -5837,6 +5859,9 @@ class BoxmanManager:
         Resume the machines: libvirt VMs → virsh resume; docker-compose
         containers → ``docker compose unpause``.
         """
+        # Ensure provider configs reflect runtime settings
+        cls._update_sessions_with_runtime()
+
         for vm_name, _ in cls._control_vm_targets(cls, cli_args):
             cls.session_for_vm(vm_name).resume_vm(vm_name)
             cls.logger.info(f"VM {vm_name} resumed")
@@ -5850,6 +5875,9 @@ class BoxmanManager:
         docker-compose containers (no save-to-file state) — an explanatory
         message is logged, no traceback.
         """
+        # Ensure provider configs reflect runtime settings
+        cls._update_sessions_with_runtime()
+
         for vm_name, workdir in cls._control_vm_targets(cls, cli_args):
             cls.session_for_vm(vm_name).save_vm(vm_name, workdir)
         for cluster_name, _cluster in cls._select_dc_clusters(cli_args):
@@ -5865,6 +5893,9 @@ class BoxmanManager:
         Start the machines: libvirt VMs (optionally --restore); docker-compose
         containers → ``docker compose start``.
         """
+        # Ensure provider configs reflect runtime settings
+        cls._update_sessions_with_runtime()
+
         for vm_name, workdir in cls._control_vm_targets(cls, cli_args):
             if cli_args.restore:
                 cls.session_for_vm(vm_name).restore_vm(vm_name, workdir)
@@ -6645,9 +6676,7 @@ class BoxmanManager:
         # Phase 1 (#49): the update/diff flow below stays on the default
         # session — it is deeply libvirt-shaped (VMStateDiffer, virsh
         # edits) and only libvirt clusters can exist until Phase 3 (#51).
-        for _session in cls._get_sessions().values():
-            if hasattr(_session, 'update_provider_config_with_runtime'):
-                _session.update_provider_config_with_runtime()
+        cls._update_sessions_with_runtime()
 
         # --- networks first ---
         # a new VM further down may be wired to a network that does not exist

--- a/tests/test_runtime_injection_flows.py
+++ b/tests/test_runtime_injection_flows.py
@@ -1,0 +1,96 @@
+"""
+Regression tests for runtime injection in snapshot/control verb flows
+(#85 item 9a, manager half).
+
+``update_provider_config_with_runtime()`` was only applied in ~5 of the
+verb flows; snapshot_take/list/restore/delete and the control verbs
+(suspend/resume/save/start) ran their provider commands with a session
+config that never saw the runtime — under the docker-compose runtime
+that meant virsh ran on the local host instead of inside the container.
+
+Every flow now calls ``BoxmanManager._update_sessions_with_runtime()``
+first; these tests drive each verb with all targets mocked out and
+assert the session's provider config picked up the runtime metadata
+(``runtime`` / ``runtime_container`` — the keys LibVirtCommandBase uses
+to wrap commands with ``docker exec``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from boxman.manager import BoxmanManager
+from boxman.providers.libvirt.session import LibVirtSession
+
+pytestmark = pytest.mark.unit
+
+
+def _mgr_with_libvirt_session() -> tuple[BoxmanManager, LibVirtSession]:
+    """A manager with one registered libvirt session, running under the
+    docker-compose runtime, with the session config NOT yet enriched."""
+    with patch("boxman.manager.BoxmanCache"):
+        m = BoxmanManager()
+    m.config = {
+        'project': 'demo',
+        'clusters': {
+            'cluster_1': {'workdir': '/tmp/x', 'vms': {'node01': {}}},
+        },
+    }
+    m.app_config = {'runtime_config': {}}
+    m.runtime = 'docker-compose'
+    m.runtime_instance.project_name = 'demo'
+
+    session = LibVirtSession(
+        config={'provider': {'libvirt': {'uri': 'qemu:///system'}}})
+    session.manager = m
+    m.register_session('libvirt', session)
+    assert 'runtime' not in session.provider_config  # not yet injected
+    return m, session
+
+
+def _cli_args(**overrides) -> MagicMock:
+    args = MagicMock(name="cli_args")
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+#: (verb, extra cli_args) pairs — every flow that gained the injection
+FLOWS = [
+    (BoxmanManager.snapshot_list, {}),
+    (BoxmanManager.snapshot_take, {'snapshot_name': 's1'}),
+    (BoxmanManager.snapshot_restore, {'snapshot_name': 's1'}),
+    (BoxmanManager.snapshot_delete, {'snapshot_name': 's1'}),
+    (BoxmanManager.suspend_vm, {}),
+    (BoxmanManager.resume_vm, {}),
+    (BoxmanManager.save_vm, {}),
+    (BoxmanManager.start_vm, {'restore': False}),
+]
+
+
+class TestRuntimeInjectionInVerbFlows:
+
+    @pytest.mark.parametrize("verb,extra", FLOWS,
+                             ids=[v.__name__ for v, _ in FLOWS])
+    def test_verb_injects_runtime_into_session_config(self, verb, extra):
+        m, session = _mgr_with_libvirt_session()
+
+        with patch.object(BoxmanManager, '_select_vm_targets',
+                          return_value=[]), \
+             patch.object(BoxmanManager, '_select_dc_clusters',
+                          return_value=[]), \
+             patch.object(BoxmanManager, '_for_each_dc_cluster',
+                          return_value=([], [])), \
+             patch.object(BoxmanManager, '_control_vm_targets',
+                          return_value=[]):
+            verb(m, _cli_args(**extra))
+
+        # the keys LibVirtCommandBase uses to wrap commands with
+        # ``docker exec --user root <container> bash -c ...``
+        assert session.provider_config['runtime'] == 'docker-compose'
+        assert session.provider_config['runtime_container'] == \
+            'boxman-libvirt-demo'
+        # the session's own keys survive the injection
+        assert session.provider_config['uri'] == 'qemu:///system'


### PR DESCRIPTION
Refs #85 (item 9, manager half — the commands.py/runtime dedup half is G2b's).

## Problem
`update_provider_config_with_runtime()` was applied in only ~5 of ~10 verb flows (present: provision, up-resume, down, deprovision, update; missing: snapshot_take, snapshot_list, snapshot_restore, snapshot_delete, control suspend/resume/save/start). The missing flows ran provider commands with a session config that never saw the runtime — under the docker-compose runtime virsh executed on the local host instead of inside the libvirt container.

## Fix
- The five copy-pasted injection loops are consolidated into `BoxmanManager._update_sessions_with_runtime()`.
- It is now called at the start of every verb flow that drives provider commands, including all snapshot verbs and the four control verbs.

## Tests
- New `tests/test_runtime_injection_flows.py`: parametrized over all 8 newly-covered flows — after the verb runs (targets mocked out), the session's provider config carries `runtime`/`runtime_container` (the keys `LibVirtCommandBase` uses to docker-exec-wrap commands), and session keys survive the injection.
- Full unit suite: 1844 passed. Ruff: no new violations (manager.py keeps its ~24 pre-existing).