### PR TITLE
fix: make projects cache atomic, corruption-tolerant, and consistent (#85 item 24)

### DIFF
--- a/src/boxman/config_cache.py
+++ b/src/boxman/config_cache.py
@@ -1,5 +1,6 @@
 import json
 import os
+import tempfile
 
 from boxman import log
 
@@ -40,6 +41,47 @@ class BoxmanCache:
             os.makedirs(self.cache_dir, exist_ok=True)
             log.info(f"cache directory created at: {self.cache_dir}")
 
+    def _load_projects_cache(self) -> dict:
+        """
+        Read the projects cache file, tolerating a missing or corrupt file.
+
+        A corrupt cache (e.g. truncated by a crashed writer) is moved aside
+        and treated as empty instead of raising ``JSONDecodeError`` through
+        every boxman command.
+        """
+        try:
+            with open(self.projects_cache_file) as fobj:
+                return json.load(fobj)
+        except FileNotFoundError:
+            return {}
+        except json.JSONDecodeError:
+            backup = self.projects_cache_file + '.corrupt'
+            os.replace(self.projects_cache_file, backup)
+            log.warning(
+                f"projects cache at {self.projects_cache_file} is corrupt; "
+                f"moved aside to {backup} and treated as empty")
+            return {}
+
+    def _write_projects_cache_file(self) -> None:
+        """
+        Write the projects cache atomically.
+
+        Dumps to a temporary file in the same directory and ``os.replace``es
+        it into place, so a crashed or concurrent writer can never leave a
+        truncated projects.json behind.
+        """
+        fd, tmp_file = tempfile.mkstemp(
+            dir=self.cache_dir, prefix='.projects.json.', suffix='.tmp')
+        try:
+            with os.fdopen(fd, 'w') as fobj:
+                json.dump(self.projects, fobj, indent=4)
+            os.replace(tmp_file, self.projects_cache_file)
+        except BaseException:
+            # don't leave the staged file behind when the dump failed
+            if os.path.exists(tmp_file):
+                os.remove(tmp_file)
+            raise
+
     def read_projects_cache(self) -> dict:
         """
         Read the cache and return its contents.
@@ -48,8 +90,7 @@ class BoxmanCache:
             log.warning(f"no projects cache file found at {self.projects_cache_file}")
             return {}
 
-        with open(self.projects_cache_file) as fobj:
-            self.projects = json.load(fobj)
+        self.projects = self._load_projects_cache()
 
         return self.projects
 
@@ -61,9 +102,8 @@ class BoxmanCache:
             log.warning("no projects to write to cache")
             return
 
-        with open(self.projects_cache_file, 'w') as fobj:
-            json.dump(self.projects, fobj, indent=4)
-            log.info(f"projects cache written to {self.projects_cache_file}")
+        self._write_projects_cache_file()
+        log.info(f"projects cache written to {self.projects_cache_file}")
 
 
     def register_project(self,
@@ -79,14 +119,12 @@ class BoxmanCache:
             project_name: Name of the project
             config_fpath: Path to the project configuration file
             runtime: The runtime environment name (e.g. 'local', 'docker-compose')
+
+        Returns:
+            True if the project was registered, False if it was already
+            in the cache.
         """
-        # Single-pass: try to read the cache; treat missing file as empty.
-        # Avoids a separate os.path.exists stat call before the read.
-        try:
-            with open(self.projects_cache_file) as fobj:
-                self.projects = json.load(fobj)
-        except FileNotFoundError:
-            self.projects = {}
+        self.projects = self._load_projects_cache()
 
         # if the project already exists, log an error and return
         if project_name in self.projects:
@@ -99,10 +137,10 @@ class BoxmanCache:
             'runtime': runtime,
         }
 
-        with open(self.projects_cache_file, 'w') as fobj:
-            json.dump(self.projects, fobj, indent=4)
+        self._write_projects_cache_file()
 
         log.info(f"project '{project_name}' registered in cache with path: {config_fpath}, runtime: {runtime}")
