### PR TITLE
Ruff sweep: 230 → 8 violations (#85 item 40)

### DIFF
--- a/scripts/count_loc.py
+++ b/scripts/count_loc.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 CATEGORIES = [
     "code", "tests", "docs", "conf", "templates",
     "boxes", "shell", "docker", "make", "claude", "other",

--- a/scripts/installer/check_prerequisites.py
+++ b/scripts/installer/check_prerequisites.py
@@ -220,7 +220,7 @@ def sudo_nopasswd_covers(sudo_l_output, binary):
         rhs = line.split("NOPASSWD", 1)[1]
         if re.search(r":\s*ALL\b", rhs):
             return True
-        if re.search(r"[/\s]%s(\b|,|$)" % re.escape(base), rhs):
+        if re.search(rf"[/\s]{re.escape(base)}(\b|,|$)", rhs):
             return True
     return False
 
@@ -385,7 +385,7 @@ def wiped_networks(networks, evidence):
     rules vouch for virbr1 and hide a genuinely wiped network.
     """
     return [name for name, bridge, expects in networks
-            if expects and not re.search(r"\b%s\b" % re.escape(bridge), evidence)]
+            if expects and not re.search(rf"\b{re.escape(bridge)}\b", evidence)]
 
 
 def forwarding_verdict(networks, evidence, docker_present, backend,
@@ -427,25 +427,25 @@ def forwarding_verdict(networks, evidence, docker_present, backend,
     # those libvirt writes nothing by design, which is exactly why a drop is
     # fatal to them.
     at_risk = [name for name, bridge, _ in networks
-               if any(not re.search(r"\b%s\b" % re.escape(bridge), closure)
+               if any(not re.search(rf"\b{re.escape(bridge)}\b", closure)
                       for closure in closures)]
 
     if wiped and not complete_view:
-        return INFO, ("part of the ruleset was unreadable, so the rules for %s "
-                      "could not be confirmed either way" % ", ".join(wiped)), False
+        return INFO, ("part of the ruleset was unreadable, so the rules for "
+                      f"{', '.join(wiped)} could not be confirmed either way"), False
 
     if wiped:
-        detail = ("no forwarding rules for active network(s): %s\n"
-                  "guests will NAT but never forward" % ", ".join(wiped))
+        detail = (f"no forwarding rules for active network(s): {', '.join(wiped)}\n"
+                  "guests will NAT but never forward")
         if docker_present:
             detail += "\ndocker shares this table and rebuilds it on restart"
         return WARN, detail, True
 
     if at_risk and complete_view:
         detail = ("a chain at the forward hook drops by default and nothing "
-                  "in it accepts: %s\n"
+                  f"in it accepts: {', '.join(at_risk)}\n"
                   "a drop in any table at the hook is final, so these guests "
-                  "cannot forward" % ", ".join(at_risk))
+                  "cannot forward")
         if backend == "nftables":
             # the half-fixed host: rules protected, policy never cleared
             detail += "\nlibvirt already has its own table -- only the policy is left"
@@ -463,14 +463,14 @@ def forwarding_verdict(networks, evidence, docker_present, backend,
         return INFO, ("rules are in place, but libvirt's firewall backend "
                       "could not be determined from here"), False
 
-    return OK, "forwarding rules present for: %s" % ", ".join(
-        name for name, _, _ in networks), False
+    return OK, "forwarding rules present for: {}".format(
+        ", ".join(name for name, _, _ in networks)), False
 
 
 # --------------------------------------------------------------------------- #
 # Small result containers                                                      #
 # --------------------------------------------------------------------------- #
-class Fix(object):
+class Fix:
     def __init__(self, description, commands=None, needs_sudo=False,
                  needs_relogin=False, disruptive=False):
         self.description = description
@@ -486,7 +486,7 @@ class Fix(object):
         return bool(self.commands)
 
 
-class Result(object):
+class Result:
     def __init__(self, name, status, detail="", fix=None):
         self.name = name
         self.status = status
@@ -511,7 +511,7 @@ def run_capture(args, timeout=20):
             args,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            universal_newlines=True,
+            text=True,
             timeout=timeout,
         )
         return proc.returncode, proc.stdout or ""
@@ -543,7 +543,7 @@ def user_group_names():
 # --------------------------------------------------------------------------- #
 # The doctor                                                                  #
 # --------------------------------------------------------------------------- #
-class Doctor(object):
+class Doctor:
     def __init__(self, opts):
         self.opts = opts
         self.os = self._detect_os()
@@ -561,15 +561,15 @@ class Doctor(object):
     def c(self, text, name):
         if not self.use_color:
             return text
-        return "\033[%sm%s\033[0m" % (_ANSI.get(name, "0"), text)
+        return "\033[{}m{}\033[0m".format(_ANSI.get(name, "0"), text)
 
     def section(self, title):
-        print("\n" + self.c("== %s ==" % title, "bold"))
+        print("\n" + self.c(f"== {title} ==", "bold"))
 
     def _print_result(self, result, prefix=""):
         tag, color = _STATUS_TAG[result.status]
-        label = self.c("[%s]" % tag, color)
-        print("%s%s %s" % (prefix, label, result.name))
+        label = self.c(f"[{tag}]", color)
+        print(f"{prefix}{label} {result.name}")
         if result.detail:
             for line in result.detail.splitlines():
                 print("       " + line)
@@ -644,7 +644,7 @@ class Doctor(object):
     def _remember_manual(self, result, note=None):
         entry = result.name
         if note:
-            entry += " (%s)" % note
+            entry += f" ({note})"
         elif result.fix and result.fix.commands:
             entry += ": " + " ; ".join(result.fix.commands)
         elif result.fix:
@@ -654,7 +654,7 @@ class Doctor(object):
 
     def _ask(self, prompt):
         try:
-            answer = input("%s [y/N] " % prompt).strip().lower()
+            answer = input(f"{prompt} [y/N] ").strip().lower()
         except (EOFError, KeyboardInterrupt, OSError):
             # OSError: the terminal went away mid-prompt (EIO on hangup).
             # Declining is the only safe reading of "no answer".
@@ -673,7 +673,7 @@ class Doctor(object):
                 return False
             if rc != 0:
                 ok = False
-                print("       " + self.c("command exited with status %d" % rc, "yellow"))
+                print("       " + self.c(f"command exited with status {rc}", "yellow"))
                 if fix.disruptive:
                     # Later commands restart services. Carrying on past a
                     # failed edit would apply the disruption without the
@@ -733,8 +733,8 @@ class Doctor(object):
             commands.append(cmd)
         commands.extend(extra_cmds or [])
         if not commands:
-            description += (" (unrecognized distro '%s' -- install %s with your "
-                            "package manager)" % (self.os["id"] or "?", pkgs))
+            description += (" (unrecognized distro '{}' -- install {} with your "
+                            "package manager)".format(self.os["id"] or "?", pkgs))
         return Fix(description, commands, needs_sudo=True, needs_relogin=relogin)
 
     def _core_stack_fix(self):
@@ -776,11 +776,11 @@ class Doctor(object):
 
     def _header(self):
         print(self.c("Boxman prerequisites checker", "bold"))
-        print("  host    : %s" % self.os["pretty"])
-        print("  family  : %s   runtime: %s" % (self.family, self.runtime))
+        print(f"  host    : {self.os['pretty']}")
+        print(f"  family  : {self.family}   runtime: {self.runtime}")
         mode = "check-only (read-only)" if self.opts.check_only else (
             "auto-fix (--yes)" if self.opts.yes else "guided (asks before any change)")
-        print("  mode    : %s" % mode)
+        print(f"  mode    : {mode}")
         if not self.opts.check_only:
             print(self.c("  Nothing is changed unless you confirm each fix.", "dim"))
 
@@ -789,28 +789,28 @@ class Doctor(object):
         self.section("Environment")
 
         def python_version():
-            ver = "%d.%d.%d" % sys.version_info[:3]
+            ver = ".".join(str(p) for p in sys.version_info[:3])
             if sys.version_info[:2] >= (3, 10):
-                return OK, "Python %s (boxman needs >= 3.10)" % ver, None
+                return OK, f"Python {ver} (boxman needs >= 3.10)", None
             fix = Fix(
                 "install Python >= 3.10 (e.g. `conda create -n boxman python=3.12` "
                 "or a system python3.10+), then reinstall boxman into it",
                 commands=[],
             )
-            return FAIL, "Python %s is too old; boxman needs >= 3.10" % ver, fix
+            return FAIL, f"Python {ver} is too old; boxman needs >= 3.10", fix
 
         self.check("Python version", python_version)
 
         def boxman_installed():
             env = os.environ.get("CONDA_DEFAULT_ENV") or os.environ.get("VIRTUAL_ENV")
-            env_note = ("active env: %s" % env) if env else "no conda/venv detected"
+            env_note = (f"active env: {env}") if env else "no conda/venv detected"
             if have("boxman"):
                 rc, out = run_capture(["boxman", "--version"])
                 ver = out.strip().splitlines()[0] if (rc == 0 and out.strip()) else "installed"
-                return OK, "%s (%s); %s" % (ver, shutil.which("boxman"), env_note), None
+                return OK, f"{ver} ({shutil.which('boxman')}); {env_note}", None
             fix = Fix("install boxman into your active environment",
                       commands=["pip install boxman"])
-            return WARN, "`boxman` not on PATH; %s" % env_note, fix
+            return WARN, f"`boxman` not on PATH; {env_note}", fix
 
         self.check("boxman on PATH", boxman_installed)
 
@@ -818,7 +818,7 @@ class Doctor(object):
             mods = ["yaml", "invoke", "jinja2", "lxml", "passlib"]
             missing = []
             for mod in mods:
-                rc, _ = run_capture([sys.executable, "-c", "import %s" % mod])
+                rc, _ = run_capture([sys.executable, "-c", f"import {mod}"])
                 if rc != 0:
                     missing.append(mod)
             if not missing:
@@ -826,9 +826,9 @@ class Doctor(object):
             hint = ("lxml needs system libxml2/libxslt; the rest come with "
                     "`pip install boxman`") if "lxml" in missing else \
                    "reinstall boxman to pull these"
-            fix = Fix("install boxman's Python deps into %s (%s)" % (sys.executable, hint),
-                      commands=["%s -m pip install %s" % (sys.executable, " ".join(missing))])
-            return WARN, "missing: %s" % ", ".join(missing), fix
+            fix = Fix(f"install boxman's Python deps into {sys.executable} ({hint})",
+                      commands=[f"{sys.executable} -m pip install {' '.join(missing)}"])
+            return WARN, f"missing: {', '.join(missing)}", fix
 
         self.check("boxman Python deps", python_deps)
 
@@ -865,7 +865,7 @@ class Doctor(object):
             except OSError:
                 pass
             fix = Fix("load the KVM kernel module (needs VT-x/AMD-V enabled in BIOS)",
-                      commands=["sudo modprobe kvm %s" % vendor_mod], needs_sudo=True)
+                      commands=[f"sudo modprobe kvm {vendor_mod}"], needs_sudo=True)
             return FAIL, "/dev/kvm missing -- KVM module not loaded", fix
 
         kvm = self.check("/dev/kvm device", dev_kvm)
@@ -896,7 +896,7 @@ class Doctor(object):
 
         def nested():
             for mod in ("kvm_intel", "kvm_amd"):
-                path = "/sys/module/%s/parameters/nested" % mod
+                path = f"/sys/module/{mod}/parameters/nested"
                 if os.path.exists(path):
                     try:
                         with open(path) as handle:
@@ -904,13 +904,13 @@ class Doctor(object):
                     except OSError:
                         continue
                     if val in ("Y", "1"):
-                        return OK, "nested virtualization enabled (%s)" % mod, None
+                        return OK, f"nested virtualization enabled ({mod})", None
                     fix = Fix(
                         "enable nested virt on the *host*, e.g. "
-                        "`echo 'options %s nested=1' | sudo tee /etc/modprobe.d/kvm.conf` "
-                        "then reload the module" % mod,
+                        f"`echo 'options {mod} nested=1' | sudo tee /etc/modprobe.d/kvm.conf` "
+                        "then reload the module",
                         commands=[])
-                    return WARN, "running in a VM and nested virt is disabled (%s=%s)" % (mod, val), fix
+                    return WARN, f"running in a VM and nested virt is disabled ({mod}={val})", fix
             return SKIP, "no kvm_intel/kvm_amd module parameter found", None
 
         self.check("Nested virtualization", nested)
@@ -927,7 +927,7 @@ class Doctor(object):
                 missing.append("qemu-system-x86_64")
             if not missing:
                 return OK, "virsh, virt-install, virt-clone, qemu-img, qemu-system present", None
-            return FAIL, "missing: %s" % ", ".join(missing), self._core_stack_fix()
+            return FAIL, f"missing: {', '.join(missing)}", self._core_stack_fix()
 
         tools = self.check("Core libvirt/QEMU tools", core_tools)
 
@@ -961,7 +961,7 @@ class Doctor(object):
                 if rc == 0:
                     return OK, "virsh can reach qemu:///system", None
                 reason = out.strip().splitlines()[-1] if out.strip() else "connection failed"
-                detail = "cannot reach qemu:///system: %s" % reason
+                detail = f"cannot reach qemu:///system: {reason}"
                 if "permission" in out.lower() or "authentication" in out.lower():
                     detail += "\n(usually a group-membership issue -- see the groups check below)"
                 return FAIL, detail, None  # fix handled by service/groups checks
@@ -975,7 +975,7 @@ class Doctor(object):
             want = [libvirt_group, "kvm"]
             missing = [g for g in want if g not in names]
             if not missing:
-                return OK, "user '%s' is in: %s" % (user, ", ".join(want)), None
+                return OK, f"user '{user}' is in: {', '.join(want)}", None
             if self.family == "nixos":
                 fix = Fix("add your user to the libvirtd/kvm groups declaratively: "
                           "users.users.<you>.extraGroups = [ \"libvirtd\" \"kvm\" ]; "
@@ -996,7 +996,7 @@ class Doctor(object):
             # directly ("/dev/kvm access", "libvirt connectivity"). If access
             # already works (world-readable device, polkit, sudo), missing group
             # membership isn't blocking -- the functional checks decide that.
-            return WARN, "user '%s' not in group(s): %s" % (user, ", ".join(missing)), fix
+            return WARN, f"user '{user}' not in group(s): {', '.join(missing)}", fix
 
         if _HAVE_UNIX_IDS:
             self.check("User groups (libvirt, kvm)", groups)
@@ -1027,10 +1027,10 @@ class Doctor(object):
             tools = ["cloud-localds", "genisoimage", "mkisofs", "xorrisofs", "xorriso"]
             found = [t for t in tools if have(t)]
             if found:
-                return OK, "cloud-init seed tool available (%s)" % found[0], None
+                return OK, f"cloud-init seed tool available ({found[0]})", None
             fix = self._install_fix(
                 "install a cloud-init seed-ISO tool", _SEED_PKG.get(self.family, "genisoimage"))
-            return FAIL, "none of: %s (needed to build cloud-init seed ISOs)" % ", ".join(tools), fix
+            return FAIL, f"none of: {', '.join(tools)} (needed to build cloud-init seed ISOs)", fix
 
         self.check("cloud-init seed tool", seed_tool)
 
@@ -1043,7 +1043,7 @@ class Doctor(object):
                 return OK, "ssh and ssh-keygen present", None
             fix = self._install_fix("install the OpenSSH client",
                                     _TOOL_PKG["openssh"].get(self.family, "openssh-client"))
-            return WARN, "missing: %s" % ", ".join(missing), fix
+            return WARN, f"missing: {', '.join(missing)}", fix
 
         self.check("SSH client tools", ssh_client)
 
@@ -1053,10 +1053,10 @@ class Doctor(object):
     def _check_simple_bin(self, label, binary, severity, feature):
         def probe():
             if have(binary):
-                return OK, "%s present" % binary, None
+                return OK, f"{binary} present", None
             pkg = _TOOL_PKG.get(binary, {}).get(self.family, binary)
-            fix = self._install_fix("install %s" % binary, pkg)
-            return severity, "%s not found (needed for %s)" % (binary, feature), fix
+            fix = self._install_fix(f"install {binary}", pkg)
+            return severity, f"{binary} not found (needed for {feature})", fix
 
         self.check(label, probe)
 
@@ -1072,7 +1072,7 @@ class Doctor(object):
                     "/etc/sudoers.d/boxman line: "
                     "`%s ALL=(root) NOPASSWD: /usr/bin/virsh, /usr/bin/qemu-img, "
                     "/usr/sbin/iptables, /usr/sbin/ip, /usr/bin/rsync, /bin/rm`" % (
-                        (user_group_names()[1] or "$USER")),
+                        user_group_names()[1] or "$USER"),
                     commands=[])
                 return WARN, ("passwordless sudo not available; boxman's automatic "
                               "iptables/NAT and cleanup steps fail when run "
@@ -1192,7 +1192,7 @@ class Doctor(object):
                 "/etc/libvirt/network.conf && printf "
                 "\"\\nfirewall_backend = \\\"nftables\\\"\\n\" "
                 ">> /etc/libvirt/network.conf'",
-                "sudo systemctl restart %s" % unit,
+                f"sudo systemctl restart {unit}",
             ]
 
         # the flag stops docker *setting* the policy; it does not clear one
@@ -1234,7 +1234,7 @@ class Doctor(object):
         restarts_docker = any("restart docker" in cmd for cmd in docker_cmds)
         if not libvirt_cmds and (
                 wiped or (restarts_docker and backend != "nftables")):
-            commands.append("sudo systemctl restart %s" % unit)
+            commands.append(f"sudo systemctl restart {unit}")
         if backend == "nftables" and docker_manages:
             description = ("stop docker forcing FORWARD to DROP -- libvirt "
                            "already has its own table")
@@ -1378,15 +1378,15 @@ class Doctor(object):
     def _optional_line(self, binary, pkgkey, feature):
         def probe():
             if have(binary):
-                return OK, "%s present" % binary, None
+                return OK, f"{binary} present", None
             if pkgkey:
                 pkg = _TOOL_PKG.get(pkgkey, {}).get(self.family, pkgkey)
-                fix = self._install_fix("install %s" % binary, pkg)
+                fix = self._install_fix(f"install {binary}", pkg)
             else:
                 url = {"oras": "https://oras.land/docs/installation",
                        "containerlab": "https://containerlab.dev/install/"}.get(binary, "")
-                fix = Fix("install %s -- see %s" % (binary, url), commands=[])
-            return WARN, "%s not installed (only needed for %s)" % (binary, feature), fix
+                fix = Fix(f"install {binary} -- see {url}", commands=[])
+            return WARN, f"{binary} not installed (only needed for {feature})", fix
 
         self.check(binary, probe)
 
@@ -1455,8 +1455,8 @@ class Doctor(object):
             try:
                 free_gb = shutil.disk_usage(probe_dir).free / (1024.0 ** 3)
             except OSError:
-                return SKIP, "cannot stat %s" % probe_dir, None
-            detail = "%.0f GB free on %s" % (free_gb, probe_dir)
+                return SKIP, f"cannot stat {probe_dir}", None
+            detail = f"{free_gb:.0f} GB free on {probe_dir}"
             if free_gb < 20:
                 return WARN, detail + " (VM images are large; ~20-50 GB recommended)", None
             return OK, detail, None
@@ -1473,7 +1473,7 @@ class Doctor(object):
             if not match:
                 return SKIP, "cannot parse MemTotal", None
             total_gb = int(match.group(1)) / (1024.0 ** 2)
-            detail = "%.1f GB RAM" % total_gb
+            detail = f"{total_gb:.1f} GB RAM"
             if total_gb < 8:
                 return WARN, detail + " (8+ GB recommended for comfortable VM clusters)", None
             return OK, detail, None
@@ -1487,9 +1487,9 @@ class Doctor(object):
             while existing and not os.path.exists(existing):
                 existing = os.path.dirname(existing)
             if existing and os.access(existing, os.W_OK):
-                return OK, "%s is writable" % full, None
-            fix = Fix("create the directory", commands=["mkdir -p %s" % full])
-            return WARN, "%s not writable (boxman auto-creates it; check permissions)" % full, fix
+                return OK, f"{full} is writable", None
+            fix = Fix("create the directory", commands=[f"mkdir -p {full}"])
+            return WARN, f"{full} not writable (boxman auto-creates it; check permissions)", fix
 
         self.check(label, probe)
 
@@ -1499,12 +1499,12 @@ class Doctor(object):
         for result in self.results:
             counts[result.status] = counts.get(result.status, 0) + 1
         self.section("Summary")
-        print("  %s   %s   %s   %s   %s" % (
-            self.c("OK: %d" % counts[OK], "green"),
-            self.c("WARN: %d" % counts[WARN], "yellow"),
-            self.c("FAIL: %d" % counts[FAIL], "red"),
-            self.c("SKIP: %d" % counts[SKIP], "dim"),
-            self.c("INFO: %d" % counts[INFO], "cyan"),
+        print("  {}   {}   {}   {}   {}".format(
+            self.c(f"OK: {counts[OK]}", "green"),
+            self.c(f"WARN: {counts[WARN]}", "yellow"),
+            self.c(f"FAIL: {counts[FAIL]}", "red"),
+            self.c(f"SKIP: {counts[SKIP]}", "dim"),
+            self.c(f"INFO: {counts[INFO]}", "cyan"),
         ))
 
         if self.manual_steps:

--- a/scripts/repackage_wheel.py
+++ b/scripts/repackage_wheel.py
@@ -21,7 +21,6 @@ import re
 import sys
 import zipfile
 from base64 import urlsafe_b64encode
-from pathlib import Path
 
 # Directories to relocate and their target under share/boxman/
 RELOCATIONS = {

--- a/src/boxman/__init__.py
+++ b/src/boxman/__init__.py
@@ -1,2 +1,4 @@
 from . import metadata
 from .loggers.logger import logger as log
+
+__all__ = ["log", "metadata"]

--- a/src/boxman/image_cache.py
+++ b/src/boxman/image_cache.py
@@ -114,7 +114,7 @@ class ImageCache:
         try:
             h = hashlib.new(algorithm)
         except ValueError:
-            raise ValueError(f"unknown checksum algorithm: '{algorithm}'")
+            raise ValueError(f"unknown checksum algorithm: '{algorithm}'") from None
 
         log.info(f"computing {algorithm} checksum of {file_path} ...")
         with open(file_path, "rb") as fobj:

--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -13,24 +13,23 @@ from typing import Any, Optional
 from urllib.parse import urlparse
 
 import yaml
-from boxman.utils.shell import run
 
 from boxman import log
-from boxman.loggers.logger import suppressed
+from boxman.abstract.providers import ProviderSession
 from boxman.config_cache import BoxmanCache
 from boxman.exceptions import ConfigError, ProvisionError, SnapshotError
 from boxman.image_cache import ImageCache
+from boxman.loggers.logger import suppressed
 from boxman.netlab import ContainerlabManager, shared_bridges
 from boxman.providers import PROVIDERS, merge_provider_configs, primary_provider_type
 from boxman.providers.libvirt import net_reconcile
-from boxman.abstract.providers import ProviderSession
 from boxman.providers.libvirt.commands import VirshCommand
 from boxman.runtime import RuntimeBase, create_runtime
 from boxman.task_runner import TaskRunner
 from boxman.utils.io import write_files
 from boxman.utils.jinja_env import create_jinja_env
 from boxman.utils.references import resolve_reference
-
+from boxman.utils.shell import run
 
 #: Seconds to wait for a finished child's queue message before declaring its
 #: result missing (the child has already joined, so any wait here is just
@@ -1405,7 +1404,7 @@ class BoxmanManager:
 
         # cluster-level files → written to cluster workdir
         clusters = self.config['clusters']
-        for cluster_name, cluster in clusters.items():
+        for _cluster_name, cluster in clusters.items():
             if files := cluster.get('files'):
                 write_files(files, rootdir=cluster['workdir'])
             wd = cluster.get('workdir')
@@ -1433,7 +1432,7 @@ class BoxmanManager:
                 self._remove_files(ws_files, rootdir=workspace_path)
 
         clusters = self.config['clusters']
-        for cluster_name, cluster in clusters.items():
+        for _cluster_name, cluster in clusters.items():
             base_path = workspace_path or cluster.get('workdir', '')
             base_path = os.path.expanduser(base_path)
 
@@ -1894,7 +1893,7 @@ class BoxmanManager:
                 if not result.ok:
                     raise PermissionError(
                         f"failed to create directory '{path}' even with sudo"
-                    )
+                    ) from None
                 # fall through to chown below
 
         # Two failure modes to repair here:
@@ -2394,11 +2393,11 @@ class BoxmanManager:
 
         # collect which templates are referenced by clusters or individual VMs
         needed_template_keys: set = set()
-        for cluster_name, cluster in self.config.get('clusters', {}).items():
+        for _cluster_name, cluster in self.config.get('clusters', {}).items():
             base_image = cluster.get('base_image', '')
             if base_image in tpl_name_to_key:
                 needed_template_keys.add(tpl_name_to_key[base_image])
-            for vm_name, vm_info in cluster.get('vms', {}).items():
+            for _vm_name, vm_info in cluster.get('vms', {}).items():
                 vm_base = vm_info.get('base_image', '')
                 if vm_base and vm_base in tpl_name_to_key:
                     needed_template_keys.add(tpl_name_to_key[vm_base])
@@ -2530,18 +2529,18 @@ class BoxmanManager:
 
         # ANSI helpers
         if use_color and pretty:
-            BOLD = "\033[1m"
-            CYAN = "\033[1;36m"
-            GREEN = "\033[1;32m"
-            YELLOW = "\033[1;33m"
-            DIM = "\033[2m"
-            RESET = "\033[0m"
+            bold = "\033[1m"
+            cyan = "\033[1;36m"
+            green = "\033[1;32m"
+            yellow = "\033[1;33m"
+            dim = "\033[2m"
+            reset = "\033[0m"
         else:
-            BOLD = CYAN = GREEN = YELLOW = DIM = RESET = ""
+            bold = cyan = green = yellow = dim = reset = ""
 
         if not projects:
             if pretty:
-                print(f"{YELLOW}No projects registered.{RESET}")
+                print(f"{yellow}No projects registered.{reset}")
             else:
                 cls.logger.info("No projects registered.")
             return
@@ -2582,7 +2581,7 @@ class BoxmanManager:
                     parts.append(cell.ljust(col_widths[i]))
                 line = "  ".join(parts)
                 if bold:
-                    return f"{BOLD}{line}{RESET}"
+                    return f"{bold}{line}{reset}"
                 return line
 
             print()
@@ -2594,24 +2593,24 @@ class BoxmanManager:
 
         elif pretty == 'plain':
             print()
-            print(f"{BOLD}Registered projects:{RESET}")
+            print(f"{bold}Registered projects:{reset}")
             print()
             for proj_name, proj_info in projects.items():
-                print(f"  {CYAN}{proj_name}{RESET}")
+                print(f"  {cyan}{proj_name}{reset}")
                 if isinstance(proj_info, dict):
                     conf = proj_info.get('conf', 'n/a')
                     runtime = proj_info.get('runtime', 'n/a')
-                    print(f"    {DIM}config:{RESET}  {conf}")
-                    print(f"    {DIM}runtime:{RESET} {runtime}")
+                    print(f"    {dim}config:{reset}  {conf}")
+                    print(f"    {dim}runtime:{reset} {runtime}")
 
                     networks = proj_info.get('networks', {})
                     if networks:
-                        print(f"    {DIM}networks:{RESET}")
+                        print(f"    {dim}networks:{reset}")
                         for net_name, net_info in networks.items():
                             ip = net_info.get('ip_address', 'n/a') if isinstance(net_info, dict) else 'n/a'
                             bridge = net_info.get('bridge_name', 'n/a') if isinstance(net_info, dict) else 'n/a'
-                            print(f"      {GREEN}-{RESET} {net_name}")
-                            print(f"          {DIM}ip:{RESET} {ip}  {DIM}bridge:{RESET} {bridge}")
+                            print(f"      {green}-{reset} {net_name}")
+                            print(f"          {dim}ip:{reset} {ip}  {dim}bridge:{reset} {bridge}")
                 else:
                     print(f"    {proj_info}")
                 print()
@@ -3783,7 +3782,7 @@ class BoxmanManager:
 
                 try:
                     cmd = f'ssh-keygen -t ed25519 -a 100 -f {admin_priv_key} -q -N ""'
-                    result = run(cmd, hide=True, warn=True)
+                    run(cmd, hide=True, warn=True)
 
                     # verify keys were created
                     if os.path.isfile(admin_priv_key) and os.path.isfile(admin_pub_key):

--- a/src/boxman/providers/__init__.py
+++ b/src/boxman/providers/__init__.py
@@ -13,35 +13,36 @@ dependencies of every other provider.
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from boxman.abstract.providers import ProviderSession
 
 
-def _libvirt_session(config: dict[str, Any]) -> "ProviderSession":
+def _libvirt_session(config: dict[str, Any]) -> ProviderSession:
     from boxman.providers.libvirt.session import LibVirtSession
     return LibVirtSession(config)
 
 
-def _virtualbox_session(config: dict[str, Any]) -> "ProviderSession":
+def _virtualbox_session(config: dict[str, Any]) -> ProviderSession:
     from boxman.providers.virtualbox.session import VirtualBoxSession
     return VirtualBoxSession(config)
 
 
-def _docker_compose_session(config: dict[str, Any]) -> "ProviderSession":
+def _docker_compose_session(config: dict[str, Any]) -> ProviderSession:
     from boxman.providers.docker_compose.session import DockerComposeSession
     return DockerComposeSession(config)
 
 
 #: provider-type name -> factory producing a live session for that provider
-PROVIDERS: dict[str, Callable[[dict[str, Any]], "ProviderSession"]] = {
+PROVIDERS: dict[str, Callable[[dict[str, Any]], ProviderSession]] = {
     'libvirt': _libvirt_session,
     'virtualbox': _virtualbox_session,
     'docker-compose': _docker_compose_session,
 }
 
 
-def create_session(provider_type: str, config: dict[str, Any]) -> "ProviderSession":
+def create_session(provider_type: str, config: dict[str, Any]) -> ProviderSession:
     """
     Create a live session for *provider_type* from *config*.
 

--- a/src/boxman/providers/docker_compose/session.py
+++ b/src/boxman/providers/docker_compose/session.py
@@ -612,7 +612,7 @@ class DockerComposeSession:
             raise ConfigError(
                 f"docker-compose cluster '{cluster_name}': readiness_timeout "
                 f"must be an integer number of seconds (got {raw!r})."
-            )
+            ) from None
         if timeout <= 0:
             raise ConfigError(
                 f"docker-compose cluster '{cluster_name}': readiness_timeout "

--- a/src/boxman/providers/libvirt/clone_vm.py
+++ b/src/boxman/providers/libvirt/clone_vm.py
@@ -129,7 +129,7 @@ class CloneVM:
                 f"found {len(interfaces)} network interfaces to remove from the vm {vm_name}")
 
             # Remove each interface
-            for iface_type, source, mac in interfaces:
+            for iface_type, _source, mac in interfaces:
                 self.logger.info(f"removing interface with MAC {mac} from the vm {vm_name}")
 
                 # Use the detach-interface command with the correct type and MAC

--- a/src/boxman/providers/libvirt/cloudinit.py
+++ b/src/boxman/providers/libvirt/cloudinit.py
@@ -30,8 +30,8 @@ from typing import Any
 import invoke
 
 from boxman import log
-from boxman.loggers.logger import is_verbose
 from boxman.image_cache import ImageCache
+from boxman.loggers.logger import is_verbose
 from boxman.utils.shell import run as _shell_run
 
 from .cloudinit_presets import (  # noqa: F401 — re-exported for back-compat
@@ -39,6 +39,8 @@ from .cloudinit_presets import (  # noqa: F401 — re-exported for back-compat
     DEFAULT_META_DATA,
     DEFAULT_NETWORK_CONFIG,
     DEFAULT_USER_DATA,
+)
+from .cloudinit_presets import (
     hash_password as _hash_password,
 )
 from .commands import VirshCommand, VirtInstallCommand

--- a/src/boxman/providers/libvirt/cloudinit_presets.py
+++ b/src/boxman/providers/libvirt/cloudinit_presets.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 from passlib.hash import sha512_crypt
 
-
 #: completion marker for templates that bring no cloudinit block of their own.
 #: This is the file the LAST ``runcmd`` entry of DEFAULT_USER_DATA appends to,
 #: which is the only thing in the stock user-data that means "finished".

--- a/src/boxman/providers/libvirt/commands.py
+++ b/src/boxman/providers/libvirt/commands.py
@@ -166,7 +166,7 @@ class LibVirtCommandBase:
                     f"Stderr: {exc.result.stderr}"
                 )
                 self.logger.error(error_message)
-                raise RuntimeError(error_message)
+                raise RuntimeError(error_message) from exc
             return exc.result
 
     def _should_use_sudo_for_command(self, command: str) -> bool:
@@ -251,7 +251,7 @@ class LibVirtCommandBase:
                     f"Stderr: {exc.result.stderr}"
                 )
                 self.logger.error(error_message)
