### PR TITLE
refactor: dedup libvirt provider helpers (#85 item 33, libvirt side)

### DIFF
--- a/src/boxman/providers/libvirt/cloudinit.py
+++ b/src/boxman/providers/libvirt/cloudinit.py
@@ -32,6 +32,7 @@ import invoke
 from boxman import log
 from boxman.image_cache import ImageCache
 from boxman.loggers.logger import is_verbose
+from boxman.utils.jinja_env import substitute_env
 from boxman.utils.shell import run as _shell_run
 
 from .cloudinit_presets import (  # noqa: F401 — re-exported for back-compat
@@ -44,6 +45,8 @@ from .cloudinit_presets import (
     hash_password as _hash_password,
 )
 from .commands import VirshCommand, VirtInstallCommand
+from .destroy_vm import shutdown_and_wait as _shutdown_and_wait
+from .destroy_vm import wait_until_shut_off as _wait_until_shut_off
 from .virsh_parse import parse_domblklist
 
 
@@ -321,11 +324,7 @@ class CloudInitTemplate:
 
         # Replace ${env:VAR} placeholders with actual environment variables
         # (run first so ${hash:${env:VAR}} resolves the env var before hashing)
-        userdata = re.sub(
-            r'\$\{env:([A-Za-z0-9_]+)\}',
-            lambda m: os.environ.get(m.group(1), ''),
-            userdata
-        )
+        userdata = substitute_env(userdata)
 
         # Replace ${hash:plaintext} placeholders with SHA-512 hashed passwords
         def _hash_repl(m):
@@ -847,12 +846,9 @@ class CloudInitTemplate:
             True once the domain reports "shut off", False when *attempts*
             run out.
         """
-        for _ in range(attempts):
-            result = self.virsh.execute("domstate", self.template_name, hide=True, warn=True)
-            if result.ok and "shut off" in result.stdout.strip():
-                return True
-            time.sleep(interval)
-        return False
+        return _wait_until_shut_off(
+            self.virsh, self.template_name,
+            timeout=attempts * interval, poll_interval=interval)
 
     def _shutdown_template(self) -> None:
         """
@@ -866,12 +862,13 @@ class CloudInitTemplate:
         self.virsh.execute("shutdown", self.template_name, hide=True, warn=True)
 
         self.logger.info("waiting for VM to shut off...")
-        if self._wait_until_shut_off():
+        if _shutdown_and_wait(self.virsh, self.template_name,
+                              timeout=60, logger=self.logger):
             self.logger.info("VM is successfully shut off.")
-            return
-
-        self.logger.warning("VM did not shut off gracefully. Forcing destroy...")
-        self.virsh.execute("destroy", self.template_name, hide=True, warn=True)
+        else:
+            self.logger.warning(
+                "VM did not shut off gracefully and the forced destroy "
+                "did not settle either.")
 
     def _verify_dhcp_on_network(self) -> bool:
         """

--- a/src/boxman/providers/libvirt/destroy_vm.py
+++ b/src/boxman/providers/libvirt/destroy_vm.py
@@ -1,7 +1,95 @@
 import time
+from collections.abc import Callable
 from typing import Any
 
+from boxman import log
+
 from .commands import VirshCommand
+
+
+def wait_until_shut_off(virsh,
+                        vm_name: str,
+                        timeout: int = 60,
+                        poll_interval: int = 2,
+                        is_shut_off: Callable[[], bool] | None = None) -> bool:
+    """
+    Poll until *vm_name* reports "shut off", giving up after *timeout* seconds.
+
+    Args:
+        virsh: Command executor with an ``execute`` method (e.g.
+            :class:`VirshCommand` or any subclass).
+        vm_name: Name of the VM.
+        timeout: Maximum seconds to wait.
+        poll_interval: Seconds between ``domstate`` polls.
+        is_shut_off: Optional custom state check; defaults to a strict
+            ``domstate`` poll for "shut off" (stricter than "not running":
+            a paused or *in shutdown* domain still has a live QEMU process).
+
+    Returns:
+        True once the domain is shut off, False when *timeout* runs out.
+    """
+    if is_shut_off is None:
+        def is_shut_off() -> bool:
+            result = virsh.execute("domstate", vm_name, warn=True)
+            return result.ok and "shut off" in result.stdout
+    waited = 0
+    while waited < timeout:
+        if is_shut_off():
+            return True
+        time.sleep(poll_interval)
+        waited += poll_interval
+    return False
+
+
+def shutdown_and_wait(virsh,
+                      vm_name: str,
+                      timeout: int = 60,
+                      force_after: bool = True,
+                      poll_interval: int = 2,
+                      logger=log,
+                      is_shut_off: Callable[[], bool] | None = None,
+                      force_off: Callable[[], bool] | None = None) -> bool:
+    """
+    Wait for *vm_name* to shut off, force-killing it after *timeout* seconds.
+
+    The caller is expected to have already issued ``virsh shutdown``; this
+    helper owns the wait loop and the ``virsh destroy`` fallback. After a
+    force kill the domain is given a moment to release and the shut-off
+    state is verified once more.
+
+    Args:
+        virsh: Command executor with an ``execute`` method.
+        vm_name: Name of the VM.
+        timeout: Maximum seconds to wait for a graceful shutdown.
+        force_after: Whether to ``virsh destroy`` when *timeout* runs out.
+        poll_interval: Seconds between state polls.
+        logger: Logger for the force-kill warning.
+        is_shut_off: Optional custom state check (see
+            :func:`wait_until_shut_off`).
+        force_off: Optional custom force-kill action; when given it
+            replaces the built-in ``destroy`` + verify and its return
+            value is returned.
+
+    Returns:
+        True when the domain ends up shut off, False otherwise.
+    """
+    if is_shut_off is None:
+        def is_shut_off() -> bool:
+            result = virsh.execute("domstate", vm_name, warn=True)
+            return result.ok and "shut off" in result.stdout
+    if wait_until_shut_off(virsh, vm_name, timeout=timeout,
+                           poll_interval=poll_interval,
+                           is_shut_off=is_shut_off):
+        return True
+    if not force_after:
+        return False
+    if force_off is not None:
+        return force_off()
+    logger.warning(
+        f"{vm_name}: did not shut off within {timeout}s, forcing it off")
+    virsh.execute("destroy", vm_name, warn=True)
+    time.sleep(2)   # let qemu release the domain before verifying
+    return is_shut_off()
 
 
 class DestroyVM(VirshCommand):
@@ -105,11 +193,12 @@ class DestroyVM(VirshCommand):
             # wait for vm to reach "shut off" — not just "not running", because
             # a VM in the "in shutdown" state is no longer "running" but the
             # QEMU process is still alive (and storage cannot be removed yet).
-            for i in range(timeout):
-                if self.is_vm_shut_off():
-                    self.logger.info(f"vm {self.name} shut down successfully after {i+1} seconds")
-                    return True
-                time.sleep(1)
+            if shutdown_and_wait(self, self.name, timeout=timeout,
+                                 force_after=False, poll_interval=1,
+                                 logger=self.logger,
+                                 is_shut_off=self.is_vm_shut_off):
+                self.logger.info(f"vm {self.name} shut down successfully")
+                return True
 
             if not force:
                 self.logger.warning(

--- a/src/boxman/providers/libvirt/disk.py
+++ b/src/boxman/providers/libvirt/disk.py
@@ -5,6 +5,25 @@ from typing import Any
 from .commands import LibVirtCommandBase, VirshCommand
 
 
+def disk_path_for(workdir: str,
+                  disk_name: str,
+                  driver_type: str = 'qcow2',
+                  disk_prefix: str | None = None) -> str:
+    """
+    Return the canonical path of a disk image under *workdir*.
+
+    Naming: ``<workdir>/<disk_prefix>_<disk_name>.<driver_type>`` when
+    *disk_prefix* is given, ``<workdir>/<disk_name>.<driver_type>``
+    otherwise; ``~`` is expanded.
+    """
+    if disk_prefix:
+        disk_path = os.path.join(
+            workdir, f"{disk_prefix}_{disk_name}.{driver_type}")
+    else:
+        disk_path = os.path.join(workdir, f"{disk_name}.{driver_type}")
+    return os.path.expanduser(disk_path)
+
+
 class DiskManager(VirshCommand):
     """
     Class for managing VM disk operations in libvirt.
@@ -179,13 +198,9 @@ class DiskManager(VirshCommand):
             bus = disk_config.get("bus", "virtio")
 
             # create disk path
-            if disk_prefix:
-                disk_path = os.path.join(workdir, f"{disk_prefix}_{disk_name}.{driver_type}")
-            else:
-                disk_path = os.path.join(workdir, f"{disk_name}.{driver_type}")
-
-            # ensure path is expanded
-            disk_path = os.path.expanduser(disk_path)
+            disk_path = disk_path_for(workdir, disk_name,
+                                      driver_type=driver_type,
+                                      disk_prefix=disk_prefix)
 
             # 1. create the disk — unless the caller flagged the config
             # attach_only (image file already exists, e.g. a leftover

--- a/src/boxman/providers/libvirt/disk_cleanup.py
+++ b/src/boxman/providers/libvirt/disk_cleanup.py
@@ -21,6 +21,8 @@ from collections.abc import Iterable
 
 from boxman import log
 
+from .disk import disk_path_for
+
 
 def remove_vm_disks(
     workdir: str,
@@ -60,12 +62,12 @@ def remove_vm_disks(
     """
     workdir = os.path.expanduser(workdir)
 
-    boot_disk = os.path.join(workdir, f'{vm_name}.qcow2')
+    boot_disk = disk_path_for(workdir, vm_name)
     if os.path.isfile(boot_disk):
         os.remove(boot_disk)
 
     for disk in extra_disks:
-        disk_path = os.path.join(workdir, f'{vm_name}_{disk["name"]}.qcow2')
+        disk_path = disk_path_for(workdir, disk["name"], disk_prefix=vm_name)
         if os.path.isfile(disk_path):
             os.remove(disk_path)
 

--- a/src/boxman/providers/libvirt/session.py
+++ b/src/boxman/providers/libvirt/session.py
@@ -11,7 +11,7 @@ from . import net_reconcile
 from .cdrom import CDROMManager
 from .clone_vm import CloneVM
 from .commands import VirshCommand
-from .destroy_vm import DestroyVM
+from .destroy_vm import DestroyVM, shutdown_and_wait
 from .disk import DiskManager
 from .disk_cleanup import remove_vm_disks
 from .import_image import ImageImporter
@@ -332,19 +332,7 @@ class LibVirtSession:
     def _power_cycle(virsh, domain: str, timeout: int = 120) -> bool:
         """Shut the domain down gracefully (force after *timeout*) and start it."""
         virsh.execute("shutdown", domain, hide=True, warn=True)
-
-        waited = 0
-        while waited < timeout:
-            state = virsh.execute("domstate", domain, hide=True, warn=True)
-            if state.ok and 'shut off' in state.stdout:
-                break
-            time.sleep(2)
-            waited += 2
-        else:
-            log.warning(
-                f"{domain}: did not shut down within {timeout}s, forcing it off")
-            virsh.execute("destroy", domain, hide=True, warn=True)
-
+        shutdown_and_wait(virsh, domain, timeout=timeout, logger=log)
         return virsh.execute("start", domain, hide=True, warn=True).ok
 
     def plan_network(self,
@@ -1494,12 +1482,10 @@ class LibVirtSession:
                     return False
 
                 # wait for the vm to shut down
-                for _i in range(30):
-                    state_result = virsh.execute("domstate", vm_name, warn=True)
-                    if state_result.ok and "shut off" in state_result.stdout:
-                        break
-                    time.sleep(1)
-                else:
+                if not shutdown_and_wait(virsh, vm_name, timeout=30,
+                                         force_after=False,
+                                         poll_interval=1,
+                                         logger=self.logger):
                     self.logger.error(f"vm {vm_name} did not shut down within timeout")
                     return False
 
@@ -1578,29 +1564,8 @@ class LibVirtSession:
         self.logger.info(f"shutting down VM {vm_name}...")
         virsh.execute('shutdown', vm_name, warn=True)
 
-        # poll for shut off
-        waited = 0
-        poll_interval = 2
-        while waited < timeout:
-            time.sleep(poll_interval)
-            waited += poll_interval
-            result = virsh.execute('domstate', vm_name, warn=True)
-            if result.ok and 'shut off' in result.stdout:
-                self.logger.info(f"VM {vm_name} is shut off after {waited}s")
-                return True
-
-        # force stop as fallback
-        self.logger.warning(
-            f"VM {vm_name} did not shut off within {timeout}s, forcing stop")
-        virsh.execute('destroy', vm_name, warn=True)
-        time.sleep(2)
-
-        result = virsh.execute('domstate', vm_name, warn=True)
-        if result.ok and 'shut off' in result.stdout:
-            return True
-
-        self.logger.error(f"failed to shut off VM {vm_name}")
-        return False
+        return shutdown_and_wait(virsh, vm_name, timeout=timeout,
+                                 logger=self.logger)
 
     def update_vm_cpu_memory(self,
                              vm_name: str,
@@ -1650,60 +1615,28 @@ class LibVirtSession:
 
         # --- Step 1: update persistent config (inactive XML) ---
         xml_content = editor.get_domain_xml(vm_name, inactive=True)
-        modifications = []
 
         desired_total = None
         if cpus:
-            sockets = cpus.get('sockets', 1)
-            cores = cpus.get('cores', 1)
-            threads = cpus.get('threads', 1)
-            desired_total = sockets * cores * threads
+            desired_total = (cpus.get('sockets', 1)
+                             * cpus.get('cores', 1)
+                             * cpus.get('threads', 1))
 
-            effective_max_vcpus = max_vcpus or desired_total
-            if max_vcpus is not None and max_vcpus < desired_total:
-                effective_max_vcpus = desired_total
+        # memory mods only apply when the memory actually changes (or a
+        # new ceiling is requested); the clamping/scaling algorithm itself
+        # is shared with VirshEdit.configure_cpu_memory
+        memory_for_mods = (
+            memory_mb
+            if memory_mb is not None
+            and (memory_mb != actual_memory_mb or max_memory_mb is not None)
+            else None)
 
-            modifications.append(('//vcpu', 'text', str(effective_max_vcpus)))
+        modifications, remove_topology = editor.cpu_memory_modifications(
+            cpus, memory_for_mods, max_vcpus, max_memory_mb,
+            logger=self.logger)
 
-            if effective_max_vcpus > desired_total:
-                # libvirt requires topology product == max vcpu count.
-                # scale sockets so that sockets * cores * threads == max.
-                cores_x_threads = cores * threads
-                if effective_max_vcpus % cores_x_threads == 0:
-                    max_sockets = effective_max_vcpus // cores_x_threads
-                    modifications.extend([
-                        ('//cpu/topology', 'sockets', str(max_sockets)),
-                        ('//cpu/topology', 'cores', str(cores)),
-                        ('//cpu/topology', 'threads', str(threads)),
-                    ])
-                else:
-                    # can't express with given cores*threads, remove topology
-                    from lxml import etree
-                    tree = etree.fromstring(xml_content.encode('utf-8'))
-                    for topo in tree.xpath('//cpu/topology'):
-                        topo.getparent().remove(topo)
-                    xml_content = etree.tostring(
-                        tree, encoding='unicode', pretty_print=True)
-
-                modifications.append(
-                    ('//vcpu', 'current', str(desired_total)))
-            else:
-                modifications.extend([
-                    ('//cpu/topology', 'sockets', str(sockets)),
-                    ('//cpu/topology', 'cores', str(cores)),
-                    ('//cpu/topology', 'threads', str(threads)),
-                ])
-
-        if memory_mb is not None and (memory_mb != actual_memory_mb or max_memory_mb is not None):
-            effective_max_memory = max_memory_mb or memory_mb
-            if max_memory_mb is not None and max_memory_mb < memory_mb:
-                effective_max_memory = memory_mb
-            max_memory_kib = effective_max_memory * 1024
-            current_memory_kib = memory_mb * 1024
-            modifications.extend([
-                ('//memory', 'text', str(max_memory_kib)),
-                ('//currentMemory', 'text', str(current_memory_kib)),
-            ])
+        if remove_topology:
+            xml_content = editor._drop_topology(xml_content)
 
         if modifications:
             modified_xml = editor.modify_xml_xpath(xml_content, modifications)

--- a/src/boxman/providers/libvirt/snapshot.py
+++ b/src/boxman/providers/libvirt/snapshot.py
@@ -535,6 +535,34 @@ class SnapshotManager:
                 pass
         return out
 
+    def _snapshot_graph(self, vm_name: str) -> dict[str, dict]:
+        """
+        Return ``{name: info}`` for every snapshot of *vm_name*.
+
+        Runs ``snapshot-list --name`` once and ``snapshot-dumpxml`` once
+        per snapshot. Each *info* carries the parsed fields from
+        :meth:`_parse_snapshot_xml` (``description`` / ``parent`` /
+        ``creation_time``, when present) plus the raw ``xml`` (``None``
+        when the dumpxml failed, so callers can skip those entries).
+        """
+        list_result = self.virsh.execute(
+            "snapshot-list", vm_name, "--name", warn=True)
+        if not list_result.ok:
+            return {}
+
+        graph: dict[str, dict] = {}
+        for name in (n.strip() for n in list_result.stdout.splitlines()):
+            if not name:
+                continue
+            xml_result = self.virsh.execute(
+                "snapshot-dumpxml", vm_name, name, warn=True)
+            xml_text = xml_result.stdout if xml_result.ok else None
+            info = (self._parse_snapshot_xml(xml_text)
+                    if xml_text is not None else {})
+            info['xml'] = xml_text
+            graph[name] = info
+        return graph
+
     def list_snapshots_detailed(self, vm_name: str) -> list[dict]:
         """
         Return per-snapshot dicts for *vm_name* in chain order
@@ -545,20 +573,10 @@ class SnapshotManager:
         snapshot — everything else is parsed out of the XML via
         :meth:`_parse_snapshot_xml`.
         """
-        list_result = self.virsh.execute(
-            "snapshot-list", vm_name, "--name", warn=True)
-        if not list_result.ok:
+        parsed = self._snapshot_graph(vm_name)
+        if not parsed:
             return []
-        names = [n.strip() for n in list_result.stdout.splitlines() if n.strip()]
-        if not names:
-            return []
-
-        parsed: dict[str, dict] = {}
-        for name in names:
-            xml_result = self.virsh.execute(
-                "snapshot-dumpxml", vm_name, name, warn=True)
-            parsed[name] = (self._parse_snapshot_xml(xml_result.stdout)
-                            if xml_result.ok else {})
+        names = list(parsed)
 
         # Topological sort by parent → child.
         children: dict[str | None, list[str]] = {}
@@ -657,28 +675,13 @@ class SnapshotManager:
             list: List of snapshot info dictionaries
         """
         try:
-            # fetch the available snapshots
-            result = self.virsh.execute("snapshot-list", vm_name, "--name")
-            if not result.ok:
-                self.logger.error(f"failed to list snapshots for vm {vm_name}: {result.stderr}")
-                return []
-
-            snapshot_names = result.stdout.strip().split('\n')
-            snapshot_names = [name for name in snapshot_names if name]
-
-            # get the snapshot details
-            snapshots = []
-            for snapshot_name in snapshot_names:
-                dumpxml_result = self.virsh.execute("snapshot-dumpxml", vm_name, snapshot_name)
-                if dumpxml_result.ok:
-                    snap_info = {'name': snapshot_name}
-                    xml_content = dumpxml_result.stdout
-
-                    root = ET.fromstring(xml_content)
-                    snap_info['description'] = root.findtext('description', default='')
-
-                    snapshots.append(snap_info)
-            return snapshots
+            # fetch the available snapshots and their descriptions
+            graph = self._snapshot_graph(vm_name)
+            return [
+                {'name': name, 'description': info.get('description', '')}
+                for name, info in graph.items()
+                if info['xml'] is not None
+            ]
         except Exception as exc:
             self.logger.error(f"error listing snapshots for vm {vm_name}: {exc}")
             return []
@@ -688,22 +691,12 @@ class SnapshotManager:
         Return a mapping of snapshot_name -> set of overlay file paths
         for every external snapshot on *vm_name*.
         """
-        result = self.virsh.execute(
-            "snapshot-list", vm_name, "--name", warn=True)
-        if not result.ok:
-            return {}
-
         overlays: dict[str, list[str]] = {}
-        for snap in result.stdout.strip().splitlines():
-            snap = snap.strip()
-            if not snap:
-                continue
-            xml_result = self.virsh.execute(
-                "snapshot-dumpxml", vm_name, snap, warn=True)
-            if not xml_result.ok:
+        for snap, info in self._snapshot_graph(vm_name).items():
+            if info['xml'] is None:
                 continue
             try:
-                root = ET.fromstring(xml_result.stdout)
+                root = ET.fromstring(info['xml'])
                 files = []
                 for disk in root.findall(".//disks/disk"):
                     if disk.get("snapshot") != "external":
@@ -1052,23 +1045,22 @@ class SnapshotManager:
         first. Built from each snapshot's ``<parent>`` element so it
         works for any tree topology, but boxman only takes linear chains.
         """
-        snaps = self.list_snapshots(vm_name)
-        if not snaps:
+        graph = self._snapshot_graph(vm_name)
+        if not graph:
             return []
 
         parents: dict[str, str | None] = {}
-        for snap in snaps:
-            xml_result = self.virsh.execute(
-                "snapshot-dumpxml", vm_name, snap['name'], warn=True)
-            if not xml_result.ok:
+        for name, info in graph.items():
+            xml_text = info['xml']
+            if xml_text is None:
                 continue
             try:
-                root = ET.fromstring(xml_result.stdout)
+                # keep the historical behavior of excluding snapshots
+                # whose dumpxml does not parse at all
+                ET.fromstring(xml_text)
             except ET.ParseError:
                 continue
-            parent_name_elem = root.find("parent/name")
-            parents[snap['name']] = (
-                parent_name_elem.text if parent_name_elem is not None else None)
+            parents[name] = info.get('parent')
 
         children: dict[str | None, list[str]] = {}
         for name, parent in parents.items():

--- a/src/boxman/providers/libvirt/storage.py
+++ b/src/boxman/providers/libvirt/storage.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import time
 from typing import Any
 from xml.etree import ElementTree as ET
 
@@ -29,6 +28,8 @@ from boxman.loggers.logger import is_verbose
 
 from .commands import LibVirtCommandBase, VirshCommand
 from .destroy_vm import DestroyVM
+from .destroy_vm import shutdown_and_wait as _shutdown_and_wait
+from .disk import disk_path_for
 
 
 def vm_disk_paths(
@@ -44,13 +45,12 @@ def vm_disk_paths(
     boot disk at ``<workdir>/<vm_name>.qcow2`` and one extra per entry in
     ``vm_info['disks']`` named ``<workdir>/<vm_name>_<disk['name']>.qcow2``.
     """
-    workdir = os.path.expanduser(workdir)
-    paths = [os.path.join(workdir, f'{vm_name}.qcow2')]
+    paths = [disk_path_for(workdir, vm_name)]
     if vm_info:
         for disk in vm_info.get('disks', []) or []:
             name = disk.get('name') if isinstance(disk, dict) else None
             if name:
-                paths.append(os.path.join(workdir, f'{vm_name}_{name}.qcow2'))
+                paths.append(disk_path_for(workdir, name, disk_prefix=vm_name))
     return paths
 
 
@@ -194,15 +194,9 @@ class StorageManager:
             self.logger.error(
                 f"virsh shutdown failed for {vm_name}: {result.stderr.strip()}")
             return False
-        deadline = time.time() + timeout_s
-        while time.time() < deadline:
-            if self.is_shut_off(vm_name):
-                return True
-            time.sleep(2)
-        self.logger.warning(
-            f"vm {vm_name} did not shutdown within {timeout_s}s — issuing destroy")
-        destroy = self.virsh.execute("destroy", vm_name, warn=True)
-        return destroy.ok
+        return _shutdown_and_wait(
+            self.virsh, vm_name, timeout=timeout_s, logger=self.logger,
+            is_shut_off=lambda: self.is_shut_off(vm_name))
 
     def start(self, vm_name: str) -> bool:
         result = self.virsh.execute("start", vm_name, warn=True)

--- a/src/boxman/providers/libvirt/virsh_edit.py
+++ b/src/boxman/providers/libvirt/virsh_edit.py
@@ -144,6 +144,106 @@ class VirshEdit:
             self.logger.error(f"failed to find xpath values: {exc}")
             raise
 
+    @staticmethod
+    def cpu_memory_modifications(cpus: dict[str, int] | None,
+                                 memory_mb: int | None,
+                                 max_vcpus: int | None,
+                                 max_memory_mb: int | None,
+                                 logger=log) -> tuple[list[tuple[str, str, str]], bool]:
+        """
+        Compute the ``(xpath, attr, value)`` modification list for CPU and
+        memory configuration.
+
+        The max ceilings (``max_vcpus`` / ``max_memory_mb``) are clamped to
+        at least the current values, and the CPU topology is scaled so that
+        ``sockets * cores * threads == max_vcpus``.
+
+        Returns:
+            ``(modifications, remove_topology)`` — *remove_topology* is
+            True when the max vCPU count cannot be expressed with the
+            given cores*threads product, in which case the caller must
+            drop the ``//cpu/topology`` element from the domain XML before
+            applying the modifications.
+        """
+        modifications: list[tuple[str, str, str]] = []
+        remove_topology = False
+
+        # configure cpu if specified
+        if cpus:
+            sockets = cpus.get('sockets', 1)
+            cores = cpus.get('cores', 1)
+            threads = cpus.get('threads', 1)
+            total_vcpus = sockets * cores * threads
+
+            effective_max_vcpus = max_vcpus or total_vcpus
+            if max_vcpus is not None and max_vcpus < total_vcpus:
+                logger.warning(
+                    f"max_vcpus ({max_vcpus}) < current vcpus ({total_vcpus}), "
+                    f"clamping max_vcpus to {total_vcpus}")
+                effective_max_vcpus = total_vcpus
+
+            modifications.append(('//vcpu', 'text', str(effective_max_vcpus)))
+
+            if effective_max_vcpus > total_vcpus:
+                # libvirt requires topology product == max vcpu count.
+                # scale sockets so that sockets * cores * threads == max.
+                # if it doesn't divide evenly, remove the topology element.
+                cores_x_threads = cores * threads
+                if effective_max_vcpus % cores_x_threads == 0:
+                    max_sockets = effective_max_vcpus // cores_x_threads
+                    modifications.extend([
+                        ('//cpu/topology', 'sockets', str(max_sockets)),
+                        ('//cpu/topology', 'cores', str(cores)),
+                        ('//cpu/topology', 'threads', str(threads))
+                    ])
+                    logger.info(
+                        f"topology adjusted to sockets={max_sockets} "
+                        f"cores={cores} threads={threads} to match "
+                        f"max_vcpus={effective_max_vcpus}")
+                else:
+                    # can't express this max with the given cores*threads,
+                    # remove topology so libvirt doesn't reject it
+                    logger.info(
+                        f"removing topology element: max_vcpus "
+                        f"({effective_max_vcpus}) not divisible by "
+                        f"cores*threads ({cores_x_threads})")
+                    remove_topology = True
+
+                modifications.append(
+                    ('//vcpu', 'current', str(total_vcpus)))
+            else:
+                # max == current, set topology normally
+                modifications.extend([
+                    ('//cpu/topology', 'sockets', str(sockets)),
+                    ('//cpu/topology', 'cores', str(cores)),
+                    ('//cpu/topology', 'threads', str(threads))
+                ])
+
+        # configure memory if specified
+        if memory_mb is not None:
+            effective_max_memory = max_memory_mb or memory_mb
+            if max_memory_mb is not None and max_memory_mb < memory_mb:
+                logger.warning(
+                    f"max_memory ({max_memory_mb}M) < memory ({memory_mb}M), "
+                    f"clamping max_memory to {memory_mb}M")
+                effective_max_memory = memory_mb
+            max_memory_kb = effective_max_memory * 1024
+            current_memory_kb = memory_mb * 1024
+            modifications.extend([
+                ('//memory', 'text', str(max_memory_kb)),
+                ('//currentMemory', 'text', str(current_memory_kb))
+            ])
+
+        return modifications, remove_topology
+
+    @staticmethod
+    def _drop_topology(xml_content: str) -> str:
+        """Remove every ``//cpu/topology`` element from *xml_content*."""
+        tree = etree.fromstring(xml_content.encode('utf-8'))
+        for topo in tree.xpath('//cpu/topology'):
+            topo.getparent().remove(topo)
+        return etree.tostring(tree, encoding='unicode', pretty_print=True)
+
     def configure_cpu_memory(self,
                            domain_name: str,
                            cpus: dict[str, int] | None = None,
@@ -181,77 +281,12 @@ class VirshEdit:
             else:
                 self.logger.debug("no topology element found")
 
-            modifications = []
+            modifications, remove_topology = self.cpu_memory_modifications(
+                cpus, memory_mb, max_vcpus, max_memory_mb,
+                logger=self.logger)
 
-            # configure memory if specified
-            if memory_mb is not None:
-                effective_max_memory = max_memory_mb or memory_mb
-                if max_memory_mb is not None and max_memory_mb < memory_mb:
-                    self.logger.warning(
-                        f"max_memory ({max_memory_mb}M) < memory ({memory_mb}M) "
-                        f"for {domain_name}, clamping max_memory to {memory_mb}M")
-                    effective_max_memory = memory_mb
-                max_memory_kb = effective_max_memory * 1024
-                current_memory_kb = memory_mb * 1024
-                modifications.extend([
-                    ('//memory', 'text', str(max_memory_kb)),
-                    ('//currentMemory', 'text', str(current_memory_kb))
-                ])
-
-            # configure cpu if specified
-            if cpus:
-                sockets = cpus.get('sockets', 1)
-                cores = cpus.get('cores', 1)
-                threads = cpus.get('threads', 1)
-                total_vcpus = sockets * cores * threads
-
-                effective_max_vcpus = max_vcpus or total_vcpus
-                if max_vcpus is not None and max_vcpus < total_vcpus:
-                    self.logger.warning(
-                        f"max_vcpus ({max_vcpus}) < current vcpus ({total_vcpus}) "
-                        f"for {domain_name}, clamping max_vcpus to {total_vcpus}")
-                    effective_max_vcpus = total_vcpus
-
-                modifications.append(('//vcpu', 'text', str(effective_max_vcpus)))
-
-                if effective_max_vcpus > total_vcpus:
-                    # libvirt requires topology product == max vcpu count.
-                    # scale sockets so that sockets * cores * threads == max.
-                    # if it doesn't divide evenly, remove the topology element.
-                    cores_x_threads = cores * threads
-                    if effective_max_vcpus % cores_x_threads == 0:
-                        max_sockets = effective_max_vcpus // cores_x_threads
-                        modifications.extend([
-                            ('//cpu/topology', 'sockets', str(max_sockets)),
-                            ('//cpu/topology', 'cores', str(cores)),
-                            ('//cpu/topology', 'threads', str(threads))
-                        ])
-                        self.logger.info(
-                            f"topology adjusted to sockets={max_sockets} "
-                            f"cores={cores} threads={threads} to match "
-                            f"max_vcpus={effective_max_vcpus}")
-                    else:
-                        # can't express this max with the given cores*threads,
-                        # remove topology so libvirt doesn't reject it
-                        self.logger.info(
-                            f"removing topology element: max_vcpus "
-                            f"({effective_max_vcpus}) not divisible by "
-                            f"cores*threads ({cores_x_threads})")
-                        tree = etree.fromstring(xml_content.encode('utf-8'))
-                        for topo in tree.xpath('//cpu/topology'):
-                            topo.getparent().remove(topo)
-                        xml_content = etree.tostring(
-                            tree, encoding='unicode', pretty_print=True)
-
-                    modifications.append(
-                        ('//vcpu', 'current', str(total_vcpus)))
-                else:
-                    # max == current, set topology normally
-                    modifications.extend([
-                        ('//cpu/topology', 'sockets', str(sockets)),
-                        ('//cpu/topology', 'cores', str(cores)),
-                        ('//cpu/topology', 'threads', str(threads))
-                    ])
+            if remove_topology:
+                xml_content = self._drop_topology(xml_content)
 
             if not modifications:
                 self.logger.info(f"no cpu/memory modifications needed for {domain_name}")

--- a/src/boxman/providers/libvirt/vm_differ.py
+++ b/src/boxman/providers/libvirt/vm_differ.py
@@ -184,16 +184,13 @@ class VMStateDiffer:
         """
         Compute the expected disk file path, matching DiskManager.configure_from_disk_config logic.
         """
+        from .disk import disk_path_for
         disk_name = disk_config.get("name", "disk")
         driver = disk_config.get("driver", {})
         driver_type = driver.get("type", "qcow2")
-
-        if disk_prefix:
-            disk_path = os.path.join(workdir, f"{disk_prefix}_{disk_name}.{driver_type}")
-        else:
-            disk_path = os.path.join(workdir, f"{disk_name}.{driver_type}")
-
-        return os.path.expanduser(disk_path)
+        return disk_path_for(workdir, disk_name,
+                             driver_type=driver_type,
+                             disk_prefix=disk_prefix)
 
     def get_actual_cdroms(self, domain_name: str) -> list[dict[str, Any]]:
         """
@@ -202,26 +199,9 @@ class VMStateDiffer:
         Returns:
             List of dicts with 'target' and 'source' keys.
         """
-        result = self.virsh.execute('domblklist', domain_name, '--details', warn=True)
-        if not result.ok:
-            return []
-
-        cdroms = []
-        for row in parse_domblklist(result.stdout):
-            if row.device != 'cdrom':
-                continue
-            source = row.source
-            if source is None or source == '-':
-                continue
-            if os.path.basename(source).startswith('seed'):
-                continue
-
-            cdroms.append({
-                'target': row.target,
-                'source': source,
-            })
-
-        return cdroms
+        from .cdrom import CDROMManager
+        return CDROMManager(
+            domain_name, provider_config=self.provider_config).get_attached_cdroms()
 
     def get_actual_shared_folders(self, domain_name: str) -> list[dict[str, Any]]:
         """
@@ -230,30 +210,10 @@ class VMStateDiffer:
         Returns:
             List of dicts with 'name', 'host_path', and 'readonly' keys.
         """
-        from lxml import etree
-
-        xml_content = self.virsh_edit.get_domain_xml(domain_name)
-        tree = etree.fromstring(xml_content.encode('utf-8'))
-
-        folders = []
-        for fs_elem in tree.xpath('//devices/filesystem'):
-            source_elem = fs_elem.find('source')
-            target_elem = fs_elem.find('target')
-            if source_elem is None or target_elem is None:
-                continue
-
-            host_path = source_elem.get('dir', '')
-            name = target_elem.get('dir', '')
-            readonly = fs_elem.find('readonly') is not None
-
-            if name and host_path:
-                folders.append({
-                    'name': name,
-                    'host_path': host_path,
-                    'readonly': readonly,
-                })
-
-        return folders
+        from .shared_folder import SharedFolderManager
+        return SharedFolderManager(
+            domain_name,
+            provider_config=self.provider_config).get_attached_shared_folders()
 
     def diff_vm(self,
                 domain_name: str,

--- a/src/boxman/utils/jinja_env.py
+++ b/src/boxman/utils/jinja_env.py
@@ -9,13 +9,20 @@ by boxman (e.g. conf.yml):
     {{ env_required("MY_VAR") }}
     {{ env_required("MY_VAR", "MY_VAR must be set") }}
     {{ env_is_set("MY_VAR") }}
+
+Also owns the legacy inline ``${env:VAR}`` placeholder substitution
+(:func:`substitute_env`) used outside Jinja2 contexts (cloud-init
+userdata).
 """
 
 import os
+import re
 
 from jinja2 import Environment, FileSystemLoader
 
 from boxman.exceptions import ConfigError
+
+_ENV_PLACEHOLDER = re.compile(r"\$\{env:([A-Za-z0-9_]+)\}")
 
 
 def env(var_name: str, default: str = "") -> str:
@@ -25,6 +32,17 @@ def env(var_name: str, default: str = "") -> str:
     If the variable is not set, return *default* (empty string by default).
     """
     return os.environ.get(var_name, default)
+
+
+def substitute_env(text: str) -> str:
+    """
+    Replace every ``${env:VAR}`` placeholder in *text* with the variable's
+    value (empty string when unset).
+
+    This is the legacy inline syntax, kept for non-Jinja2 payloads such as
+    cloud-init userdata where ``{{ env(...) }}`` is not rendered.
+    """
+    return _ENV_PLACEHOLDER.sub(lambda m: env(m.group(1)), text)
 
 
 def env_required(var_name: str, message: str = None) -> str:

--- a/tests/test_libvirt_storage.py
+++ b/tests/test_libvirt_storage.py
@@ -365,7 +365,7 @@ class TestShutdownAndWait:
         with patch.object(sm, "is_shut_off",
                           side_effect=lambda _vm: next(shut_off_states)), \
              patch.object(sm.virsh, "execute", return_value=_result()) as exe, \
-             patch("boxman.providers.libvirt.storage.time.sleep"):
+             patch("boxman.providers.libvirt.destroy_vm.time.sleep"):
             assert sm.shutdown_and_wait("vm01", timeout_s=10) is True
         verbs = [c.args[0] for c in exe.call_args_list]
         assert "shutdown" in verbs
@@ -376,22 +376,14 @@ class TestShutdownAndWait:
         with patch.object(sm, "is_shut_off",
                           side_effect=lambda _vm: next(shut_off_states)), \
              patch.object(sm.virsh, "execute", return_value=_result()), \
-             patch("boxman.providers.libvirt.storage.time.sleep"):
+             patch("boxman.providers.libvirt.destroy_vm.time.sleep"):
             assert sm.shutdown_and_wait("vm01", timeout_s=10) is True
 
     def test_destroys_after_timeout(self, sm: StorageManager):
         # is_shut_off stays False forever — must fall through to destroy
-        time_values = [0]  # always before deadline=5 on entry, after on second check
-
-        def fake_time():
-            time_values[0] += 100
-            return time_values[0]
-
         with patch.object(sm, "is_shut_off", return_value=False), \
              patch.object(sm.virsh, "execute", return_value=_result()) as exe, \
-             patch("boxman.providers.libvirt.storage.time.time",
-                   side_effect=fake_time), \
-             patch("boxman.providers.libvirt.storage.time.sleep"):
+             patch("boxman.providers.libvirt.destroy_vm.time.sleep"):
             sm.shutdown_and_wait("vm01", timeout_s=5)
         verbs = [c.args[0] for c in exe.call_args_list]
         assert "shutdown" in verbs


### PR DESCRIPTION
Refs #85 (item 33, libvirt side). Manager-side dedup follows in a separate PR.

## What

- **shutdown-and-wait ×5** → new module-level `shutdown_and_wait()` / `wait_until_shut_off()` in `destroy_vm.py` with (timeout, force_after) semantics. Migrated: `DestroyVM.shutdown_vm`, `session.shutdown_and_wait`, `session._power_cycle`, the session restore path's inline wait, `storage.shutdown_and_wait`, `cloudinit._shutdown_template` / `_wait_until_shut_off`.
- **snapshot chain listing ×4** → `SnapshotManager._snapshot_graph(vm)` (one `snapshot-list` + one `snapshot-dumpxml` per snapshot, XML parsed once via the existing `_parse_snapshot_xml`). Migrated: `list_snapshots_detailed`, `list_snapshots`, `_get_snapshot_overlay_files`, `_chain_order` (which previously dumpxml'd every snapshot *twice*). `utils/snapshot_graph.py` was checked and does NOT fit — it's the ASCII `snapshot log` lane renderer, not chain fetching.
- **device listing ×2 each**: `vm_differ.get_actual_cdroms` / `get_actual_shared_folders` were verbatim copies of `CDROMManager.get_attached_cdroms` / `SharedFolderManager.get_attached_shared_folders` — they now delegate.
- **disk-path naming ×4** → `disk.disk_path_for()`; migrated `DiskManager.configure_from_disk_config`, `vm_differ._expected_disk_path`, `storage.vm_disk_paths`, `disk_cleanup.remove_vm_disks`.
- **CPU/mem max-clamping + topology scaling ×2** → `VirshEdit.cpu_memory_modifications()` (+ `_drop_topology()`); `session.update_vm_cpu_memory` delegates.
- **`${env:VAR}` substitution ×2** → cloudinit now uses `utils.jinja_env.substitute_env()` (new, wrapping the canonical `env()` helper).

## Deliberately left: virt-install building ×2

`cloudinit.py` and `direct_vm.py` both hand-build virt-install argv, but the flag sets diverge far beyond repeated `--disk`: different `--os-variant` semantics, `--import` vs `--boot`, bridge-vs-network resolution, media args, extra-args passthrough, and inconsistent quoting. Teaching the kwargs builder list expansion would only cover the prologue; not worth the churn.

## Behavior notes (picked semantics, called out per instructions)

- **Force-kill verification unified**: after `virsh destroy` the helper settles 2s and verifies "shut off". Previously: session verified, storage returned `destroy.ok` unverified, cloudinit/`_power_cycle` didn't verify. Verification is the correct semantic; `_power_cycle` still proceeds to `start` regardless (its callers treat the cycle as best-effort).
- **`storage.shutdown_and_wait` timeout path** now returns False if the VM is *still* not shut off after destroy (was: `destroy.ok`).
- Poll intervals preserved per call site (1s for DestroyVM/restore, 2s elsewhere); total wait budgets unchanged.
- `_chain_order` still excludes snapshots whose dumpxml is unparseable (an explicit re-check preserves the old `ET.ParseError → skip` behavior).
- Logging messages shifted slightly (clamping warnings now also fire on the `update` path).

## Tests

- `tests/test_libvirt_storage.py`: three `shutdown_and_wait` tests re-pointed at `destroy_vm.time.sleep` / dropped a `time.time` fake — mechanical consequence of the wait loop moving module; asserted behavior unchanged.
- `pytest tests -q`: 1863 passed, 141 deselected
- `ruff check src tests scripts`: 8 errors (the known 8)