+        return True
 
     def unregister_project(self, project_name: str) -> bool:
         """
@@ -124,10 +162,37 @@ class BoxmanCache:
 
         # remove the project and update the file
         removed_path = self.projects.pop(project_name)
-        with open(self.projects_cache_file, 'w') as fobj:
-            json.dump(self.projects, fobj, indent=4)
+        self._write_projects_cache_file()
 
         log.info(f"project '{project_name}' unregistered from cache (was at: {removed_path})")
+        return True
+
+    def unregister_network(self, project_name: str, network_name: str) -> bool:
+        """
+        Remove a network's entry from its project's cache record.
+
+        Networks are added to the cache when defined; removing the libvirt
+        network without dropping its entry would leave a stale record that
+        ``check_network_exists()`` counts as a conflict with any later
+        network of the same name.
+
+        Args:
+            project_name: Name of the project that owns the network
+            network_name: Full name of the network to forget
+
+        Returns:
+            True if an entry was removed, False when the project or the
+            network was not in the cache.
+        """
+        self.projects = self._load_projects_cache()
+        project = (self.projects or {}).get(project_name)
+        if not project or network_name not in project.get('networks', {}):
+            return False
+
+        del project['networks'][network_name]
+        self._write_projects_cache_file()
+
+        log.info(f"network '{network_name}' removed from the projects cache")
         return True
 
     def list_projects(self) -> dict:

--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -3002,17 +3002,11 @@ class BoxmanManager:
         Needed before redefining it: ``check_network_exists()`` walks every
         cached project *including this one*, so a network's own leftover entry
         counts as a conflict with itself -- same name, same address -- and the
-        redefine raises instead of running. ``remove_network()`` only touches
-        libvirt and iptables, never the cache.
+        redefine raises instead of running.
         """
         try:
-            self.cache.read_projects_cache()
-            project = (self.cache.projects or {}).get(self.config['project'])
-            if not project or full_name not in project.get('networks', {}):
-                return
-            del project['networks'][full_name]
-            self.cache.write_projects_cache()
-            self.logger.debug(f"removed {full_name} from the projects cache")
+            if self.cache.unregister_network(self.config['project'], full_name):
+                self.logger.debug(f"removed {full_name} from the projects cache")
         except (KeyError, OSError, ValueError) as exc:
             # not fatal on its own, but the redefine that follows will fail on
             # the stale entry, so say why
@@ -3159,9 +3153,13 @@ class BoxmanManager:
 
         return 'recreated'
 
-    def destroy_networks(self) -> None:
+    def destroy_networks(self) -> dict:
         """
         Destroy the networks specified in the cluster configuration (parallel).
+
+        Returns:
+            The ``failures`` dict from :meth:`_run_parallel`, empty when
+            every network was removed.
         """
         def _destroy(cluster_name, cluster, network_name, network_info):
             _network_name = self.full_network_name(
@@ -3186,7 +3184,9 @@ class BoxmanManager:
             for cluster_name, cluster in self._vm_clusters.items()
             for network_name, network_info in (cluster.get('networks') or {}).items()
         ]
-        self._run_parallel(processes, op_label='destroy network')
+        _results, failures = self._run_parallel(
+            processes, op_label='destroy network')
+        return failures
     ### end networks define / remove / destroy
 
     ### vms define / remove / destroy
@@ -4740,14 +4740,24 @@ class BoxmanManager:
             for cluster_name, cluster in cls._vm_clusters.items()
             for vm_name, vm_info in cluster['vms'].items()
         ]
-        cls._run_parallel(processes, op_label='deprovision vm')
+        _results, vm_failures = cls._run_parallel(
+            processes, op_label='deprovision vm')
 
-        cls.destroy_networks()
+        net_failures = cls.destroy_networks()
 
         if getattr(cli_args, 'cleanup', False):
             cls.deprovision_files()
 