-                raise RuntimeError(error_message)
+                raise RuntimeError(error_message) from exc
             return exc.result
 
     def _wrap_for_runtime(self, command: str) -> str:

--- a/src/boxman/providers/libvirt/net.py
+++ b/src/boxman/providers/libvirt/net.py
@@ -2,7 +2,6 @@ import ipaddress
 import os
 import re
 import shlex
-import sys
 import tempfile
 import uuid
 import xml.etree.ElementTree as ET
@@ -676,7 +675,7 @@ class Network(VirshCommand):
             for project, project_conflicts in conflicts.items():
                 if 'networks' in project_conflicts:
                     for net_name, net_conflicts in project_conflicts['networks'].items():
-                        for conflict_type, conflict_msg in net_conflicts.items():
+                        for _conflict_type, conflict_msg in net_conflicts.items():
                             self.logger.error(f"{conflict_msg} (project: {project}, network: {net_name})")
 
             msg = f"found {n_conflicts} conflicts for network {self.name} in project {self.manager.config['project']}"

--- a/src/boxman/providers/libvirt/oci_pull.py
+++ b/src/boxman/providers/libvirt/oci_pull.py
@@ -21,10 +21,8 @@ import subprocess
 import tarfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 from boxman import log
-
 
 # ── metadata sidecar (vmimage.json) ──────────────────────────────────────────
 
