### PR TITLE
fix: ensure shared bridges exist before dc snapshot restore (#85 item 27)

### DIFF
--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -410,6 +410,12 @@ class BoxmanManager:
         """Run the validated docker-compose restores, isolating per-cluster
         failures so one bad cluster can't strand the rest. Returns the names
         of the clusters that failed."""
+        if not dc_plan:
+            return []
+        # The macvlan parent bridges must exist before compose recreates the
+        # containers — after a host reboot they are gone and the recreate
+        # would fail with a cryptic "parent interface does not exist".
+        self.ensure_shared_bridges()
         failed = []
         for cname, cluster, snap in dc_plan:
             try:

--- a/tests/test_docker_compose_provider.py
+++ b/tests/test_docker_compose_provider.py
@@ -1352,6 +1352,29 @@ class TestSnapshotDcWiring:
         sess.snapshot_restore_cluster.assert_called_once_with(
             "services", m.config["clusters"]["services"], "new")
 
+    def test_restore_plan_ensures_shared_bridges_before_compose_up(self):
+        """Regression (#85 item 27): after a host reboot the macvlan parent
+        bridges are gone; the dc restore plan must recreate them before the
+        compose recreate, or it fails with a cryptic "parent interface does
+        not exist"."""
+        m = self._mgr()
+        sess = self._restore_session(latest="new")
+        m.session_for_cluster = lambda c: sess
+        order = []
+        m.ensure_shared_bridges = lambda: order.append("bridges")
+        sess.snapshot_restore_cluster.side_effect = (
+            lambda *a: order.append("restore"))
+        args = SimpleNamespace(snapshot_name=None, cluster=None, vms="all")
+        with mock.patch.object(BoxmanManager, "_select_vm_targets", staticmethod(lambda cls, a: [])):
+            BoxmanManager.snapshot_restore(m, args)
+        assert order == ["bridges", "restore"]
+
+    def test_restore_dc_plan_empty_skips_bridges(self):
+        m = self._mgr()
+        m.ensure_shared_bridges = mock.Mock()
+        assert m._restore_dc_plan([]) == []
+        m.ensure_shared_bridges.assert_not_called()
+
     def test_restore_validates_before_mutating(self):
         """An invalid container snapshot must abort *before* the destructive
         up --force-recreate (mher: partial-restore ordering)."""


### PR DESCRIPTION
Refs #85 (item 27).

**Problem:** every bring-up path calls `ensure_shared_bridges()` (manager.py:4366, 4534, 4567, 6701) except the docker-compose snapshot restore plan (`_restore_dc_plan`). After a host reboot the macvlan parent bridge is gone and dc snapshot restore fails with a cryptic compose "parent interface does not exist".

**Fix:** `_restore_dc_plan` now calls `ensure_shared_bridges()` before the first compose recreate (skipped for an empty plan). The helper is idempotent and a no-op without `shared_networks:`, so non-macvlan projects are unaffected.

**Tests:** new in `TestSnapshotDcWiring` (tests/test_docker_compose_provider.py) — full `snapshot_restore` flow records bridges-before-restore ordering; empty plan skips the call. Full unit suite: 1866 passed. Ruff: no new violations.