-        cls.unregister_from_cache()
+        if vm_failures or net_failures:
+            # Resources survived the teardown: keep the project registered
+            # so it stays visible to `boxman list` and a later deprovision
+            # can finish the job instead of the leftovers becoming
+            # cache-invisible.
+            cls.logger.warning(
+                "deprovision left resources behind; keeping project "
+                f"'{cls.config['project']}' registered in the cache")
+        else:
+            cls.unregister_from_cache()
 
         return
 

--- a/tests/test_config_cache.py
+++ b/tests/test_config_cache.py
@@ -164,3 +164,121 @@ class TestWriteProjectsCache:
         cache.write_projects_cache()
         on_disk = json.loads(Path(cache.projects_cache_file).read_text())
         assert on_disk == cache.projects
+
+
+class TestCorruptCache:
+    """Regression: a corrupt projects.json (e.g. truncated by a crashed
+    writer) must not raise JSONDecodeError through every boxman command —
+    it is moved aside and treated as empty."""
+
+    def test_read_treats_corrupt_as_empty_and_backs_up(self, cache: BoxmanCache):
+        Path(cache.projects_cache_file).write_text("{not json")
+        assert cache.read_projects_cache() == {}
+        backup = Path(cache.projects_cache_file + ".corrupt")
+        assert backup.read_text() == "{not json"
+        assert not Path(cache.projects_cache_file).exists()
+
+    def test_register_project_survives_corrupt_cache(
+            self, cache: BoxmanCache, tmp_path: Path):
+        Path(cache.projects_cache_file).write_text("garbage")
+        conf = tmp_path / "p.yml"
+        conf.write_text("x")
+        assert cache.register_project("p", str(conf)) is True
+        on_disk = json.loads(Path(cache.projects_cache_file).read_text())
+        assert "p" in on_disk
+
+    def test_list_projects_survives_corrupt_cache(self, cache: BoxmanCache):
+        Path(cache.projects_cache_file).write_text("]")
+        assert cache.list_projects() == {}
+
+
+class TestAtomicWrite:
+    """Regression: cache writes must go through tmp-file + os.replace so a
+    crashed or concurrent writer can never truncate projects.json."""
+
+    def test_failed_dump_leaves_existing_file_intact(
+            self, cache: BoxmanCache, monkeypatch):
+        original = {"p": {"conf": "/tmp/p.yml", "runtime": "local"}}
+        Path(cache.projects_cache_file).write_text(json.dumps(original))
+        cache.projects = {"q": {}}
+
+        def _crash(*_a, **_k):
+            raise RuntimeError("crash mid-write")
+
+        monkeypatch.setattr(json, "dump", _crash)
+        with pytest.raises(RuntimeError, match="crash mid-write"):
+            cache.write_projects_cache()
+        assert json.loads(Path(cache.projects_cache_file).read_text()) == original
+
+    def test_no_tmp_files_left_behind(self, cache: BoxmanCache):
+        cache.projects = {"x": {}}
+        cache.write_projects_cache()
+        leftovers = [p.name for p in Path(cache.cache_dir).iterdir()]
+        assert leftovers == ["projects.json"]
+
+    def test_concurrent_writers_keep_file_valid(
+            self, cache: BoxmanCache, tmp_path: Path):
+        import threading
+        conf = tmp_path / "c.yml"
+        conf.write_text("x")
+        errors = []
+
+        def worker(i):
+            try:
+                for n in range(25):
+                    name = f"p{i}-{n}"
+                    cache.register_project(name, str(conf))
+                    cache.unregister_project(name)
+            except Exception as exc:  # pragma: no cover - failure path
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        # whatever the interleaving, the file must still be valid JSON
+        json.loads(Path(cache.projects_cache_file).read_text())
+
+
+class TestRegisterProjectReturn:
+
+    def test_returns_true_on_success(self, cache: BoxmanCache, tmp_path: Path):
+        conf = tmp_path / "p.yml"
+        conf.write_text("x")
+        assert cache.register_project("p", str(conf)) is True
+
+
+class TestUnregisterNetwork:
+
+    def _seed(self, cache: BoxmanCache, tmp_path: Path):
+        conf = tmp_path / "p.yml"
+        conf.write_text("x")
+        cache.register_project("proj", str(conf))
+        cache.projects["proj"]["networks"] = {
+            "net_a": {"ip_address": "10.0.0.1"},
+            "net_b": {"ip_address": "10.0.1.1"},
+        }
+        cache.write_projects_cache()
+
+    def test_removes_entry_and_keeps_others(
+            self, cache: BoxmanCache, tmp_path: Path):
+        self._seed(cache, tmp_path)
+        assert cache.unregister_network("proj", "net_a") is True
+        on_disk = json.loads(Path(cache.projects_cache_file).read_text())
+        assert on_disk["proj"]["networks"] == {
+            "net_b": {"ip_address": "10.0.1.1"}}
+        # the rest of the project record is untouched
+        assert on_disk["proj"]["runtime"] == "local"
+
+    def test_false_when_network_not_cached(
+            self, cache: BoxmanCache, tmp_path: Path):
+        self._seed(cache, tmp_path)
+        before = Path(cache.projects_cache_file).read_text()
+        assert cache.unregister_network("proj", "net_x") is False
+        assert Path(cache.projects_cache_file).read_text() == before
+
+    def test_false_when_project_not_cached(self, cache: BoxmanCache):
+        assert cache.unregister_network("nope", "net_a") is False

