### PR TITLE
Strip private plan-path references from src docstrings (#85 item 41, src part)

### DIFF
--- a/src/boxman/exceptions.py
+++ b/src/boxman/exceptions.py
@@ -4,7 +4,7 @@ Exception hierarchy for boxman.
 A small, purpose-built hierarchy that lets callers distinguish between
 config errors, provisioning failures, and transient runtime issues
 without matching on exception messages. Added in Phase 2.2 of the
-review plan (see /home/mher/.claude/plans/).
+engineering review plan.
 
 Callers should prefer these over bare ``Exception`` so failure classes
 can be handled differently (e.g. retry transient runtime failures but

--- a/src/boxman/providers/libvirt/cloudinit_presets.py
+++ b/src/boxman/providers/libvirt/cloudinit_presets.py
@@ -1,8 +1,8 @@
 """
 Preset cloud-init user-data, meta-data, and network-config templates.
 
-Extracted from ``cloudinit.py`` in Phase 2.7 of the review plan
-(see /home/mher/.claude/plans/) so the bulk of the orchestration class
+Extracted from ``cloudinit.py`` in Phase 2.7 of the engineering
+review plan so the bulk of the orchestration class
 stays smaller and these presets can be imported directly (e.g. by tests)
 without pulling in the whole ``CloudInitTemplate`` class.
 

--- a/src/boxman/providers/libvirt/disk_cleanup.py
+++ b/src/boxman/providers/libvirt/disk_cleanup.py
@@ -2,7 +2,7 @@
 Filesystem-only helpers for removing a VM's disks and leftover artifacts.
 
 Extracted from :meth:`LibVirtSession.destroy_disks` in Phase 2.6 of the
-review plan (see /home/mher/.claude/plans/) so that the pure filesystem
+engineering review plan so that the pure filesystem
 logic lives outside the libvirt session class — both for clarity and so
 it can be exercised without constructing a session.
 

--- a/src/boxman/scripts/cli_parser.py
+++ b/src/boxman/scripts/cli_parser.py
@@ -1,8 +1,8 @@
 """
 Argparse parser construction for the boxman CLI.
 
-Extracted from ``scripts/app.py`` in Phase 2.5 of the review plan
-(see /home/mher/.claude/plans/) to keep the argparse wiring separate
+Extracted from ``scripts/app.py`` in Phase 2.5 of the engineering
+review plan to keep the argparse wiring separate
 from the orchestration in ``main()``. The public surface is just
 :func:`parse_args`, which returns the top-level
 :class:`argparse.ArgumentParser` ready for ``.parse_known_args()``.

--- a/src/boxman/utils/decorators.py
+++ b/src/boxman/utils/decorators.py
@@ -6,7 +6,7 @@ Currently just :func:`safe_execute`, which collapses the
 ``providers/libvirt/snapshot.py``, ``cloudinit.py``, and a handful of
 other helper methods.
 
-Added in Phase 2.2 of the review plan (see /home/mher/.claude/plans/).
+Added in Phase 2.2 of the engineering review plan.
 """
 
 from __future__ import annotations

--- a/src/boxman/utils/shell.py
+++ b/src/boxman/utils/shell.py
@@ -20,7 +20,7 @@ Defaulting ``in_stream=False`` disables the stdin pump. Interactive
 callers (there are none today, but keep the override path open) can
 still pass a non-False stream explicitly.
 
-Added in Phase 2.8 follow-up (see /home/mher/.claude/plans/).
+Added in a Phase 2.8 follow-up of the engineering review plan.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Refs #85 — item 41, src-docstring part only (the non-src parts belong to the parallel group).

Six src modules cited a private local plan path `/home/mher/.claude/plans/...` in their module docstrings: `exceptions.py`, `scripts/cli_parser.py`, `utils/decorators.py`, `utils/shell.py`, `providers/libvirt/disk_cleanup.py`, `providers/libvirt/cloudinit_presets.py`. The path citations are stripped; the useful phase/design context ("Phase 2.x of the engineering review plan") is kept.

The item also listed `utils/references.py` and `abstract/providers.py`, but both are already clean on current origin/polish (verified by grepping the whole `src/` tree for `.claude/plans` / `claude` — only the six files above matched).

Tests: `pytest tests` — 1852 passed, 141 deselected. Ruff on changed files: only pre-existing violations (N818 on `RuntimeUnavailable`, I001 import sorting — identical on origin/polish), nothing new.