### PR TITLE
Consolidate test helpers and fix unit-marker gaps (#85 item 42)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,160 +1,29 @@
 """
-Shared pytest fixtures for the boxman test suite.
-
-Added 2026-04-21 as part of Phase 1.1 of the review plan
-(see /home/mher/.claude/plans/check-the-claude-dir-fizzy-hearth.md).
+Shared pytest fixtures and helpers for the boxman test suite.
 
 Fixtures:
 
-    tmp_workspace    — an isolated boxman workspace rooted in ``tmp_path``
-                       with a minimal ``boxman.yml`` and an empty cache dir.
-    fake_virsh       — a ``MagicMock`` that emits canned virsh-style output
-                       on demand. Used by libvirt unit tests to avoid
-                       needing a live libvirtd.
-    fake_runtime     — a stub Runtime whose ``wrap_command`` is identity
-                       and whose ``ensure_ready`` is a no-op. Lets provider
-                       tests skip docker entirely.
     captured_logs    — thin wrapper around pytest's ``caplog`` that attaches
                        to boxman's module-level ``log`` singleton, so tests
                        can assert on what the code logged.
+
+Helpers (plain importable functions, not fixtures):
+
+    make_bare_manager — a ``BoxmanManager`` built via ``__new__`` (constructor
+                       bypassed, so no config files are loaded) with an
+                       in-memory config dict and a mocked logger, for unit
+                       tests that exercise manager methods in isolation.
 """
 
 from __future__ import annotations
 
-import json
 import logging
-from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
-
-# ---------------------------------------------------------------------------
-# Workspace fixture
-# ---------------------------------------------------------------------------
-
-MINIMAL_BOXMAN_YML = """\
-version: '1.0'
-workdir: {workdir}
-provider:
-  libvirt:
-    uri: qemu:///system
-    use_sudo: false
-    virsh_cmd: /usr/bin/virsh
-runtime:
-  name: local
-"""
-
-
-@pytest.fixture
-def tmp_workspace(tmp_path: Path) -> Path:
-    """
-    Build an isolated boxman workspace under *tmp_path*.
-
-    Layout:
-
-        <tmp_path>/
-            boxman.yml
-            cache/
-                projects.json   (empty {})
-            workdir/
-    """
-    workdir = tmp_path / "workdir"
-    workdir.mkdir()
-    cache = tmp_path / "cache"
-    cache.mkdir()
-    (cache / "projects.json").write_text("{}\n")
-    (tmp_path / "boxman.yml").write_text(
-        MINIMAL_BOXMAN_YML.format(workdir=str(workdir))
-    )
-    return tmp_path
-
-
-# ---------------------------------------------------------------------------
-# Fake virsh — canned output for libvirt unit tests
-# ---------------------------------------------------------------------------
-
-class FakeVirshResult:
-    """Mimic the shape of an ``invoke.Result``: .stdout/.stderr/.ok/.return_code."""
-
-    def __init__(
-        self,
-        stdout: str = "",
-        stderr: str = "",
-        return_code: int = 0,
-    ):
-        self.stdout = stdout
-        self.stderr = stderr
-        self.return_code = return_code
-        self.ok = return_code == 0
-        self.failed = not self.ok
-
-
-@pytest.fixture
-def fake_virsh() -> MagicMock:
-    """
-    Return a MagicMock preconfigured with common virsh outputs.
-
-    Use ``fake_virsh.set_output(pattern, stdout)`` to register responses.
-    The mock's ``.run(cmd)`` method matches ``cmd`` against registered
-    patterns (substring match) and returns a ``FakeVirshResult``.
-
-    Default responses cover ``virsh list --all`` (empty) and
-    ``virsh net-list --all`` (empty).
-    """
-    mock = MagicMock(name="fake_virsh")
-    responses: dict[str, FakeVirshResult] = {
-        "list --all": FakeVirshResult(stdout=" Id   Name   State\n-----------------\n"),
-        "net-list --all": FakeVirshResult(stdout=" Name   State   Autostart   Persistent\n"),
-    }
-
-    def set_output(pattern: str, stdout: str = "", return_code: int = 0) -> None:
-        responses[pattern] = FakeVirshResult(stdout=stdout, return_code=return_code)
-
-    def run(command: str, *_args: Any, **_kwargs: Any) -> FakeVirshResult:
-        for pattern, result in responses.items():
-            if pattern in command:
-                return result
-        return FakeVirshResult(stdout="", return_code=0)
-
-    mock.set_output = set_output
-    mock.run = run
-    mock.responses = responses
-    return mock
-
-
-# ---------------------------------------------------------------------------
-# Fake runtime — decouple provider tests from runtime classes
-# ---------------------------------------------------------------------------
-
-class FakeRuntime:
-    """A Runtime stub that passes commands through unchanged."""
-
-    name: str = "fake"
-
-    def __init__(self, config: dict[str, Any] | None = None):
-        self.config = config or {}
-        self.ensure_ready_calls = 0
-
-    def wrap_command(self, command: str) -> str:
-        return command
-
-    def ensure_ready(self) -> None:
-        self.ensure_ready_calls += 1
-
-    def inject_into_provider_config(
-        self, provider_config: dict[str, Any]
-    ) -> dict[str, Any]:
-        cfg = dict(provider_config)
-        cfg["runtime"] = self.name
-        return cfg
-
-
-@pytest.fixture
-def fake_runtime() -> FakeRuntime:
-    return FakeRuntime()
-
+from boxman.manager import BoxmanManager
 
 # ---------------------------------------------------------------------------
 # Captured logs — attach caplog to boxman's module-level singleton
@@ -182,16 +51,21 @@ def captured_logs(caplog: pytest.LogCaptureFixture) -> pytest.LogCaptureFixture:
 
 
 # ---------------------------------------------------------------------------
-# Small helpers reusable across tests
+# Bare manager — the BoxmanManager.__new__ bypass shared by unit tests
 # ---------------------------------------------------------------------------
 
-@pytest.fixture
-def write_json(tmp_path: Path):
-    """Return a helper that writes a JSON blob to a tmp path."""
+def make_bare_manager(config: dict[str, Any] | None = None) -> BoxmanManager:
+    """
+    Return a bare ``BoxmanManager`` with an in-memory config dict.
 
-    def _write(name: str, payload: Any) -> Path:
-        path = tmp_path / name
-        path.write_text(json.dumps(payload))
-        return path
-
-    return _write
+    The constructor is bypassed (``__new__`` only), so no config files are
+    loaded and no provider/runtime is created; only the attributes unit
+    tests rely on are populated. Callers set any further attributes
+    (``provider``, …) on the returned instance as needed.
+    """
+    mgr = BoxmanManager.__new__(BoxmanManager)
+    mgr.config = config
+    mgr.config_path = None
+    mgr.logger = MagicMock()
+    mgr._netlab = None
+    return mgr

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -354,22 +354,19 @@ class TestConfigDryRun:
     """
 
     def test_template_config_renders_and_parses(self):
-        from pathlib import Path as P
         import yaml
+
         from boxman.utils.jinja_env import create_jinja_env
 
-        tpl_dir = P(__file__).resolve().parent.parent / "data" / "templates"
-        candidates = list(tpl_dir.glob("conf*.yml"))
-        if not candidates:
-            pytest.skip("no example template config found in data/templates/")
-
+        tpl_dir = Path(__file__).resolve().parent.parent / "data" / "templates"
         env = create_jinja_env(str(tpl_dir))
-        template = env.get_template(candidates[0].name)
+        template = env.get_template("conf.libvirt.yml")
         rendered = template.render()
-        # must be parseable YAML
+        # must be parseable YAML with the expected top-level structure
         data = yaml.safe_load(rendered)
-        # bare minimum: has a project key or something structurally similar
-        assert isinstance(data, (dict, type(None)))
+        assert isinstance(data, dict)
+        assert "project" in data
+        assert "clusters" in data
 
 
 class TestImageDispatch:

--- a/tests/test_docker_compose_provider.py
+++ b/tests/test_docker_compose_provider.py
@@ -52,6 +52,8 @@ from boxman.providers.docker_compose.session import (
     _snapshot_tag,
 )
 
+pytestmark = pytest.mark.unit
+
 
 # --------------------------------------------------------------------------
 # ComposeGenerator

--- a/tests/test_netlab_manager_integration.py
+++ b/tests/test_netlab_manager_integration.py
@@ -14,44 +14,35 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock
 
 import pytest
 import yaml
 
 from boxman.manager import BoxmanManager
-
+from conftest import make_bare_manager
 
 pytestmark = pytest.mark.unit
-
-
-def _make_manager(config: dict | None) -> BoxmanManager:
-    mgr = BoxmanManager.__new__(BoxmanManager)
-    mgr.config = config
-    mgr.config_path = None
-    mgr.logger = MagicMock()
-    mgr._netlab = None
-    return mgr
 
 
 class TestNetlabProperty:
 
     def test_none_when_no_config(self):
-        mgr = _make_manager(None)
+        mgr = make_bare_manager(None)
         assert mgr.netlab is None
 
     def test_none_when_containerlab_absent(self):
-        mgr = _make_manager({"clusters": {}})
+        mgr = make_bare_manager({"clusters": {}})
         assert mgr.netlab is None
 
     def test_none_when_explicitly_disabled(self):
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "containerlab": {"enabled": False, "lab_name": "netlab"},
         })
         assert mgr.netlab is None
 
     def test_instance_when_enabled(self, tmp_path):
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "workspace": {"path": str(tmp_path)},
             "containerlab": {"lab_name": "netlab", "topology": {"nodes": {}}},
         })
@@ -60,7 +51,7 @@ class TestNetlabProperty:
         assert netlab.lab_name == "netlab"
 
     def test_cached(self, tmp_path):
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "workspace": {"path": str(tmp_path)},
             "containerlab": {"lab_name": "netlab", "topology": {"nodes": {}}},
         })
@@ -72,12 +63,12 @@ class TestNetlabProperty:
 class TestDeployNetlab:
 
     def test_noop_when_not_configured(self):
-        mgr = _make_manager({"clusters": {}})
+        mgr = make_bare_manager({"clusters": {}})
         # Should not raise or call anything.
         mgr.deploy_netlab()
 
     def test_calls_preflight_render_deploy_in_order(self, tmp_path):
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "workspace": {"path": str(tmp_path)},
             "containerlab": {"lab_name": "netlab", "topology": {"nodes": {}}},
         })
@@ -94,7 +85,7 @@ class TestDeployNetlab:
         assert call_order == ["preflight", "render", "deploy"]
 
     def test_propagates_preflight_error(self, tmp_path):
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "workspace": {"path": str(tmp_path)},
             "containerlab": {"lab_name": "netlab", "topology": {"nodes": {}}},
         })
@@ -112,11 +103,11 @@ class TestDeployNetlab:
 class TestDestroyNetlab:
 
     def test_noop_when_not_configured(self):
-        mgr = _make_manager({"clusters": {}})
+        mgr = make_bare_manager({"clusters": {}})
         mgr.destroy_netlab()  # no raise
 
     def test_calls_destroy(self, tmp_path):
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "workspace": {"path": str(tmp_path)},
             "containerlab": {"lab_name": "netlab", "topology": {"nodes": {}}},
         })
@@ -128,7 +119,7 @@ class TestDestroyNetlab:
         fake_netlab.destroy.assert_called_once()
 
     def test_survives_missing_binary(self, tmp_path):
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "workspace": {"path": str(tmp_path)},
             "containerlab": {"lab_name": "netlab", "topology": {"nodes": {}}},
         })
@@ -146,11 +137,11 @@ class TestEnsureNetlabUp:
     """`boxman up` path: reconcile the lab without tearing it down."""
 
     def test_noop_when_not_configured(self):
-        mgr = _make_manager({"clusters": {}})
+        mgr = make_bare_manager({"clusters": {}})
         mgr.ensure_netlab_up()  # no raise
 
     def test_calls_preflight_render_ensure_up_in_order(self, tmp_path):
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "workspace": {"path": str(tmp_path)},
             "containerlab": {"lab_name": "netlab", "topology": {"nodes": {}}},
         })
@@ -171,17 +162,17 @@ class TestNetlabCliHandlers:
     """Unit-test the four static CLI handlers without argparse plumbing."""
 
     def test_netlab_deploy_logs_error_when_absent(self):
-        mgr = _make_manager({"clusters": {}})
+        mgr = make_bare_manager({"clusters": {}})
         BoxmanManager.netlab_deploy(mgr, MagicMock())
         mgr.logger.error.assert_called_once()
 
     def test_netlab_destroy_logs_error_when_absent(self):
-        mgr = _make_manager({"clusters": {}})
+        mgr = make_bare_manager({"clusters": {}})
         BoxmanManager.netlab_destroy(mgr, MagicMock())
         mgr.logger.error.assert_called_once()
 
     def test_netlab_inspect_prints_json(self, tmp_path, capsys):
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "workspace": {"path": str(tmp_path)},
             "containerlab": {"lab_name": "netlab", "topology": {"nodes": {}}},
         })
@@ -196,7 +187,7 @@ class TestNetlabCliHandlers:
         fake_netlab.preflight.assert_called_once()
 
     def test_netlab_ssh_prints_command(self, tmp_path, capsys):
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "workspace": {"path": str(tmp_path)},
             "containerlab": {
                 "lab_name": "netlab",
@@ -212,7 +203,7 @@ class TestNetlabCliHandlers:
         assert out == "ssh admin@clab-netlab-sw1"
 
     def test_netlab_ssh_with_custom_user(self, tmp_path, capsys):
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "workspace": {"path": str(tmp_path)},
             "containerlab": {
                 "lab_name": "netlab",
@@ -227,7 +218,7 @@ class TestNetlabCliHandlers:
         assert "ssh root@clab-netlab-sw1" in capsys.readouterr().out
 
     def test_netlab_ssh_missing_node_logs_error(self, tmp_path):
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "workspace": {"path": str(tmp_path)},
             "containerlab": {"lab_name": "netlab", "topology": {"nodes": {}}},
         })
@@ -267,7 +258,7 @@ class TestNetlabStartupConfigSourceRoot:
     def test_deploy_netlab_relative_conf_resolves_to_box_dir(
             self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "workspace": {"path": str(tmp_path / "ws")},
             "containerlab": {"lab_name": "netlab", "topology": {"nodes": {}}},
         })
@@ -280,7 +271,7 @@ class TestNetlabStartupConfigSourceRoot:
     def test_ensure_netlab_up_relative_conf_resolves_to_box_dir(
             self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "workspace": {"path": str(tmp_path / "ws")},
             "containerlab": {"lab_name": "netlab", "topology": {"nodes": {}}},
         })
@@ -304,7 +295,7 @@ class TestNetlabWorkdirAbsolute:
     def test_workdir_absolute_when_config_path_relative(
             self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "containerlab": {"lab_name": "netlab", "topology": {"nodes": {}}},
         })
         mgr.config_path = "conf.yml"  # bare relative default, no workspace.path
@@ -317,7 +308,7 @@ class TestNetlabWorkdirAbsolute:
     def test_workdir_absolute_when_workspace_path_relative(
             self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "workspace": {"path": "ws"},
             "containerlab": {"lab_name": "netlab", "topology": {"nodes": {}}},
         })
@@ -332,7 +323,7 @@ class TestNetlabWorkdirAbsolute:
         monkeypatch.chdir(tmp_path)
         (tmp_path / "configs").mkdir()
         (tmp_path / "configs" / "sw1.cfg.j2").write_text("hostname sw1\n")
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "containerlab": {
                 "lab_name": "netlab",
                 "topology": {

--- a/tests/test_netlab_schema.py
+++ b/tests/test_netlab_schema.py
@@ -17,24 +17,16 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from boxman.manager import BoxmanManager
 from boxman.providers.libvirt.net import NetworkInterface
-
+from conftest import make_bare_manager
 
 pytestmark = pytest.mark.unit
-
-
-def _make_manager(config: dict) -> BoxmanManager:
-    mgr = BoxmanManager.__new__(BoxmanManager)
-    mgr.config = config
-    mgr.logger = MagicMock()
-    return mgr
 
 
 class TestAdapterResolution:
 
     def test_shared_network_rewrites_to_bridge(self):
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "project": "p1",
             "shared_networks": {
                 "lab_mgmt": {"bridge": "shared_lab_mgmt"},
@@ -48,7 +40,7 @@ class TestAdapterResolution:
         assert adapter["source_type"] == "bridge"
 
     def test_global_adapter_unchanged(self):
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "project": "p1",
             "shared_networks": {"lab_mgmt": {"bridge": "br1"}},
             "clusters": {},
@@ -60,7 +52,7 @@ class TestAdapterResolution:
         assert "source_type" not in adapter
 
     def test_cluster_scoped_network_prefixed(self):
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "project": "p1",
             "shared_networks": {},
             "clusters": {},
@@ -77,7 +69,7 @@ class TestAdapterResolution:
         # A name that matches shared_networks should resolve as a bridge
         # even if is_global is also set. Shared bridges are already the
         # "global" concept for hybrid L2 glue.
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "project": "p1",
             "shared_networks": {"lab_mgmt": {"bridge": "br_lab"}},
             "clusters": {},
@@ -89,7 +81,7 @@ class TestAdapterResolution:
         assert adapter["source_type"] == "bridge"
 
     def test_no_shared_networks_key_falls_back(self):
-        mgr = _make_manager({
+        mgr = make_bare_manager({
             "project": "p1",
             "clusters": {},
         })

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -3,13 +3,16 @@ Tests for the boxman update feature: VMStateDiffer, hot/cold CPU/memory,
 disk resize, and update orchestration logic.
 """
 
-import os
-import pytest
-from unittest.mock import patch, MagicMock, PropertyMock, call
+from unittest.mock import MagicMock, call, patch
 
-from boxman.providers.libvirt.vm_differ import VMStateDiffer
-from boxman.providers.libvirt.virsh_edit import VirshEdit
+import pytest
+
 from boxman.providers.libvirt.disk import DiskManager
+from boxman.providers.libvirt.virsh_edit import VirshEdit
+from boxman.providers.libvirt.vm_differ import VMStateDiffer
+from conftest import make_bare_manager
+
+pytestmark = pytest.mark.unit
 
 
 # ---------------------------------------------------------------------------
@@ -600,17 +603,19 @@ class TestVMStateDifferMaxDiff:
 # ---------------------------------------------------------------------------
 # DiskManager XML generation tests
 # ---------------------------------------------------------------------------
+def _make_disk_manager():
+    """Bare DiskManager instance (constructor bypassed) for unit tests."""
+    dm = DiskManager.__new__(DiskManager)
+    dm.vm_name = 'test-vm'
+    dm.logger = MagicMock()
+    dm.provider_config = {'uri': 'qemu:///system'}
+    return dm
+
+
 class TestDiskManagerXml:
 
-    def _make_manager(self):
-        dm = DiskManager.__new__(DiskManager)
-        dm.vm_name = 'test-vm'
-        dm.logger = MagicMock()
-        dm.provider_config = {'uri': 'qemu:///system'}
-        return dm
-
     def test_generate_disk_xml_includes_bus_virtio(self):
-        dm = self._make_manager()
+        dm = _make_disk_manager()
         xml = dm._generate_disk_xml(
             disk_path='/data/disk.qcow2',
             target_dev='vdb',
@@ -620,7 +625,7 @@ class TestDiskManagerXml:
         assert "bus='virtio'" in xml
 
     def test_generate_disk_xml_custom_bus(self):
-        dm = self._make_manager()
+        dm = _make_disk_manager()
         xml = dm._generate_disk_xml(
             disk_path='/data/disk.qcow2',
             target_dev='sdb',
@@ -636,16 +641,9 @@ class TestDiskManagerXml:
 # ---------------------------------------------------------------------------
 class TestDiskManagerResize:
 
-    def _make_manager(self):
-        dm = DiskManager.__new__(DiskManager)
-        dm.vm_name = 'test-vm'
-        dm.logger = MagicMock()
-        dm.provider_config = {'uri': 'qemu:///system'}
-        return dm
-
     @patch('boxman.providers.libvirt.disk.LibVirtCommandBase')
     def test_resize_disk_offline_success(self, mock_cmd_cls):
-        dm = self._make_manager()
+        dm = _make_disk_manager()
         mock_instance = MagicMock()
         mock_cmd_cls.return_value = mock_instance
         mock_instance.execute_shell.return_value = MagicMock(ok=True)
@@ -657,7 +655,7 @@ class TestDiskManagerResize:
 
     @patch('boxman.providers.libvirt.disk.LibVirtCommandBase')
     def test_resize_disk_offline_failure(self, mock_cmd_cls):
-        dm = self._make_manager()
+        dm = _make_disk_manager()
         mock_instance = MagicMock()
         mock_cmd_cls.return_value = mock_instance
         mock_instance.execute_shell.return_value = MagicMock(ok=False, stderr='err')
@@ -666,7 +664,7 @@ class TestDiskManagerResize:
         assert result is False
 
     def test_resize_disk_online_success(self):
-        dm = self._make_manager()
+        dm = _make_disk_manager()
         dm.execute = MagicMock(return_value=MagicMock(ok=True))
 
         result = dm.resize_disk_online('vdb', 4096)
@@ -675,7 +673,7 @@ class TestDiskManagerResize:
             'blockresize', 'test-vm', 'vdb', '--size=4096M', warn=True)
 
     def test_resize_disk_routes_to_online_when_running(self):
-        dm = self._make_manager()
+        dm = _make_disk_manager()
         dm.resize_disk_online = MagicMock(return_value=True)
         dm.resize_disk_offline = MagicMock(return_value=True)
 
@@ -685,7 +683,7 @@ class TestDiskManagerResize:
         dm.resize_disk_offline.assert_not_called()
 
     def test_resize_disk_routes_to_offline_when_stopped(self):
-        dm = self._make_manager()
+        dm = _make_disk_manager()
         dm.resize_disk_online = MagicMock(return_value=True)
         dm.resize_disk_offline = MagicMock(return_value=True)
 
@@ -742,9 +740,7 @@ class TestDestroyRemovedVm:
 
     def _make_manager(self):
         """Bare BoxmanManager instance with a mocked provider."""
-        from boxman.manager import BoxmanManager
-        mgr = BoxmanManager.__new__(BoxmanManager)
-        mgr.logger = MagicMock()
+        mgr = make_bare_manager()
         mgr.provider = MagicMock()
         mgr.provider.provider_config = {'uri': 'qemu:///system'}
         return mgr

--- a/tests/test_workspace_defaults.py
+++ b/tests/test_workspace_defaults.py
@@ -3,17 +3,16 @@ Tests for BoxmanManager.resolve_workspace_defaults().
 """
 
 import os
-import yaml
-import pytest
 
-from boxman.manager import BoxmanManager
+import yaml
+
 from boxman.utils.env_loader import load_workspace_env
+from conftest import make_bare_manager
 
 
 def _make_manager(config):
     """Create a BoxmanManager with an in-memory config dict (no file loading)."""
-    mgr = BoxmanManager()
-    mgr.config = config
+    mgr = make_bare_manager(config)
     mgr.resolve_workspace_defaults()
     return mgr
 
@@ -28,7 +27,7 @@ class TestWorkdirResolution:
                 'web': {'vms': {'web01': {}}},
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         assert config['clusters']['web']['workdir'] == os.path.join(
             '~/workspaces/myproject', 'web'
         )
@@ -44,7 +43,7 @@ class TestWorkdirResolution:
                 },
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         assert config['clusters']['db']['workdir'] == '~/custom/db-workdir'
 
     def test_multiple_clusters_get_own_workdir(self):
@@ -56,7 +55,7 @@ class TestWorkdirResolution:
                 'beta': {'vms': {'b01': {}}},
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         assert config['clusters']['alpha']['workdir'] == '/opt/boxman/alpha'
         assert config['clusters']['beta']['workdir'] == '/opt/boxman/beta'
 
@@ -67,7 +66,7 @@ class TestWorkdirResolution:
                 'orphan': {'vms': {'vm01': {}}},
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         # no workdir should be set, no files generated
         assert 'workdir' not in config['clusters']['orphan']
         assert 'files' not in config['clusters']['orphan']
@@ -93,7 +92,7 @@ class TestPerClusterInventoryGeneration:
                 },
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         cfiles = config['clusters']['c1']['files']
         assert 'inventory/01-hosts.yml' in cfiles
         parsed = yaml.safe_load(cfiles['inventory/01-hosts.yml'])
@@ -109,7 +108,7 @@ class TestPerClusterInventoryGeneration:
                 'cluster_2': {'vms': {'service01': {}, 'node01': {}}},
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         inv1 = yaml.safe_load(
             config['clusters']['cluster_1']['files']['inventory/01-hosts.yml'])
         inv2 = yaml.safe_load(
@@ -135,7 +134,7 @@ class TestPerClusterInventoryGeneration:
                 'cluster_2': {'vms': {'service01': {}, 'node01': {}}},
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         combined = yaml.safe_load(
             config['workspace']['files']['inventory/01-hosts.yml'])
         inv2 = yaml.safe_load(
@@ -156,7 +155,7 @@ class TestPerClusterInventoryGeneration:
                 },
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         cfiles = config['clusters']['cluster_2']['files']
         assert 'inventory_cluster_2/01-hosts.yml' in cfiles
         assert 'inventory/01-hosts.yml' not in cfiles
@@ -173,7 +172,7 @@ class TestPerClusterInventoryGeneration:
                 },
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         assert config['clusters']['c1']['files']['inventory/01-hosts.yml'] == custom
 
     def test_no_per_cluster_inventory_without_workdir(self):
@@ -183,7 +182,7 @@ class TestPerClusterInventoryGeneration:
                 'orphan': {'vms': {'vm01': {}}},
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         assert 'files' not in config['clusters']['orphan']
 
 
@@ -269,7 +268,7 @@ class TestAnsibleCfgGeneration:
                 'c1': {'vms': {'vm01': {}}},
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         cfg = config['workspace']['files']['ansible.cfg']
         assert '[defaults]' in cfg
         assert 'host_key_checking = False' in cfg
@@ -293,7 +292,7 @@ class TestAnsibleCfgGeneration:
                 'c1': {'vms': {'vm01': {}}},
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         assert config['workspace']['files']['ansible.cfg'] == custom_cfg
 
 
@@ -307,7 +306,7 @@ class TestEnvShGeneration:
                 'c1': {'vms': {'node01': {}, 'node02': {}}},
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         env_sh = config['workspace']['files']['env.sh']
         assert 'export INVENTORY=inventory' in env_sh
         assert 'export SSH_CONFIG=ssh_config' in env_sh
@@ -326,7 +325,7 @@ class TestEnvShGeneration:
                 'c1': {'vms': {'alpha': {}, 'beta': {}, 'gamma': {}}},
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         env_sh = config['workspace']['files']['env.sh']
         assert 'export GATEWAYHOST=c1_alpha' in env_sh
 
@@ -338,7 +337,7 @@ class TestEnvShGeneration:
                 'c1': {'vms': {'vm01': {}}},
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         env_sh = config['workspace']['files']['env.sh']
         assert 'export SSH_CONFIG=ssh_config' in env_sh
         assert 'export ANSIBLE_CONFIG=ansible.cfg' in env_sh
@@ -357,7 +356,7 @@ class TestEnvShGeneration:
                 },
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         assert config['workspace']['files']['env.sh'] == custom_env
 
 
@@ -371,7 +370,7 @@ class TestWorkspaceInventoryGeneration:
                 'c1': {'vms': {'node01': {}, 'node02': {}}},
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         inv = config['workspace']['files']['inventory/01-hosts.yml']
         parsed = yaml.safe_load(inv)
         assert set(parsed['all']['hosts'].keys()) == {'c1_node01', 'c1_node02'}
@@ -390,7 +389,7 @@ class TestWorkspaceInventoryGeneration:
                 'db': {'vms': {'db01': {}}},
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         inv = config['workspace']['files']['inventory/01-hosts.yml']
         parsed = yaml.safe_load(inv)
         assert set(parsed['all']['hosts'].keys()) == {'web_web01', 'web_web02', 'db_db01'}
@@ -414,7 +413,7 @@ class TestWorkspaceInventoryGeneration:
                 'c1': {'vms': {'vm01': {}}},
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         assert config['workspace']['files']['inventory/01-hosts.yml'] == custom_inv
 
 
@@ -428,7 +427,7 @@ class TestEdgeCases:
                 'empty': {'vms': {}},
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         assert 'files' not in config['clusters']['empty']
 
     def test_cluster_without_vms_key_skipped(self):
@@ -439,13 +438,13 @@ class TestEdgeCases:
                 'novms': {},
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         assert 'files' not in config['clusters']['novms']
 
     def test_no_clusters_key(self):
         """Config with no clusters key does not raise."""
         config = {'workspace': {'path': '/tmp/ws'}}
-        mgr = _make_manager(config)  # should not raise
+        _make_manager(config)  # should not raise
 
     def test_partial_explicit_files_are_preserved(self):
         """Only missing workspace files are auto-generated; explicit ones are kept."""
@@ -461,7 +460,7 @@ class TestEdgeCases:
                 },
             },
         }
-        mgr = _make_manager(config)
+        _make_manager(config)
         ws_files = config['workspace']['files']
         # ansible.cfg kept as-is
         assert ws_files['ansible.cfg'] == custom_cfg


### PR DESCRIPTION
Refs #85 — item 42. Evidence: `doc/engineering-review.md`.

**Unit-marker gap**
- `tests/test_update.py` and `tests/test_docker_compose_provider.py` had no `pytestmark = pytest.mark.unit`, so `pytest -m unit` silently skipped them. Added the module-level mark (same style as sibling files). Verified: `-m unit` collection goes **1135 → 1343** (+208 = 45 + 163 tests; the review said 147 for the dc-provider file, actual count is 163).
- Follow-up not done here (out of the item's scope): 11 other test files lack `pytestmark`, incl. unit-only ones like `test_workspace_defaults.py` (27 tests), `test_runtime.py`, `test_jinja_env.py` — worth a sweep if `-m unit` is meant to be complete.

**Shared `_make_manager`**
- New `make_bare_manager()` in `tests/conftest.py` (plain importable helper: `BoxmanManager.__new__` bypass + in-memory config + mocked logger + `config_path`/`_netlab` baselines).
- Rewired all definitions: `test_netlab_schema.py`, `test_netlab_manager_integration.py`, `test_workspace_defaults.py` (kept a thin local wrapper that also calls `resolve_workspace_defaults()`, now on the bare instance instead of the real constructor), and `TestDestroyRemovedVm._make_manager` in `test_update.py`. The review said "twice in test_update.py" — only one was a BoxmanManager bypass; the other two were identical DiskManager builders, now consolidated into one module-level `_make_disk_manager()`.
- `MINIMAL_DOMAIN_XML`: copy-pasted only in `test_libvirt_shared_folder.py`, which is outside this group's file set — left as-is.

**conftest dead-fixture sweep (conftest part of item 37)**
- Deleted `tmp_workspace`, `fake_virsh`, `fake_runtime`, `write_json` (~140 lines). Verified per-fixture grep: zero references in any test file (the `fake_virsh` in `test_ps.py:86` is a local function, not the fixture). `captured_logs` stays — 7 test files use it. Also dropped the stale private plan-path reference from the conftest docstring.

**Smoke test pinning**
- `tests/test_cli_smoke.py`: the template dry-run test globbed `conf*.yml` and tested `candidates[0]` (arbitrary filesystem order), asserting only `isinstance(data, (dict, type(None)))`. Now pinned to `data/templates/conf.libvirt.yml` explicitly, asserting `project:`/`clusters:` keys. Coordinated with item 41 (PR #122), which deleted the v1 leftovers `conf.yml`/`conf.virtualbox.yml` — `conf.libvirt.yml` is what remains.

**F841 sweep**
- `test_workspace_defaults.py`: dropped the unused `mgr = _make_manager(config)` assignment at **all 23** call sites — the review listed 5 (lines 417/431/442/448/464), but every site in the file is the same "does not raise" pattern; tests assert on the mutated config dict.

**Incidental ruff cleanup** (safe `--fix` only, on the files this PR touches): import sorting + unused-import removal. Ruff violations on the touched files: 34 → 3 (the 3 remaining are pre-existing I001s in `test_cli_smoke.py` regions this change doesn't touch; baseline had 5 there).

Verification: affected files 311 passed; full suite after rebase onto origin/polish@021c7df → **1852 passed, 141 deselected** (unit-only; no integration tests run). Ruff clean on all touched files except the 3 pre-existing I001s noted above.