--- a/tests/test_deprovision_unregister.py
+++ b/tests/test_deprovision_unregister.py
@@ -1,0 +1,94 @@
+"""
+Regression tests for #85 item 24 (b+c): cache/network divergence.
+
+- ``deprovision`` must keep the project registered in the cache when the
+  VM or network teardown left resources behind, so the leftovers stay
+  visible to ``boxman list`` and a later deprovision can finish the job.
+- ``_forget_cached_network`` drops the network entry through the normal
+  ``BoxmanCache.unregister_network`` path.
+"""
+
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from boxman.manager import BoxmanManager
+
+pytestmark = pytest.mark.unit
+
+
+def _manager():
+    mgr = BoxmanManager.__new__(BoxmanManager)
+    mgr.config = {
+        "project": "demo",
+        "clusters": {
+            "cluster_1": {
+                "workdir": "/tmp/ws/c1",
+                "vms": {"service01": {}},
+            },
+        },
+    }
+    mgr.logger = MagicMock()
+    mgr.cache = MagicMock()
+    mgr.unregister_from_cache = MagicMock()
+    mgr._update_sessions_with_runtime = MagicMock()
+    mgr.destroy_netlab = MagicMock()
+    mgr.deprovision_compose_clusters = MagicMock()
+    return mgr
+
+
+class TestDeprovisionUnregister:
+
+    def _run(self, mgr, vm_failures, net_failures):
+        mgr._run_parallel = MagicMock(return_value=({}, vm_failures))
+        mgr.destroy_networks = MagicMock(return_value=net_failures)
+        BoxmanManager.deprovision(mgr, types.SimpleNamespace(cleanup=False))
+
+    def test_unregisters_when_teardown_succeeds(self):
+        mgr = _manager()
+        self._run(mgr, vm_failures={}, net_failures={})
+        mgr.unregister_from_cache.assert_called_once()
+
+    def test_skips_unregister_when_vm_teardown_failed(self):
+        mgr = _manager()
+        self._run(mgr, vm_failures={"cluster_1/service01": "boom"},
+                  net_failures={})
+        mgr.unregister_from_cache.assert_not_called()
+        mgr.logger.warning.assert_called()
+
+    def test_skips_unregister_when_network_teardown_failed(self):
+        mgr = _manager()
+        self._run(mgr, vm_failures={}, net_failures={"cluster_1/net": "boom"})
+        mgr.unregister_from_cache.assert_not_called()
+        mgr.logger.warning.assert_called()
+
+
+class TestForgetCachedNetwork:
+
+    def test_delegates_to_cache_unregister_network(self):
+        mgr = _manager()
+        mgr.cache.unregister_network.return_value = True
+        mgr._forget_cached_network("bprj__demo__bprj_cluster_1_net")
+        mgr.cache.unregister_network.assert_called_once_with(
+            "demo", "bprj__demo__bprj_cluster_1_net")
+
+    def test_swallows_cache_errors_with_warning(self):
+        mgr = _manager()
+        mgr.cache.unregister_network.side_effect = OSError("disk gone")
+        mgr._forget_cached_network("net")  # must not raise
+        mgr.logger.warning.assert_called_once()
+
+
+class TestDestroyNetworksFailures:
+
+    def test_returns_run_parallel_failures(self):
+        mgr = _manager()
+        mgr.config["clusters"]["cluster_1"]["networks"] = {"net": {}}
+        mgr._run_parallel = MagicMock(return_value=({}, {"cluster_1/net": "x"}))
+        assert mgr.destroy_networks() == {"cluster_1/net": "x"}
+
+    def test_returns_empty_dict_on_success(self):
+        mgr = _manager()
+        mgr._run_parallel = MagicMock(return_value=({}, {}))
+        assert mgr.destroy_networks() == {}

