### PR TITLE
fix: absolutize netlab workdir so containerlab startup-config paths resolve (#85 item 20)

### DIFF
--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -584,10 +584,16 @@ class BoxmanManager:
 
         workspace_path = (self.config.get("workspace", {}) or {}).get("path")
         workdir = workspace_path or os.path.dirname(self.config_path or ".") or "."
-        jinja_env = create_jinja_env(os.path.expanduser(workdir))
+        # The workdir must be absolute: containerlab resolves relative
+        # startup-config paths in the topology against the topology file's
+        # own directory, so a relative workdir would emit paths like
+        # ``netlab/configs/x.cfg`` that containerlab then looks up as
+        # ``netlab/netlab/configs/x.cfg``.
+        workdir = os.path.abspath(os.path.expanduser(workdir))
+        jinja_env = create_jinja_env(workdir)
         self._netlab = ContainerlabManager(
             lab_config=lab_config,
-            workdir=os.path.expanduser(workdir),
+            workdir=workdir,
             jinja_env=jinja_env,
         )
         return self._netlab

--- a/tests/test_netlab_manager_integration.py
+++ b/tests/test_netlab_manager_integration.py
@@ -13,9 +13,11 @@ Covers:
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+import yaml
 
 from boxman.manager import BoxmanManager
 
@@ -287,3 +289,68 @@ class TestNetlabStartupConfigSourceRoot:
 
         mgr.ensure_netlab_up()
         self._assert_resolves_to_cwd(captured, tmp_path)
+
+
+class TestNetlabWorkdirAbsolute:
+    """Regression: the netlab workdir must be absolute.
+
+    Containerlab resolves relative ``startup-config`` paths in the
+    topology against the topology file's own directory, so a relative
+    workdir would emit paths like ``netlab/configs/sw1.cfg`` inside
+    ``netlab/<lab>.clab.yml`` — containerlab then looks for
+    ``netlab/netlab/configs/sw1.cfg`` and the deploy fails.
+    """
+
+    def test_workdir_absolute_when_config_path_relative(
+            self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        mgr = _make_manager({
+            "containerlab": {"lab_name": "netlab", "topology": {"nodes": {}}},
+        })
+        mgr.config_path = "conf.yml"  # bare relative default, no workspace.path
+
+        netlab = mgr.netlab
+        assert netlab is not None
+        assert netlab.workdir.is_absolute()
+        assert netlab.workdir == tmp_path
+
+    def test_workdir_absolute_when_workspace_path_relative(
+            self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        mgr = _make_manager({
+            "workspace": {"path": "ws"},
+            "containerlab": {"lab_name": "netlab", "topology": {"nodes": {}}},
+        })
+
+        netlab = mgr.netlab
+        assert netlab is not None
+        assert netlab.workdir.is_absolute()
+        assert netlab.workdir == tmp_path / "ws"
+
+    def test_rendered_topology_startup_config_paths_absolute(
+            self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "configs").mkdir()
+        (tmp_path / "configs" / "sw1.cfg.j2").write_text("hostname sw1\n")
+        mgr = _make_manager({
+            "containerlab": {
+                "lab_name": "netlab",
+                "topology": {
+                    "nodes": {
+                        "sw1": {
+                            "kind": "arista_ceos",
+                            "startup-config": "configs/sw1.cfg.j2",
+                        },
+                    },
+                },
+            },
+        })
+        mgr.config_path = "conf.yml"
+
+        topology_path = mgr.netlab.render_topology()
+
+        rendered = yaml.safe_load(topology_path.read_text())
+        startup = rendered["topology"]["nodes"]["sw1"]["startup-config"]
+        assert os.path.isabs(startup), (
+            f"startup-config path must be absolute, got {startup!r}")
+        assert Path(startup).exists()


### PR DESCRIPTION
Refs #85 (item 20).

**Problem:** `BoxmanManager.netlab` (manager.py) passed the workdir through `expanduser` only. A project without `workspace.path` (or a relative `--conf`) yielded a relative workdir; `ContainerlabManager._render_startup_config` then embedded a RELATIVE path like `netlab/configs/sw1.cfg` in the topology written at `netlab/<lab>.clab.yml`. Containerlab resolves relative node paths against the topology file's directory → it looked for `netlab/netlab/configs/sw1.cfg` and the deploy failed.

**Fix:** absolutize the workdir with `os.path.abspath(os.path.expanduser(workdir))` in the manager property so every emitted path is absolute.

**Note (out of file set):** an alternative/additional hardening would be `Path(workdir).resolve()` in `ContainerlabManager.__init__` (src/boxman/netlab/containerlab.py) so direct users of the class get the same guarantee; that file is outside this group's file set, so the manager-side fix was applied here.

**Tests:** new `TestNetlabWorkdirAbsolute` in tests/test_netlab_manager_integration.py — relative `--conf` and relative `workspace.path` both yield absolute workdirs, and the rendered topology's startup-config path is absolute and exists. Targeted netlab tests pass; full unit suite 1847 passed.