### PR TITLE
fix: translate virtualbox stub NotImplementedError into exit 2 (#85 item 28)

### DIFF
--- a/src/boxman/scripts/app.py
+++ b/src/boxman/scripts/app.py
@@ -318,6 +318,11 @@ def main():
     (:class:`~boxman.exceptions.ProvisionError`) or a missing docker/compose
     plugin (:class:`~boxman.exceptions.RuntimeUnavailable`). All other flow
     (including the ``sys.exit()`` calls throughout) lives in :func:`_main`.
+
+    Also translates the virtualbox provider's ``NotImplementedError`` stubs
+    into a clean exit 2: the provider is registered but Phase 1 (config
+    surface only, non-functional), so without this every operation would die
+    with a raw traceback mid-flow.
     """
     try:
         _main()
@@ -328,6 +333,18 @@ def main():
         # it is not swallowed (exit 2 with empty output).
         logging.getLogger('boxman').setLevel(logging.ERROR)
         log.error(str(exc))
+        sys.exit(2)
+    except NotImplementedError as exc:
+        if not str(exc).startswith("VirtualBox provider:"):
+            raise
+        # The virtualbox provider is registered but Phase 1 (config surface
+        # only, non-functional): every operation stub raises
+        # NotImplementedError. Translate it into a clear message instead of
+        # a raw traceback mid-flow.
+        logging.getLogger('boxman').setLevel(logging.ERROR)
+        log.error(
+            f"{exc} — the virtualbox provider is Phase 1 "
+            "(config surface only, non-functional)")
         sys.exit(2)
 
 

--- a/tests/test_virtualbox_provider.py
+++ b/tests/test_virtualbox_provider.py
@@ -267,6 +267,36 @@ class TestStubbedOperations:
             _ = self._session().storage
 
 
+# --- CLI dispatch -------------------------------------------------------------
+
+class TestCliDispatch:
+    """#85 item 28: a virtualbox stub dying mid-flow must surface as a clean
+    exit 2 with a Phase 1 message, not a raw traceback."""
+
+    def test_virtualbox_stub_exits_2_with_message(self):
+        from boxman.scripts import app
+        with patch("boxman.scripts.app._main",
+                   side_effect=NotImplementedError(
+                       "VirtualBox provider: start_vm lands in Phase 2")), \
+                patch("boxman.scripts.app.log") as mock_log:
+            with pytest.raises(SystemExit) as exc:
+                app.main()
+        assert exc.value.code == 2
+        msg = mock_log.error.call_args.args[0]
+        assert "start_vm lands in Phase 2" in msg
+        assert "Phase 1" in msg
+        assert "non-functional" in msg
+
+    def test_unrelated_not_implemented_still_raises(self):
+        """Only the virtualbox stubs are translated; an unrelated
+        NotImplementedError keeps its traceback."""
+        from boxman.scripts import app
+        with patch("boxman.scripts.app._main",
+                   side_effect=NotImplementedError("something else broke")):
+            with pytest.raises(NotImplementedError, match="something else"):
+                app.main()
+
+
 # --- salvaged command builders ----------------------------------------------
 
 class TestCommandBuilders:


### PR DESCRIPTION
Refs #85 (item 28).

**Problem:** the virtualbox provider is registered (providers/__init__.py) but every one of its ~40 operation stubs raises `NotImplementedError("VirtualBox provider: <method> lands in Phase N")`. `main()` only translated `BoxmanError`, so any operation on a virtualbox project died with a raw traceback mid-flow.

**Fix (less invasive option — provider stays registered):** `main()` in app.py now also catches `NotImplementedError`; when the message carries the `VirtualBox provider:` stub prefix it exits 2 with a clear "the virtualbox provider is Phase 1 (config surface only, non-functional)" message that includes the original stub text. Unrelated `NotImplementedError`s still propagate with their traceback.

**Tests:** new `TestCliDispatch` in tests/test_virtualbox_provider.py — virtualbox stub → SystemExit code 2 with the Phase 1 message (no traceback); unrelated `NotImplementedError` re-raised. Full unit suite: 1868 passed. Ruff: no new violations (5 pre-existing both before/after).