@@ -39,14 +37,14 @@ class VmImageMetadata:
     """
 
     firmware: str = "uefi"  # "uefi" or "bios"
-    machine: Optional[str] = None
+    machine: str | None = None
     disk_bus: str = "virtio"
     net_model: str = "virtio"
 
     # display / informational
-    name: Optional[str] = None
-    version: Optional[str] = None
-    arch: Optional[str] = None
+    name: str | None = None
+    version: str | None = None
+    arch: str | None = None
 
 
 def _metadata_from_dict(raw: dict) -> VmImageMetadata:
@@ -95,7 +93,7 @@ def _repo_without_tag(ref: str) -> str:
     return ref
 
 
-def _find_qcow2(out_dir: Path) -> Optional[Path]:
+def _find_qcow2(out_dir: Path) -> Path | None:
     """Locate the qcow2 in a pulled oras output directory.
 
     Prefers ``disk.qcow2``; otherwise the first ``*.qcow2`` (sorted).
@@ -122,8 +120,7 @@ def _run_oras(cmd: list, action: str, ref: str) -> subprocess.CompletedProcess:
         result = subprocess.run(
             cmd,
             check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
         )
     except FileNotFoundError as exc:
@@ -230,7 +227,7 @@ def _manifest_kind(manifest: dict) -> str:
     return "unknown"
 
 
