### PR TITLE
refactor: shared virsh-output parsers with golden fixtures (#85 item 32)

### DIFF
--- a/src/boxman/manager.py
+++ b/src/boxman/manager.py
@@ -24,6 +24,7 @@ from boxman.netlab import ContainerlabManager, shared_bridges
 from boxman.providers import PROVIDERS, merge_provider_configs, primary_provider_type
 from boxman.providers.libvirt import net_reconcile
 from boxman.providers.libvirt.commands import VirshCommand
+from boxman.providers.libvirt.virsh_parse import parse_domblklist
 from boxman.runtime import RuntimeBase, create_runtime
 from boxman.task_runner import TaskRunner
 from boxman.utils.io import write_files
@@ -3464,12 +3465,9 @@ class BoxmanManager:
             "domblklist", full_vm_name, "--details", warn=True)
         dirs = set()
         if result.ok:
-            for line in result.stdout.splitlines():
-                # domblklist --details columns: Type  Device  Target  Source
-                # maxsplit=3 so disk paths containing spaces survive
-                parts = line.split(None, 3)
-                if len(parts) >= 4 and parts[1] == 'disk' and parts[3] != '-':
-                    dirs.add(os.path.dirname(parts[3]))
+            for row in parse_domblklist(result.stdout):
+                if row.device == 'disk' and row.source not in (None, '-'):
+                    dirs.add(os.path.dirname(row.source))
         if not dirs:
             self.logger.warning(
                 f"could not query disk paths for {full_vm_name} from "

--- a/src/boxman/providers/libvirt/cdrom.py
+++ b/src/boxman/providers/libvirt/cdrom.py
@@ -4,6 +4,7 @@ from typing import Any
 from xml.sax.saxutils import escape
 
 from .commands import VirshCommand
+from .virsh_parse import parse_domblklist
 
 
 def _xml_attr(value: str) -> str:
@@ -192,17 +193,10 @@ class CDROMManager(VirshCommand):
             return []
 
         cdroms = []
-        lines = result.stdout.strip().split('\n')
-        for line in lines[2:]:
-            parts = line.split()
-            if len(parts) < 3:
+        for row in parse_domblklist(result.stdout):
+            if row.device != 'cdrom':
                 continue
-            device = parts[1]
-            target = parts[2]
-            source = parts[3] if len(parts) >= 4 else '-'
-
-            if device != 'cdrom':
-                continue
+            source = row.source or '-'
             if source == '-':
                 continue
             # exclude seed ISOs (cloud-init)
@@ -210,7 +204,7 @@ class CDROMManager(VirshCommand):
                 continue
 
             cdroms.append({
-                'target': target,
+                'target': row.target,
                 'source': source,
             })
 
@@ -262,11 +256,7 @@ class CDROMManager(VirshCommand):
 
         used_targets = set()
         if result.ok:
-            lines = result.stdout.strip().split('\n')
-            for line in lines[2:]:
-                parts = line.split()
-                if len(parts) >= 3:
-                    used_targets.add(parts[2])
+            used_targets = {row.target for row in parse_domblklist(result.stdout)}
 
         # IDE supports hda-hdd (4 devices)
         for suffix in ('a', 'b', 'c', 'd'):

--- a/src/boxman/providers/libvirt/clone_vm.py
+++ b/src/boxman/providers/libvirt/clone_vm.py
@@ -4,6 +4,7 @@ from typing import Any
 from boxman import log
 
 from .commands import VirshCommand, VirtCloneCommand
+from .virsh_parse import parse_domiflist
 
 
 class CloneVM:
@@ -109,21 +110,10 @@ class CloneVM:
                 return False
 
             # parse the output to extract interface information
-            # output format is like:
-            # Interface  Type       Source     Model       MAC
-            # -------------------------------------------------------
-            # vnet0      network    default    virtio      52:54:00:xx:xx:xx
-
-            interfaces = []
-            lines = result.stdout.strip().split('\n')
-            if len(lines) > 2:  # Skip header and separator lines
-                for line in lines[2:]:
-                    parts = line.split()
-                    if len(parts) >= 5:  # Interface Type Source Model MAC
-                        iface_type = parts[1]
-                        source = parts[2]
-                        mac = parts[4]
-                        interfaces.append((iface_type, source, mac))
+            interfaces = [
+                (row.type, row.source, row.mac)
+                for row in parse_domiflist(result.stdout)
+            ]
 
             self.logger.info(
                 f"found {len(interfaces)} network interfaces to remove from the vm {vm_name}")

--- a/src/boxman/providers/libvirt/cloudinit.py
+++ b/src/boxman/providers/libvirt/cloudinit.py
@@ -44,6 +44,7 @@ from .cloudinit_presets import (
     hash_password as _hash_password,
 )
 from .commands import VirshCommand, VirtInstallCommand
+from .virsh_parse import parse_domblklist
 
 
 class CloudInitTemplate:
@@ -1041,11 +1042,9 @@ class CloudInitTemplate:
         blklist = self.virsh.execute(
             "domblklist", self.template_name, "--details", warn=True)
         if blklist.ok:
-            for line in blklist.stdout.splitlines():
-                parts = line.split()
-                # columns: Type  Device  Target  Source
-                if len(parts) >= 4 and parts[1] == 'cdrom':
-                    target, source = parts[2], parts[3]
+            for row in parse_domblklist(blklist.stdout):
+                if row.device == 'cdrom' and row.source is not None:
+                    target, source = row.target, row.source
                     if os.path.basename(source).startswith('seed'):
                         self.logger.info(
                             f"ejecting seed cdrom '{target}' from template "

--- a/src/boxman/providers/libvirt/net.py
+++ b/src/boxman/providers/libvirt/net.py
@@ -14,6 +14,7 @@ from boxman import log
 
 from . import net_reconcile
 from .commands import VirshCommand
+from .virsh_parse import parse_domiflist
 
 
 class Network(VirshCommand):
@@ -583,10 +584,8 @@ class Network(VirshCommand):
                 "domiflist", domain, hide=True, warn=True)
             if not iflist.ok:
                 continue
-            for line in iflist.stdout.splitlines():
-                fields = line.split()
-                # columns: Interface Type Source Model MAC
-                if len(fields) >= 3 and fields[1] == 'network' and fields[2] == self.name:
+            for row in parse_domiflist(iflist.stdout):
+                if row.type == 'network' and row.source == self.name:
                     attached.append(domain)
                     break
         return attached

--- a/src/boxman/providers/libvirt/session.py
+++ b/src/boxman/providers/libvirt/session.py
@@ -21,6 +21,7 @@ from .shared_folder import SharedFolderManager
 from .snapshot import SnapshotManager
 from .storage import StorageManager
 from .virsh_edit import VirshEdit
+from .virsh_parse import parse_domblklist, parse_domiflist
 
 
 class LibVirtSession:
@@ -188,11 +189,9 @@ class LibVirtSession:
             return 'failed'
 
         interfaces = []
-        for line in iflist.stdout.splitlines():
-            fields = line.split()
-            # columns: Interface Type Source Model MAC
-            if len(fields) >= 5 and fields[1] == 'network' and fields[2] == network_name:
-                interfaces.append({'model': fields[3], 'mac': fields[4]})
+        for row in parse_domiflist(iflist.stdout):
+            if row.type == 'network' and row.source == network_name:
+                interfaces.append({'model': row.model, 'mac': row.mac})
 
         if not interfaces:
             return 'skipped'
@@ -1270,12 +1269,10 @@ class LibVirtSession:
         result = virsh.execute("domblklist", vm_name, "--details", warn=True)
         if not result.ok:
             return
-        for line in result.stdout.splitlines():
-            parts = line.split()
-            # domblklist --details columns: Type  Device  Target  Source
-            if len(parts) >= 3 and parts[1] == 'cdrom':
-                target = parts[2]
-                source = parts[3] if len(parts) >= 4 else '-'
+        for row in parse_domblklist(result.stdout):
+            if row.device == 'cdrom':
+                target = row.target
+                source = row.source if row.source is not None else '-'
                 if source == '-':
                     self.logger.debug(f"cdrom {target} on {vm_name} is already empty")
                     continue

--- a/src/boxman/providers/libvirt/snapshot.py
+++ b/src/boxman/providers/libvirt/snapshot.py
@@ -13,6 +13,7 @@ from xml.etree import ElementTree as ET
 from boxman import log
 
 from .commands import VirshCommand
+from .virsh_parse import parse_domblklist
 
 
 class SnapshotManager:
@@ -133,11 +134,9 @@ class SnapshotManager:
         if not result.ok:
             return []
         args = []
-        for line in result.stdout.splitlines():
-            parts = line.split()
-            # domblklist --details columns: Type  Device  Target  Source
-            if len(parts) >= 3 and parts[1] == 'cdrom':
-                args.extend(["--diskspec", f"{parts[2]},snapshot=no"])
+        for row in parse_domblklist(result.stdout):
+            if row.device == 'cdrom':
+                args.extend(["--diskspec", f"{row.target},snapshot=no"])
         return args
 
     def create_snapshot(self,
@@ -1094,14 +1093,10 @@ class SnapshotManager:
         if not result.ok:
             return []
         disks: list[tuple[str, str]] = []
-        for line in result.stdout.splitlines():
-            parts = line.split()
-            if len(parts) < 4:
+        for row in parse_domblklist(result.stdout):
+            if row.device != 'disk' or row.source is None:
                 continue
-            # columns: Type Device Target Source
-            if parts[1] != 'disk':
-                continue
-            disks.append((parts[2], parts[3]))
+            disks.append((row.target, row.source))
         return disks
 
     def _overlay_path_for_snapshot(self,

--- a/src/boxman/providers/libvirt/virsh_parse.py
+++ b/src/boxman/providers/libvirt/virsh_parse.py
@@ -1,0 +1,93 @@
+"""
+Shared parsers for ``virsh`` tabular output.
+
+``virsh domblklist --details`` and ``virsh domiflist`` print fixed-column
+tables with a header row and a dashed separator row.  The parsers below
+skip both, tolerate empty output, and — for ``domblklist`` — split the
+Source column with ``maxsplit=3`` so disk paths containing spaces survive
+(a trailing ``-`` printed by virsh for an empty source is kept verbatim;
+a genuinely missing column comes back as ``None``).
+"""
+
+from typing import NamedTuple
+
+
+class DomblkRow(NamedTuple):
+    """One row of ``virsh domblklist --details`` output."""
+
+    type: str          # file, block, ...
+    device: str        # disk, cdrom, ...
+    target: str        # vda, hda, ...
+    source: str | None  # path, '-' for an empty slot, None if column missing
+
+
+class DomifRow(NamedTuple):
+    """One row of ``virsh domiflist`` output."""
+
+    interface: str     # vnet0, ...
+    type: str          # network, bridge, direct, ...
+    source: str        # network/bridge name
+    model: str         # virtio, ...
+    mac: str
+
+
+def parse_domblklist(output: str) -> list[DomblkRow]:
+    """
+    Parse ``virsh domblklist --details`` output into rows.
+
+    Header and separator lines are skipped, as are lines with fewer than
+    three columns.  The Source column is split with ``maxsplit=3`` so
+    paths containing spaces survive; a missing Source column yields
+    ``None`` (virsh prints ``-`` for an empty slot, which is kept as-is).
+    """
+    rows = []
+    for line in output.splitlines():
+        if _is_header_or_separator(line):
+            continue
+        parts = line.split(None, 3)
+        if len(parts) < 3:
+            continue
+        rows.append(DomblkRow(
+            type=parts[0],
+            device=parts[1],
+            target=parts[2],
+            source=parts[3] if len(parts) >= 4 else None,
+        ))
+    return rows
+
+
+def parse_domiflist(output: str) -> list[DomifRow]:
+    """
+    Parse ``virsh domiflist`` output into rows.
+
+    Header and separator lines are skipped, as are lines with fewer than
+    three columns; rows short of the full five columns are padded with
+    ``-`` so callers can read any column uniformly.
+    """
+    rows = []
+    for line in output.splitlines():
+        if _is_header_or_separator(line):
+            continue
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        parts += ['-'] * (5 - len(parts))
+        rows.append(DomifRow(
+            interface=parts[0],
+            type=parts[1],
+            source=parts[2],
+            model=parts[3],
+            mac=parts[4],
+        ))
+    return rows
+
+
+def _is_header_or_separator(line: str) -> bool:
+    """True for the table's header row and its dashed separator row."""
+    stripped = line.strip()
+    if not stripped:
+        return True
+    if set(stripped) <= {'-', ' '}:
+        return True
+    first = stripped.split(None, 1)[0]
+    return first in ('Type', 'Device', 'Target', 'Source', 'Interface')

--- a/src/boxman/providers/libvirt/vm_differ.py
+++ b/src/boxman/providers/libvirt/vm_differ.py
@@ -5,6 +5,7 @@ from boxman import log
 
 from .commands import VirshCommand
 from .virsh_edit import VirshEdit
+from .virsh_parse import parse_domblklist
 
 
 class VMStateDiffer:
@@ -131,23 +132,16 @@ class VMStateDiffer:
             return []
 
         disks = []
-        lines = result.stdout.strip().split('\n')
-        # skip header lines (Type Device Target Source)
-        for line in lines[2:]:
-            parts = line.split()
-            if len(parts) < 4:
+        for row in parse_domblklist(result.stdout):
+            if row.device != 'disk' or row.type != 'file':
                 continue
-            disk_type = parts[0]   # file, block, etc.
-            device = parts[1]      # disk, cdrom
-            target = parts[2]      # vda, vdb, hda, sda
-            source = parts[3]      # /path/to/file or -
-
-            if device != 'disk' or disk_type != 'file' or source == '-':
+            source = row.source
+            if source is None or source == '-':
                 continue
 
-            size_mb = self._get_disk_size_mb(domain_name, target)
+            size_mb = self._get_disk_size_mb(domain_name, row.target)
             disks.append({
-                'target': target,
+                'target': row.target,
                 'source': source,
                 'size_mb': size_mb
             })
@@ -213,24 +207,17 @@ class VMStateDiffer:
             return []
 
         cdroms = []
-        lines = result.stdout.strip().split('\n')
-        for line in lines[2:]:
-            parts = line.split()
-            if len(parts) < 3:
+        for row in parse_domblklist(result.stdout):
+            if row.device != 'cdrom':
                 continue
-            device = parts[1]
-            target = parts[2]
-            source = parts[3] if len(parts) >= 4 else '-'
-
-            if device != 'cdrom':
-                continue
-            if source == '-':
+            source = row.source
+            if source is None or source == '-':
                 continue
             if os.path.basename(source).startswith('seed'):
                 continue
 
             cdroms.append({
-                'target': target,
+                'target': row.target,
                 'source': source,
             })
 

--- a/tests/test_virsh_parse.py
+++ b/tests/test_virsh_parse.py
@@ -1,0 +1,115 @@
+"""
+Golden-output tests for boxman.providers.libvirt.virsh_parse.
+
+The fixtures are realistic ``virsh domblklist --details`` / ``virsh
+domiflist`` captures, including the edge cases the shared parsers were
+built for (#85 item 32): disk paths containing spaces, empty device
+lists, cdrom entries with and without media.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from boxman.providers.libvirt.virsh_parse import (
+    DomblkRow,
+    DomifRow,
+    parse_domblklist,
+    parse_domiflist,
+)
+
+pytestmark = pytest.mark.unit
+
+DOMBLKLIST_GOLDEN = """\
+ Type   Device   Target   Source
+------------------------------------------------
+ file   disk     vda      /var/lib/libvirt/images/boxman-vm01.qcow2
+ file   disk     vdb      /vm images/boxman-vm01_data with spaces.qcow2
+ file   cdrom    hda      /var/lib/libvirt/images/seed-vm01.iso
+ file   cdrom    hdb      -
+ block  disk     vdc      /dev/sdb1
+"""
+
+DOMBLKLIST_EMPTY = """\
+ Type   Device   Target   Source
+------------------------------------------------
+"""
+
+DOMBLKLIST_HEADER_ONLY_NO_SEPARATOR = """\
+Type   Device  Target  Source
+file   cdrom   hdc     /iso/seed.iso
+file   disk    vda     /vms/vm.qcow2
+"""
+
+DOMIFLIST_GOLDEN = """\
+Interface   Type       Source     Model       MAC
+------------------------------------------------------
+vnet0       network    default    virtio      52:54:00:aa:bb:cc
+vnet1       bridge     br0        virtio      52:54:00:aa:bb:dd
+"""
+
+DOMIFLIST_EMPTY = """\
+Interface   Type       Source     Model       MAC
+------------------------------------------------------
+"""
+
+
+class TestParseDomblklist:
+
+    def test_parses_all_rows(self):
+        rows = parse_domblklist(DOMBLKLIST_GOLDEN)
+        assert rows == [
+            DomblkRow('file', 'disk', 'vda',
+                      '/var/lib/libvirt/images/boxman-vm01.qcow2'),
+            DomblkRow('file', 'disk', 'vdb',
+                      '/vm images/boxman-vm01_data with spaces.qcow2'),
+            DomblkRow('file', 'cdrom', 'hda',
+                      '/var/lib/libvirt/images/seed-vm01.iso'),
+            DomblkRow('file', 'cdrom', 'hdb', '-'),
+            DomblkRow('block', 'disk', 'vdc', '/dev/sdb1'),
+        ]
+
+    def test_path_with_spaces_survives(self):
+        rows = parse_domblklist(DOMBLKLIST_GOLDEN)
+        assert rows[1].source == '/vm images/boxman-vm01_data with spaces.qcow2'
+
+    def test_empty_device_list(self):
+        assert parse_domblklist(DOMBLKLIST_EMPTY) == []
+
+    def test_empty_output(self):
+        assert parse_domblklist('') == []
+        assert parse_domblklist('\n') == []
+
+    def test_header_without_separator_line(self):
+        rows = parse_domblklist(DOMBLKLIST_HEADER_ONLY_NO_SEPARATOR)
+        assert [row.target for row in rows] == ['hdc', 'vda']
+
+    def test_missing_source_column_is_none(self):
+        rows = parse_domblklist("file   cdrom   hdc\n")
+        assert rows == [DomblkRow('file', 'cdrom', 'hdc', None)]
+
+    def test_short_line_skipped(self):
+        rows = parse_domblklist("garbage\nfile   disk   vda   /x.qcow2\n")
+        assert rows == [DomblkRow('file', 'disk', 'vda', '/x.qcow2')]
+
+
+class TestParseDomiflist:
+
+    def test_parses_all_rows(self):
+        rows = parse_domiflist(DOMIFLIST_GOLDEN)
+        assert rows == [
+            DomifRow('vnet0', 'network', 'default', 'virtio',
+                     '52:54:00:aa:bb:cc'),
+            DomifRow('vnet1', 'bridge', 'br0', 'virtio',
+                     '52:54:00:aa:bb:dd'),
+        ]
+
+    def test_empty_device_list(self):
+        assert parse_domiflist(DOMIFLIST_EMPTY) == []
+
+    def test_empty_output(self):
+        assert parse_domiflist('') == []
+
+    def test_short_row_padded(self):
+        rows = parse_domiflist("vnet0   network   default\n")
+        assert rows == [DomifRow('vnet0', 'network', 'default', '-', '-')]


### PR DESCRIPTION
Refs #85 (item 32).

## What

New `src/boxman/providers/libvirt/virsh_parse.py` with `parse_domblklist(output)` / `parse_domiflist(output)`, migrating all 12 hand-rolled copies of domblklist/domiflist parsing:

- `session.py` ×2 (interface attach check, seed-cdrom eject)
- `net.py` (`attached_domains`)
- `clone_vm.py` (`remove_network_interfaces`)
- `snapshot.py` ×2 (cdrom diskspec args, data-disk targets)
- `vm_differ.py` ×2 (`get_actual_disks`, `get_actual_cdroms`)
- `cdrom.py` ×2 (`get_attached_cdroms`, `_find_next_available_target`)
- `cloudinit.py` (template seed-cdrom eject)
- `manager.py` (`_vm_disk_dirs`)

The parsers skip header/separator lines robustly, handle empty output, and expose the full row (`DomblkRow`/`DomifRow` namedtuples) so callers pick the columns they need. Golden-output tests with realistic captures (paths with spaces, empty device lists, cdrom entries, header-without-separator) added in `tests/test_virsh_parse.py`.

## Behavior notes (all in the correct direction, flagged per instructions)

- **Paths with spaces**: previously only `manager._vm_disk_dirs` used `split(None, 3)`; the shared parser applies maxsplit=3 everywhere, so a disk path containing spaces now survives in the other 11 call sites too (they previously truncated such a path at the first space — broken output, now correct).
- **Missing Source column**: `DomblkRow.source` is `None` when the column is absent (vs virsh's literal `-` for an empty slot); callers preserve their prior distinctions (`snapshot._data_disk_targets` still includes `-` rows, cdrom filters still exclude them).
- **Malformed short domiflist rows**: padded with `-` so all columns are readable; real virsh output always has 5 columns, so no practical change.

## Verification

- `pytest tests -q`: 1863 passed (11 new), 141 deselected
- `ruff check src tests scripts`: 8 errors (the known 8: N818×2, B027, UP036, B905×4)