--- a/tests/test_net_reconcile.py
+++ b/tests/test_net_reconcile.py
@@ -406,8 +406,13 @@ class TestRecreateSequence:
 
         mgr.cache = MagicMock()
         mgr.cache.projects = {'p1': {'networks': {'full-net': {'ip_address': '10.5.3.1'}}}}
-        mgr.cache.read_projects_cache.side_effect = lambda: calls.append('cache-read')
-        mgr.cache.write_projects_cache.side_effect = lambda: calls.append('cache-write')
+
+        def _unregister_network(project, name):
+            calls.append('cache-write')
+            mgr.cache.projects[project]['networks'].pop(name, None)
+            return True
+
+        mgr.cache.unregister_network.side_effect = _unregister_network
 
         provider = MagicMock()
         provider.remove_network.side_effect = lambda **kw: (


### PR DESCRIPTION
Refs #85 (item 24).

**(a) config_cache.py atomicity + robustness**
- `write_projects_cache`/`register_project`/`unregister_project` did read-modify-write with plain `json.dump` — two concurrent boxman runs could lose updates or truncate the file. All writes now go through a shared `_write_projects_cache_file()`: dump to a unique tmp file in the same dir, then `os.replace` (tmp file cleaned up if the dump fails).
- A corrupt `projects.json` made `json.load` raise `JSONDecodeError` through every command. New `_load_projects_cache()` moves the corrupt file aside to `projects.json.corrupt`, warns, and treats it as empty.
- `register_project` was annotated `-> bool` but returned `None` on success; now returns `True`.

**(b) network cache divergence** — `remove_network` never updates the cache, which forced `_forget_cached_network` to open-code read-modify-write in the manager. New `BoxmanCache.unregister_network(project_name, network_name)` is the normal path; `_forget_cached_network` now delegates to it.

**(c) deprovision unregistered unconditionally** (manager.py) — item 4 already made teardown failures visible via `_run_parallel`; now `deprovision` captures the VM-teardown failures and the new `destroy_networks()` failures return value, and skips `unregister_from_cache()` (with a warning) when anything survived, so leftovers don't become cache-invisible.

**Tests** (all unit):
- tests/test_config_cache.py: corrupt-cache fallback for read/register/list; failed dump leaves existing file intact; no tmp leftovers; 4-thread concurrent register/unregister keeps the file valid JSON; register returns True; `unregister_network` behavior.
- tests/test_deprovision_unregister.py (new): deprovision unregisters on success, skips on VM or network teardown failure; `_forget_cached_network` delegation + error swallowing; `destroy_networks` failure passthrough.
- tests/test_net_reconcile.py: stub wiring updated for the new delegation (assertions unchanged).

Full unit suite: 1864 passed. Ruff: no new violations (manager.py 24 pre-existing both before/after; config_cache.py clean).