-def _select_index_digest(manifest: dict) -> Optional[str]:
+def _select_index_digest(manifest: dict) -> str | None:
     """Pick the ``linux/<host-arch>`` manifest digest from an image index.
 
     Matches strictly on the host OS/architecture — selecting a different
@@ -311,7 +308,7 @@ def _blob_fetch_to_file(repo: str, digest: str, dest: Path) -> None:
         action="blob fetch", ref=f"{repo}@{digest}")
 
 
-def _extract_disk_from_layer(blob_path: Path, out_dir: Path) -> Optional[Path]:
+def _extract_disk_from_layer(blob_path: Path, out_dir: Path) -> Path | None:
     """Extract the embedded VM disk image from a single (compressed) layer tarball.
 
     Streams the tar (``r|*`` auto-detects gzip/bzip2/xz; zstd is unsupported and
@@ -325,9 +322,9 @@ def _extract_disk_from_layer(blob_path: Path, out_dir: Path) -> Optional[Path]:
 
     Returns the path to the extracted disk image, or ``None`` if the layer has none.
     """
-    chosen: Optional[Path] = None
+    chosen: Path | None = None
     chosen_size = -1
-    writing: Optional[Path] = None
+    writing: Path | None = None
     try:
         with open(blob_path, "rb") as raw, tarfile.open(fileobj=raw, mode="r|*") as tar:
             for member in tar:
@@ -363,7 +360,7 @@ def _extract_disk_from_layer(blob_path: Path, out_dir: Path) -> Optional[Path]:
     return chosen
 
 
-def _extract_embedded_disk(ref: str, manifest: dict, out_dir: Path) -> Optional[Path]:
+def _extract_embedded_disk(ref: str, manifest: dict, out_dir: Path) -> Path | None:
     """Extract the VM disk image embedded in a container image's layers.
 
     Layers are scanned from topmost to bottom (so an upper layer's disk wins);
@@ -463,7 +460,7 @@ def pull_oci_image(image_ref: str, out_dir: str) -> str:
     return str(disk)
 
 
-def _fetch_vmimage_metadata(ref: str, layers: list) -> Optional[VmImageMetadata]:
+def _fetch_vmimage_metadata(ref: str, layers: list) -> VmImageMetadata | None:
     """Best-effort fetch of the ``vmimage.json`` blob for inspection.
 
     Returns ``None`` if there is no such layer or the small blob cannot be
@@ -482,8 +479,7 @@ def _fetch_vmimage_metadata(ref: str, layers: list) -> Optional[VmImageMetadata]
         result = subprocess.run(
             ["oras", "blob", "fetch", f"{repo}@{digest}", "--output", "-"],
             check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
         )
     except FileNotFoundError:

--- a/src/boxman/providers/libvirt/oci_push.py
+++ b/src/boxman/providers/libvirt/oci_push.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 import os
 import subprocess
 from pathlib import Path
-from typing import Optional
 
 
 def push_oci_image(
     image_ref: str,
     qcow2_path: str,
-    metadata_path: Optional[str] = None,
+    metadata_path: str | None = None,
 ) -> None:
     """Push a local qcow2 image and optional metadata to an OCI registry.
 
@@ -40,7 +39,7 @@ def push_oci_image(
 def _oras_push(
     image_ref: str,
     qcow2_path: str,
-    metadata_path: Optional[str] = None,
+    metadata_path: str | None = None,
 ) -> None:
     """Push an OCI artifact to a registry using the oras CLI.
 
@@ -96,8 +95,7 @@ def _oras_push(
             cmd,
             cwd=str(work_dir),
             check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
         )
     except FileNotFoundError as exc:

--- a/src/boxman/providers/libvirt/session.py
+++ b/src/boxman/providers/libvirt/session.py
@@ -7,6 +7,7 @@ from xml.etree import ElementTree as ET
 
 from boxman import log
 
+from . import net_reconcile
 from .cdrom import CDROMManager
 from .clone_vm import CloneVM
 from .commands import VirshCommand
@@ -15,11 +16,10 @@ from .disk import DiskManager
 from .disk_cleanup import remove_vm_disks
 from .import_image import ImageImporter
 from .iso_boot_vm import IsoBootVM
-from . import net_reconcile
 from .net import Network, NetworkInterface
 from .shared_folder import SharedFolderManager
 from .snapshot import SnapshotManager
-from .storage import StorageManager, vm_disk_paths
+from .storage import StorageManager
 from .virsh_edit import VirshEdit
 
 
@@ -1497,7 +1497,7 @@ class LibVirtSession:
                     return False
 
                 # wait for the vm to shut down
-                for i in range(30):
+                for _i in range(30):
                     state_result = virsh.execute("domstate", vm_name, warn=True)
                     if state_result.ok and "shut off" in state_result.stdout:
                         break

--- a/src/boxman/scripts/app.py
+++ b/src/boxman/scripts/app.py
@@ -1,21 +1,19 @@
 #!/usr/bin/env python
 
-import argparse
 import logging
 import os
 import shutil
 import sys
-from argparse import RawTextHelpFormatter
 
 import yaml
 
 import boxman
 from boxman import log
 from boxman.exceptions import BoxmanError, ConfigError
+from boxman.loggers.logger import set_quiet, set_verbosity, suppressed
 from boxman.manager import BoxmanManager
 from boxman.providers import create_session, merge_provider_configs, primary_provider_type
 from boxman.providers.libvirt.import_image import ImageImporter
-from boxman.loggers.logger import set_quiet, set_verbosity, suppressed
 from boxman.scripts.cli_parser import parse_args, resolve_verbosity
 from boxman.utils.jinja_env import create_jinja_env
 

--- a/src/boxman/scripts/cli_parser.py
+++ b/src/boxman/scripts/cli_parser.py
@@ -18,7 +18,6 @@ import boxman
 from boxman.manager import BoxmanManager
 from boxman.providers import PROVIDERS
 
-
 #: Default snapshot name — current UTC timestamp formatted for display.
 #: Evaluated at module-import time (same semantics as the original
 #: module-level constant in app.py).

--- a/src/boxman/task_runner.py
+++ b/src/boxman/task_runner.py
@@ -86,7 +86,6 @@ from boxman import log
 from boxman.exceptions import ConfigError
 from boxman.utils.env_loader import load_workspace_env
 
-
 #: Names (VMs, clusters, hosts) that will be interpolated into a shell
 #: command must match this pattern. Alphanumerics, underscore, hyphen,
 #: dot — nothing that a shell treats specially. Rejects backticks,
@@ -184,7 +183,7 @@ class TaskRunner:
     def _log_env(self) -> None:
         """Log workspace environment variables at info level."""
         # Access self.env to ensure _workspace_vars is populated
-        self.env
+        _ = self.env
         for key in sorted(self._workspace_vars):
             log.info(f"  {key}={self._workspace_vars[key]}")
 

--- a/src/boxman/utils/references.py
+++ b/src/boxman/utils/references.py
@@ -22,7 +22,6 @@ import os
 import re
 from typing import Any
 
-
 _ENV_PATTERN = re.compile(r"\$\{env:(.+)\}")
 
 

--- a/src/boxman/utils/snapshot_graph.py
+++ b/src/boxman/utils/snapshot_graph.py
@@ -84,10 +84,10 @@ def _row_prefix(lanes: list[str | None], this_lane_idx: int) -> str:
     caller can append the row content directly.
     """
     chars: list[str] = []
-    for i, l in enumerate(lanes):
+    for i, lane in enumerate(lanes):
         if i == this_lane_idx:
             chars.append('*')
-        elif l is None:
+        elif lane is None:
             chars.append(' ')
         else:
             chars.append('|')

--- a/tests/test_bare_vm.py
+++ b/tests/test_bare_vm.py
@@ -11,7 +11,6 @@ import pytest
 
 from boxman.providers.libvirt.bare_vm import BareVM
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_boxman_conf.py
+++ b/tests/test_boxman_conf.py
@@ -4,14 +4,14 @@ Test that --boxman-conf overrides the default ~/.config/boxman/boxman.yml.
 
 import logging
 import os
-import tempfile
-import yaml
-import pytest
 import shutil as _shutil
 
-from boxman.scripts.app import load_boxman_config
-from boxman.manager import BoxmanManager
+import pytest
+import yaml
+
 from boxman.exceptions import ConfigError
+from boxman.manager import BoxmanManager
+from boxman.scripts.app import load_boxman_config
 
 
 class TestBoxmanConfOverride:
@@ -610,6 +610,7 @@ class TestWriteSshConfig:
 
     def test_docker_runtime_emits_jump_stanza_and_proxyjump(self, tmp_path):
         from unittest.mock import PropertyMock, patch
+
         from boxman.runtime.docker_compose import DockerComposeRuntime
 
         mgr = self._make_manager(tmp_path, runtime_name="docker-compose")
@@ -694,7 +695,6 @@ class TestNormalizeOwnership:
 
     def test_clean_user_owned_tree_is_a_noop(self, tmp_path, monkeypatch):
         """No foreign entries → no unlink, no sudo, nothing logged."""
-        from unittest.mock import patch
         (tmp_path / "a.txt").write_text("hi")
         (tmp_path / "sub").mkdir()
         (tmp_path / "sub" / "b.txt").write_text("hi")
@@ -722,7 +722,6 @@ class TestNormalizeOwnership:
     ):
         """Stale root-owned file inside user-writable dir → unlinked
         directly, no sudo escalation."""
-        from unittest.mock import patch
         stale = tmp_path / "seed.iso"
         stale.write_bytes(b"stale")
 
@@ -748,7 +747,7 @@ class TestNormalizeOwnership:
                 self.name = real.name
                 self._fake_uid = fake_uid
             def stat(self, follow_symlinks=False):
-                real_stat = self._real.stat(follow_symlinks=follow_symlinks)
+                self._real.stat(follow_symlinks=follow_symlinks)
                 # st_uid is read-only; build a tuple-like proxy.
                 class _Stat:
                     pass
@@ -1207,8 +1206,8 @@ class TestMainConfigErrorExit:
         """Phase 3: the wrapper now catches the whole BoxmanError family, so an
         operational failure on the docker-compose path (an unhealthy service →
         ProvisionError) exits 2 cleanly instead of dumping a traceback."""
-        from boxman.scripts import app
         from boxman.exceptions import ProvisionError
+        from boxman.scripts import app
 
         def _raise():
             raise ProvisionError('service never became healthy')

--- a/tests/test_check_prerequisites.py
+++ b/tests/test_check_prerequisites.py
@@ -477,7 +477,7 @@ def test_forwarding_verdict_bridge_match_is_not_a_substring():
 # --------------------------------------------------------------------------- #
 # disruptive fixes are never applied unattended                               #
 # --------------------------------------------------------------------------- #
-class _Opts(object):
+class _Opts:
     def __init__(self, yes=True, check_only=False):
         self.yes = yes
         self.check_only = check_only
@@ -710,17 +710,17 @@ def test_core_stack_covers_exactly_the_imperative_families():
 
 @pytest.mark.parametrize("family", ALL_FAMILIES)
 def test_seed_pkg_has_a_column_for_every_family(family):
-    assert family in checker._SEED_PKG, "missing _SEED_PKG column: %s" % family
-    assert checker._SEED_PKG[family], "empty _SEED_PKG entry: %s" % family
+    assert family in checker._SEED_PKG, f"missing _SEED_PKG column: {family}"
+    assert checker._SEED_PKG[family], f"empty _SEED_PKG entry: {family}"
 
 
 @pytest.mark.parametrize("tool", sorted(checker._TOOL_PKG))
 @pytest.mark.parametrize("family", ALL_FAMILIES)
 def test_tool_pkg_has_a_column_for_every_family(tool, family):
     assert family in checker._TOOL_PKG[tool], \
-        "missing _TOOL_PKG[%r] column: %s" % (tool, family)
+        f"missing _TOOL_PKG[{tool!r}] column: {family}"
     assert checker._TOOL_PKG[tool][family], \
-        "empty _TOOL_PKG[%r] entry: %s" % (tool, family)
+        f"empty _TOOL_PKG[{tool!r}] entry: {family}"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -23,7 +23,6 @@ import pytest
 import boxman.metadata
 from boxman.scripts.app import main, parse_args
 
-
 pytestmark = pytest.mark.smoke
 
 
@@ -153,6 +152,7 @@ class TestStorageDispatch:
 
     def test_storage_compact_rejects_bad_method(self):
         import pytest as _pytest
+
         from boxman.scripts.app import parse_args
         parser = parse_args()
         with _pytest.raises(SystemExit):
@@ -228,6 +228,7 @@ class TestStorageDispatch:
 
     def test_snapshot_collapse_requires_to(self):
         import pytest as _pytest
+
         from boxman.scripts.app import parse_args
         parser = parse_args()
         with _pytest.raises(SystemExit):

--- a/tests/test_cloudinit_presets.py
+++ b/tests/test_cloudinit_presets.py
@@ -21,7 +21,6 @@ from boxman.providers.libvirt.cloudinit_presets import (
     hash_password,
 )
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_config_cache.py
+++ b/tests/test_config_cache.py
@@ -19,7 +19,6 @@ import pytest
 
 from boxman.config_cache import BoxmanCache
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -6,6 +6,7 @@ Requires Docker with compose v2 and /dev/kvm on the host.
 
 import os
 import time
+
 import invoke
 import pytest
 
@@ -44,7 +45,7 @@ class TestDockerCompose:
         """SSH into the container and run a simple command."""
         max_attempts = 5
         last_err = None
-        for attempt in range(1, max_attempts + 1):
+        for _attempt in range(1, max_attempts + 1):
             result = _run('make ssh cmd="echo ok"', warn=True)
             if result.ok and "ok" in result.stdout:
                 return  # success

--- a/tests/test_docker_compose_provider_e2e.py
+++ b/tests/test_docker_compose_provider_e2e.py
@@ -68,6 +68,7 @@ def _workspace_path(box_dir):
     inventory / ssh_config / env.sh are written (a cluster ``workdir`` only
     holds that cluster's own files)."""
     import yaml
+
     from boxman.utils.jinja_env import create_jinja_env
 
     raw = open(os.path.join(box_dir, "conf.yml")).read()
@@ -350,11 +351,11 @@ class TestHybridVmContainer:
         bridge, while only the *shared* network is a macvlan onto the host
         bridge — so internal traffic never reaches the VM's L2 domain."""
         nets = _run("docker network ls --format '{{.Name}} {{.Driver}}'", warn=True).stdout
-        internal = [l for l in nets.splitlines() if "backend" in l]
+        internal = [line for line in nets.splitlines() if "backend" in line]
         assert internal, f"cluster-internal network not found in:\n{nets}"
         assert all(line.split()[1] == "bridge" for line in internal)
 
-        shared = [l for l in nets.splitlines() if "app_bridge" in l]
+        shared = [line for line in nets.splitlines() if "app_bridge" in line]
         assert shared, f"shared macvlan network not found in:\n{nets}"
         for line in shared:
             name = line.split()[0]

--- a/tests/test_exceptions_and_decorators.py
+++ b/tests/test_exceptions_and_decorators.py
@@ -20,7 +20,6 @@ from boxman.exceptions import (
 )
 from boxman.utils.decorators import safe_execute
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -172,7 +171,8 @@ class TestVirshEditRaisesProvisionError:
     not bare RuntimeError, on failure."""
 
     def test_runtime_error_is_wrapped_in_provision_error(self):
-        from unittest.mock import patch, MagicMock
+        from unittest.mock import patch
+
         from boxman.providers.libvirt.virsh_edit import VirshEdit
 
         editor = VirshEdit(provider_config={"use_sudo": False})

--- a/tests/test_file_provisioning.py
+++ b/tests/test_file_provisioning.py
@@ -3,15 +3,13 @@ Tests for file provisioning, deprovision (removal), env.sh skip behaviour,
 and extra_args_mode in TaskRunner.
 """
 
-import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from boxman.utils.io import write_files
 from boxman.manager import BoxmanManager
 from boxman.task_runner import TaskRunner
-
+from boxman.utils.io import write_files
 
 # ---------------------------------------------------------------------------
 # write_files: env.sh skip behaviour

--- a/tests/test_hostnames.py
+++ b/tests/test_hostnames.py
@@ -11,7 +11,6 @@ import pytest
 
 from boxman.utils.hostnames import expand_name_range
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -14,7 +14,6 @@ import pytest
 
 from boxman.image_cache import ImageCache
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_jinja_env.py
+++ b/tests/test_jinja_env.py
@@ -2,13 +2,12 @@
 Tests for boxman.utils.jinja_env – Jinja2 template helpers for env vars.
 """
 
-import os
 import pytest
 import yaml
 
 from boxman.exceptions import BoxmanError, ConfigError
-from boxman.utils.jinja_env import env, env_required, env_is_set, create_jinja_env
 from boxman.manager import BoxmanManager
+from boxman.utils.jinja_env import create_jinja_env, env, env_is_set, env_required
 
 
 class TestEnvFunction:

--- a/tests/test_libvirt_cdrom.py
+++ b/tests/test_libvirt_cdrom.py
@@ -14,7 +14,6 @@ import pytest
 
 from boxman.providers.libvirt.cdrom import CDROMManager
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_libvirt_clone_vm.py
+++ b/tests/test_libvirt_clone_vm.py
@@ -15,7 +15,6 @@ import pytest
 from boxman.providers.libvirt.clone_vm import CloneVM
 from boxman.providers.libvirt.session import LibVirtSession
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_libvirt_cloudinit.py
+++ b/tests/test_libvirt_cloudinit.py
@@ -21,9 +21,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from boxman.providers.libvirt.cloudinit import (
-    CloudInitTemplate, DEFAULT_USER_DATA, DEFAULT_META_DATA, DEFAULT_DONE_MARKER,
+    DEFAULT_DONE_MARKER,
+    DEFAULT_META_DATA,
+    DEFAULT_USER_DATA,
+    CloudInitTemplate,
 )
-
 
 pytestmark = pytest.mark.unit
 

--- a/tests/test_libvirt_destroy_vm.py
+++ b/tests/test_libvirt_destroy_vm.py
@@ -13,7 +13,6 @@ import pytest
 
 from boxman.providers.libvirt.destroy_vm import DestroyVM
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_libvirt_disk_cleanup.py
+++ b/tests/test_libvirt_disk_cleanup.py
@@ -17,7 +17,6 @@ import pytest
 
 from boxman.providers.libvirt.disk_cleanup import remove_vm_disks
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_libvirt_import_image.py
+++ b/tests/test_libvirt_import_image.py
@@ -15,7 +15,6 @@ import pytest
 
 from boxman.providers.libvirt.import_image import ImageImporter
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_libvirt_net.py
+++ b/tests/test_libvirt_net.py
@@ -19,7 +19,6 @@ import pytest
 
 from boxman.providers.libvirt.net import Network, NetworkInterface
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_libvirt_oci_pull.py
+++ b/tests/test_libvirt_oci_pull.py
@@ -25,7 +25,6 @@ from boxman.providers.libvirt.oci_pull import (
     pull_oci_image,
 )
 
-
 pytestmark = pytest.mark.unit
 
 # Embedded containerDisk disks are validated as qcow2 by content, so fake disks
@@ -685,6 +684,7 @@ class TestOciCacheUrl:
     def test_distinct_registries_same_tail_do_not_collide(self):
         import os
         from urllib.parse import urlparse
+
         from boxman.providers.libvirt.cloudinit import CloudInitTemplate
 
         a = CloudInitTemplate._oci_cache_url("oci://regA/team1/ubuntu:latest")

--- a/tests/test_libvirt_oci_push.py
+++ b/tests/test_libvirt_oci_push.py
@@ -10,7 +10,6 @@ unittest.TestCase → pytest style.
 from __future__ import annotations
 
 import os
-import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -19,7 +18,6 @@ import pytest
 
 from boxman.manager import BoxmanManager
 from boxman.providers.libvirt.oci_push import push_oci_image
-
 
 pytestmark = pytest.mark.unit
 

--- a/tests/test_libvirt_session.py
+++ b/tests/test_libvirt_session.py
@@ -26,7 +26,6 @@ import pytest
 
 from boxman.providers.libvirt.session import LibVirtSession
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_libvirt_shared_folder.py
+++ b/tests/test_libvirt_shared_folder.py
@@ -14,7 +14,6 @@ import pytest
 
 from boxman.providers.libvirt.shared_folder import SharedFolderManager
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_libvirt_snapshot.py
+++ b/tests/test_libvirt_snapshot.py
@@ -19,7 +19,6 @@ import pytest
 
 from boxman.providers.libvirt.snapshot import SnapshotManager
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_libvirt_storage.py
+++ b/tests/test_libvirt_storage.py
@@ -13,7 +13,6 @@ Covers:
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -21,7 +20,6 @@ import pytest
 
 from boxman.providers.libvirt.destroy_vm import DestroyVM
 from boxman.providers.libvirt.storage import StorageManager, vm_disk_paths
-
 
 pytestmark = pytest.mark.unit
 

--- a/tests/test_lifecycle_e2e.py
+++ b/tests/test_lifecycle_e2e.py
@@ -29,13 +29,11 @@ from __future__ import annotations
 import os
 import time
 from pathlib import Path
-from unittest.mock import patch
 
 import invoke
 import pytest
 
 from boxman.manager import BoxmanManager
-
 
 pytestmark = [pytest.mark.integration, pytest.mark.slow]
 
@@ -111,7 +109,7 @@ def _ssh(host: str, cmd: str, ssh_config: Path, warn: bool = False) -> invoke.ru
 def _wait_for_ssh(host: str, ssh_config: Path, max_attempts: int = 20) -> None:
     """Wait until *host* accepts SSH. Raises on timeout."""
     last_err = ""
-    for attempt in range(1, max_attempts + 1):
+    for _attempt in range(1, max_attempts + 1):
         result = _ssh(host, "hostname", ssh_config, warn=True)
         if result.ok and result.stdout.strip():
             return

--- a/tests/test_manager_core.py
+++ b/tests/test_manager_core.py
@@ -20,7 +20,6 @@ Part of Phase 1.2 of the review plan
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -28,7 +27,6 @@ import pytest
 
 from boxman.manager import BoxmanManager
 from boxman.providers import merge_provider_configs
-
 
 pytestmark = pytest.mark.unit
 
@@ -86,10 +84,10 @@ class TestMergeProviderConfigs:
 
     def test_does_not_mutate_inputs(self):
         g = {"sudo_skip_commands": ["ls"]}
-        l = {"sudo_skip_commands": ["cat"]}
-        merge_provider_configs(g, l)
+        local = {"sudo_skip_commands": ["cat"]}
+        merge_provider_configs(g, local)
         assert g == {"sudo_skip_commands": ["ls"]}
-        assert l == {"sudo_skip_commands": ["cat"]}
+        assert local == {"sudo_skip_commands": ["cat"]}
 
 
 class TestCanonicalRuntimeName:
@@ -289,7 +287,8 @@ class TestCheckTemplatesForClusters:
 
     @staticmethod
     def _mgr_with_template(tmp_path: Path):
-        from unittest.mock import MagicMock, patch as _patch
+        from unittest.mock import MagicMock
+        from unittest.mock import patch as _patch
         with _patch("boxman.manager.BoxmanCache"):
             m = BoxmanManager()
         m.config = {
@@ -433,7 +432,8 @@ class TestCloneAndConfigureNewVmsExitCodeGuard:
         return proc
 
     def _mgr_with_one_vm(self, tmp_path: Path):
-        from unittest.mock import MagicMock, patch as _patch
+        from unittest.mock import MagicMock
+        from unittest.mock import patch as _patch
         with _patch("boxman.manager.BoxmanCache"):
             m = BoxmanManager()
         m.config = {

--- a/tests/test_net_reconcile.py
+++ b/tests/test_net_reconcile.py
@@ -25,7 +25,6 @@ import pytest
 from boxman.providers.libvirt import net_reconcile as nr
 from boxman.providers.libvirt.net import Network
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_netlab_cli.py
+++ b/tests/test_netlab_cli.py
@@ -14,7 +14,6 @@ import pytest
 from boxman.manager import BoxmanManager
 from boxman.scripts.app import main, parse_args
 
-
 pytestmark = pytest.mark.smoke
 
 

--- a/tests/test_netlab_containerlab.py
+++ b/tests/test_netlab_containerlab.py
@@ -20,7 +20,6 @@ from boxman.netlab.containerlab import (
 )
 from boxman.utils.jinja_env import create_jinja_env
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_netlab_shared_bridges.py
+++ b/tests/test_netlab_shared_bridges.py
@@ -15,7 +15,6 @@ import pytest
 from boxman.exceptions import ConfigError
 from boxman.netlab import shared_bridges
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_network_reconcile_integration.py
+++ b/tests/test_network_reconcile_integration.py
@@ -49,7 +49,6 @@ import yaml
 from boxman.manager import BoxmanManager
 from boxman.providers.libvirt.session import LibVirtSession
 
-
 pytestmark = pytest.mark.integration
 
 URI = os.environ.get("BOXMAN_IT_URI", "qemu:///system")

--- a/tests/test_oci_base_image_expand.py
+++ b/tests/test_oci_base_image_expand.py
@@ -13,7 +13,6 @@ import pytest
 
 from boxman.manager import BoxmanManager
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_provider_protocol.py
+++ b/tests/test_provider_protocol.py
@@ -17,7 +17,6 @@ from boxman.abstract.providers import Provider, ProviderSession
 from boxman.providers.libvirt.session import LibVirtSession
 from boxman.providers.virtualbox.session import VirtualBoxSession
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_pxe_session.py
+++ b/tests/test_pxe_session.py
@@ -7,14 +7,12 @@ Unit tests for PXE-related methods added to LibVirtSession:
 
 from __future__ import annotations
 
-import socket
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from lxml import etree
 
 from boxman.providers.libvirt.session import LibVirtSession
-
 
 pytestmark = pytest.mark.unit
 

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -18,7 +18,6 @@ import pytest
 
 from boxman.utils.references import resolve_reference
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -26,7 +26,6 @@ from boxman.providers.libvirt.shared_folder import SharedFolderManager
 from boxman.providers.libvirt.snapshot import SnapshotManager
 from boxman.runtime.docker_compose import DockerComposeRuntime
 
-
 pytestmark = pytest.mark.regression
 
 
@@ -45,7 +44,7 @@ def _result(stdout: str = "", ok: bool = True, stderr: str = "", return_code: in
 #           batched sudo rsync before revert
 # ---------------------------------------------------------------------------
 
-class TestSnapshotOverlayPreservation_057eb7d:
+class TestSnapshotOverlayPreservation057eb7d:
 
     def test_revert_order_is_preserve_then_revert_then_restore(self):
         """Regression: libvirt deletes the *current* snapshot's overlay
@@ -108,7 +107,7 @@ class TestSnapshotOverlayPreservation_057eb7d:
 # 5e96515 — ssh proxyjump for docker runtime
 # ---------------------------------------------------------------------------
 
-class TestDockerRuntimeSshProxyJump_5e96515:
+class TestDockerRuntimeSshProxyJump5e96515:
 
     def test_no_jump_stanza_for_local_runtime(self, tmp_path: Path):
         mgr = BoxmanManager()
@@ -166,7 +165,7 @@ class TestDockerRuntimeSshProxyJump_5e96515:
 # eca430e — multi-project port isolation for docker runtime
 # ---------------------------------------------------------------------------
 
-class TestMultiProjectPortIsolation_eca430e:
+class TestMultiProjectPortIsolationEca430e:
 
     def test_default_project_maps_to_offset_zero(self):
         """Legacy single-project setups must keep 2222/16509/16514."""
@@ -197,7 +196,7 @@ class TestMultiProjectPortIsolation_eca430e:
 # 380b776 — allow excluding some commands from sudo
 # ---------------------------------------------------------------------------
 
-class TestSudoSkipCommands_380b776:
+class TestSudoSkipCommands380b776:
 
     def test_skip_list_wins_over_use_sudo_true(self):
         cmd = LibVirtCommandBase(provider_config={
@@ -261,7 +260,7 @@ class TestRmNeverSudo:
 # 36a8a6b — shared folder + cdrom hotplug
 # ---------------------------------------------------------------------------
 
-class TestCdromHotplug_36a8a6b:
+class TestCdromHotplug36a8a6b:
 
     def test_attach_uses_persistent_flag_not_config_only(self, tmp_path: Path):
         """Live+persistent hotplug means `--persistent` (defaults to runtime
@@ -281,7 +280,7 @@ class TestCdromHotplug_36a8a6b:
         assert "--config" not in args
 
 
-class TestSharedFolderHotplug_36a8a6b:
+class TestSharedFolderHotplug36a8a6b:
 
     def test_tries_live_persistent_before_config_fallback(self, tmp_path: Path):
         """Live attach first; only fall back to --config when live fails.
@@ -327,7 +326,7 @@ class TestSharedFolderHotplug_36a8a6b:
 # ece550a — per-VM base image override
 # ---------------------------------------------------------------------------
 
-class TestPerVmBaseImage_ece550a:
+class TestPerVmBaseImageEce550a:
     """
     Regression: base images can be specified at the VM level to override
     the cluster-wide template.base_image. The override must work when both
@@ -368,7 +367,6 @@ class TestDestroyReadsProjectCache:
 
     def test_destroy_loads_cache_before_in_cache_check(self, tmp_path: Path, capsys):
         import json as _json
-        import os as _os
 
         # Build a cache that already contains our project
         cache_dir = tmp_path / "cache"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3,13 +3,14 @@ Tests for boxman.runtime – runtime factory, wrapping, and config injection.
 """
 
 import shlex
+from unittest.mock import MagicMock, patch
 
 import pytest
-from unittest.mock import patch, MagicMock
+
 from boxman.exceptions import BoxmanError, ConfigError
 from boxman.runtime import create_runtime
-from boxman.runtime.local import LocalRuntime
 from boxman.runtime.docker_compose import DockerComposeRuntime
+from boxman.runtime.local import LocalRuntime
 
 
 class TestCreateRuntime:
@@ -1084,9 +1085,10 @@ class TestDockerComposeRuntimeBridgeConflict:
     def test_cache_filtering_by_runtime(self):
         """Projects registered under a different runtime should be ignored
         during conflict checks."""
+        from unittest.mock import MagicMock, patch
+
         from boxman.manager import BoxmanManager
         from boxman.providers.libvirt.net import Network
-        from unittest.mock import MagicMock, patch
 
         mgr = BoxmanManager()
         mgr._runtime_name = 'docker-compose'
@@ -1123,9 +1125,10 @@ class TestDockerComposeRuntimeBridgeConflict:
 
     def test_cache_conflict_same_runtime(self):
         """Projects in the same runtime SHOULD trigger conflicts."""
+        from unittest.mock import MagicMock, patch
+
         from boxman.manager import BoxmanManager
         from boxman.providers.libvirt.net import Network
-        from unittest.mock import MagicMock, patch
 
         mgr = BoxmanManager()
         mgr._runtime_name = 'docker-compose'

--- a/tests/test_snapshot_graph.py
+++ b/tests/test_snapshot_graph.py
@@ -17,7 +17,6 @@ from boxman.utils.snapshot_graph import (
     render_graph,
 )
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -3,19 +3,15 @@ Tests for boxman.utils.env_loader and boxman.task_runner.
 """
 
 import os
-import stat
-import subprocess
-import textwrap
 import types
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from boxman.exceptions import BoxmanError, ConfigError
-from boxman.utils.env_loader import source_env_file, load_workspace_env
-from boxman.task_runner import TaskRunner
 from boxman.manager import BoxmanManager
-
+from boxman.task_runner import TaskRunner
+from boxman.utils.env_loader import load_workspace_env, source_env_file
 
 # ---------------------------------------------------------------------------
 # env_loader tests
@@ -291,10 +287,9 @@ class TestTaskRunner:
         assert out_file.read_text().strip() == "test_inventory"
 
     def test_run_task_with_extra_args(self, basic_config, tmp_path):
-        out_file = tmp_path / "args_out.txt"
         basic_config["tasks"]["echo_args"] = {
             "description": "echo args",
-            "command": f"echo",
+            "command": "echo",
         }
         runner = TaskRunner(basic_config)
         exit_code = runner.run("echo_args", extra_args=["hello", "world"])

--- a/tests/test_task_runner_security.py
+++ b/tests/test_task_runner_security.py
@@ -18,7 +18,6 @@ import pytest
 
 from boxman.task_runner import SAFE_NAME_RE, TaskRunner, _validate_safe_name
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_utils_shell.py
+++ b/tests/test_utils_shell.py
@@ -16,7 +16,6 @@ import pytest
 
 from boxman.utils.shell import run as shell_run
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/test_virtualbox_provider.py
+++ b/tests/test_virtualbox_provider.py
@@ -19,7 +19,7 @@ All external calls are mocked — no VBoxManage is invoked on any host.
 from __future__ import annotations
 
 import subprocess
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -28,7 +28,6 @@ from boxman.exceptions import ConfigError
 from boxman.providers.virtualbox import VirtualBoxSession as VirtualBoxSessionExport
 from boxman.providers.virtualbox.commands import VBoxManageCommand
 from boxman.providers.virtualbox.session import VirtualBoxSession
-
 
 pytestmark = pytest.mark.unit
 


### PR DESCRIPTION
Refs #85 (item 40).

`ruff check src tests scripts` before: **230 errors** (111 auto-fixable). After: **8 errors**, none auto-fixable.

## What was done
- `ruff check --fix`: 114 safe autofixes (I001 import sorting, F401 unused imports, UP045/UP037/UP004/UP035/UP021/UP034 pyupgrade, F541, F841).
- Manual mechanical fixes, all behavior-preserving:
  - F401/F841/I001/B007 cleared everywhere (B007 loop vars renamed to `_`-prefixed).
  - `src/boxman/__init__.py` F401: intentional re-export (`log`, `metadata`) — kept, declared via `__all__`.
  - N806: ANSI helper constants in `manager.py` list-projects function lowercased.
  - N801: 7 regression test classes renamed to CapWords (e.g. `TestCdromHotplug_36a8a6b` → `TestCdromHotplug36a8a6b`); no external references.
  - B904: `raise ... from None`/`from exc` added at 5 sites where messages are self-contained.
  - E741 (`l`), B018, UP022 (`capture_output=True`) fixed.
  - UP031 (65): all %-formatting in `scripts/installer/check_prerequisites.py` (61) and `tests/test_check_prerequisites.py` (4) converted to f-strings/.format with identical output semantics (output-asserting tests confirm).

## Remaining violations (8) — deliberate leaves, one-line reason each
- `N818 src/boxman/exceptions.py:49` `RuntimeUnavailable` — public exception name; renaming is an API change, needs a deprecation pass.
- `N818 src/boxman/netlab/containerlab.py:30` `ContainerlabNotInstalled` — same reason.
- `B027 src/boxman/runtime/base.py:31` `ensure_ready` — intentionally a concrete no-op default; `@abstractmethod` would break subclasses that don't override.
- `UP036 scripts/installer/check_prerequisites.py:793` — standalone installer script that may run on end-user Python < 3.10; the version check is live there, ruff's `target-version = py310` assumption doesn't apply. Follow-up candidate: per-file noqa.
- `B905 src/boxman/manager.py:3311,6116,6119,6333` `zip()` without `strict=` — can't statically prove equal lengths; `strict=True` risks behavior change, `strict=False` is pure noise.

## Verification
- `pytest tests -q`: **1852 passed, 141 deselected** — run twice, both green (baseline was identical).
- No ruff config changes; no new rules enabled.

## CI note
PR #127 added `ruff check src tests scripts` to CI. Until this PR merges, the lint job is red; after merge it will still be red on the 8 violations above — that is intended: they're itemized follow-ups, and silencing them (noqa/per-file-ignores) is a separate decision.