### PR TITLE
Remove broken export/import subcommands (#85 item 36)

### DIFF
--- a/src/boxman/scripts/app.py
+++ b/src/boxman/scripts/app.py
@@ -178,51 +178,6 @@ def machine_start(session, cli_args):
     [p.join() for p in processes]
 
 
-def export_config(session: Session, cli_args):
-    """
-    Take the vms
-
-    :param session: The instance of a session
-    :param cli_args: The parsed arguments from the cli
-
-    .. todo:: add option to specify exporting a certain snapshot
-    """
-    vms = parse_vms_list(session, cli_args)
-    assert cli_args.path
-    os.makedirs(cli_args.path, exist_ok=False)
-    def _export_vm(vm, dirpath):
-        session.savestate(vm)
-        session.export_vm(
-            vm,
-            path=os.path.expanduser(os.path.join(dirpath, f'{vm}.ovf'))
-        )
-        session.startvm(vm)
-    processes = [Process(target=_export_vm, args=(vm, cli_args.path)) for vm in vms]
-    [p.start() for p in processes]
-    [p.join() for p in processes]
-    #_ = [_export_vm(vm, cli_args.export_path) for vm in vms]
-
-
-def import_config(session: Session, cli_args):
-    """
-    Take a snapshot of the vms
-
-    :param session: The instance of a session
-    :param cli_args: The parsed arguments from the cli
-    # .. todo:: add option to start/resume the vms once imported
-    """
-    raise NotImplementedError('importing is not implemented yet')
-    #vms = parse_vms_list(session, cli_args)
-    #def _take(vm):
-    #    session.snapshot.take(
-    #        vm,
-    #        snap_name=cli_args.snapshot_name,
-    #        live=cli_args.live)
-    #processes = [Process(target=_take, args=(vm,)) for vm in vms]
-    #[p.start() for p in processes]
-    #[p.join() for p in processes]
-    ##_ = [_take(vm) for vm in vms]
-
 def _default_boxman_config() -> dict:
     """
     Return the default boxman application configuration.

--- a/src/boxman/scripts/cli_parser.py
+++ b/src/boxman/scripts/cli_parser.py
@@ -6,11 +6,6 @@ Extracted from ``scripts/app.py`` in Phase 2.5 of the review plan
 from the orchestration in ``main()``. The public surface is just
 :func:`parse_args`, which returns the top-level
 :class:`argparse.ArgumentParser` ready for ``.parse_known_args()``.
-
-Two local helpers (``export_config`` / ``import_config``) are still
-imported lazily inside :func:`parse_args` to avoid a circular import
-— they'll migrate here once the remaining app.py split lands in a
-follow-up pass.
 """
 
 from __future__ import annotations
@@ -34,10 +29,6 @@ SUPPORTED_PROVIDERS = ['libvirt', 'virtualbox']
 
 
 def parse_args():
-    # Lazy-imported here (not at module scope) to avoid a circular import
-    # with boxman.scripts.app, which imports parse_args from this module.
-    from boxman.scripts.app import export_config, import_config  # noqa: F401
-
     parser = argparse.ArgumentParser(
         description=(
             f"Boxman version {boxman.metadata.version}\n"
@@ -983,45 +974,6 @@ def parse_args():
         default=False,
         help='restore the saved state of the vm before starting',
         dest='restore'
-    )
-
-    #
-    # sub parser for the 'export' subcommand
-    #
-    parser_export = subparsers.add_parser('export', parents=[common], help='export the vms')
-    parser_export.set_defaults(func=export_config)
-    parser_export.add_argument(
-        '--vms',
-        type=str,
-        help='the names of the vms as a csv list',
-        dest='vms',
-        default='all'
-    )
-    parser_export.add_argument(
-        '--path',
-        type=str,
-        help='the names of the vms as a csv list',
-        dest='path',
-        default=None
-    )
-
-    #
-    # sub parser for the 'import' subcommand
-    #
-    parser_import_image = subparsers.add_parser('import', parents=[common], help='import the vms')
-    parser_import_image.set_defaults(func=import_config)
-    parser_import_image.add_argument(
-        '--vms',
-        type=str,
-        help='the names of the vms as a csv list',
-        dest='vms',
-        default='all'
-    )
-    parser_import_image.add_argument(
-        '--path',
-        type=str,
-        help='the names of the vms as a csv list',
-        dest='path',
     )
 
     #


### PR DESCRIPTION
Refs #85 — item 36.

The `export` and `import` CLI subcommands were written for the removed VirtualBox-era Session API:
- `export_config()` reads `session.conf` and calls `session.savestate()` / `session.export_vm()` / `session.startvm()` — none of which exist on the current provider sessions, so invoking the subcommand tracebacks.
- `import_config()` is a bare `NotImplementedError`.

Changes:
- Removed both subparser blocks from `scripts/cli_parser.py` and both functions from `scripts/app.py`.
- Removed the lazy `from boxman.scripts.app import export_config, import_config` inside `parse_args()`, which existed solely as a circular-import workaround for these bindings.
- The `parser_import_image` variable shadowing (`import` subparser reusing the `import-image` variable name) disappears with the deletion; `import-image` is unaffected.

Verified before deleting: `grep -rn 'export_config\|import_config' src/ tests/` — only hits were the definitions and the parser bindings themselves. No tests reference either subcommand.

Tests: `pytest tests` — 1868 passed, 141 deselected. Ruff on changed files: only pre-existing violations (identical on origin/polish), nothing new.