### PR TITLE
refactor: consolidate the session config surface across providers (#85 item 34)

### DIFF
--- a/src/boxman/abstract/providers.py
+++ b/src/boxman/abstract/providers.py
@@ -1,39 +1,29 @@
 """
-Protocols that describe the provider surface (libvirt / VirtualBox).
+Protocol that describes the shared provider-session surface.
 
-``LibVirtSession`` and the legacy VirtualBox session both implement the
-same high-level contract: a constructor that takes a config dict, a
-mutable ``provider_config`` + ``uri`` + ``use_sudo`` surface, and a
-small set of orchestration methods (``start_vm``, ``destroy_vm``,
-``clone_vm``, ``define_network``, snapshot APIs, etc.).
+``LibVirtSession``, ``VirtualBoxSession`` and ``DockerComposeSession``
+all implement the same core contract: a constructor that takes a config
+dict, a mutable ``provider_config`` + ``uri`` + ``use_sudo`` surface
+(see :class:`boxman.providers.session_base.SessionConfigMixin`), and a
+common set of lifecycle/network/snapshot methods.
 
-These used to be empty sentinel classes (``class Provider: pass``).
-Phase 2.3 of the review plan turns them into
-:class:`typing.Protocol`\\s so that code annotated with the protocol
-type-checks against any concrete implementation — the protocols are
-structural (duck-typed), not an inheritance contract.
+This used to be an empty sentinel class (``class Provider: pass``).
+Phase 2.3 of the review plan turned it into a :class:`typing.Protocol`
+so that code annotated with the protocol type-checks against any
+concrete implementation — the protocol is structural (duck-typed), not
+an inheritance contract.
 
-Only the methods that are actually consumed by ``BoxmanManager`` and the
-CLI are listed here. Provider-internal helpers stay off the protocol so
-that implementations can keep internal refactoring flexibility.
+The protocol deliberately lists only the surface that is **uniform
+across all three providers** — the subset ``BoxmanManager`` and the CLI
+drive provider-agnostically. The manager calls many more
+provider-specific methods (per-cluster lifecycle on docker-compose,
+plan/update/storage ops on libvirt); those stay off the protocol so
+implementations keep their internal refactoring flexibility.
 """
 
 from __future__ import annotations
 
 from typing import Any, Protocol, runtime_checkable
-
-
-@runtime_checkable
-class Provider(Protocol):
-    """A provider represents the static side of an infrastructure backend.
-
-    At the moment this is thin — the bulk of the contract is on
-    :class:`ProviderSession`. Kept as its own protocol so future
-    provider-level metadata (display name, available regions, etc.)
-    can be added without churning session-level callers.
-    """
-
-    name: str
 
 
 @runtime_checkable

--- a/src/boxman/providers/docker_compose/session.py
+++ b/src/boxman/providers/docker_compose/session.py
@@ -20,7 +20,6 @@ import re
 from datetime import datetime, timezone
 from typing import Any
 
-from boxman import log
 from boxman.exceptions import ConfigError, ProvisionError
 from boxman.providers.docker_compose.compose_generator import (
     ComposeGenerator,
@@ -31,48 +30,20 @@ from boxman.providers.docker_compose.compose_runner import (
     DEFAULT_READINESS_TIMEOUT,
     ComposeRunner,
 )
+from boxman.providers.session_base import SessionConfigMixin
+from boxman.utils.compose_names import sanitize_project_name
 
 
-class DockerComposeSession:
+class DockerComposeSession(SessionConfigMixin):
     """Per-cluster docker-compose provider session."""
 
+    provider_key = "docker-compose"
+    #: docker-compose has no libvirt-style URI; the docker host is implicit.
+    default_uri = ""
+
     def __init__(self, config: dict[str, Any] | None = None) -> None:
-        self.config = config or {}
-        self.logger = log
-        #: set externally by scripts/app.py right after construction
-        self.manager = None
-        self._provider_config = (
-            (self.config.get("provider") or {}).get("docker-compose") or {}
-        )
+        super().__init__(config)
         self._generator = ComposeGenerator(logger=self.logger)
-
-    # -- ProviderSession protocol: config surface --------------------------
-
-    @property
-    def provider_config(self) -> dict[str, Any]:
-        return self._provider_config
-
-    @provider_config.setter
-    def provider_config(self, value: dict[str, Any]) -> None:
-        self._provider_config = value or {}
-
-    @property
-    def uri(self) -> str:
-        # docker-compose has no libvirt-style URI; the docker host is implicit.
-        return self._provider_config.get("uri", "")
-
-    @property
-    def use_sudo(self) -> bool:
-        return bool(self._provider_config.get("use_sudo", False))
-
-    def update_provider_config(self, new_config: dict[str, Any]) -> None:
-        self._provider_config = {**self._provider_config, **(new_config or {})}
-
-    def update_provider_config_with_runtime(self) -> None:
-        """No-op: the docker-compose provider requires ``runtime: local``,
-        so there is no runtime enrichment to apply. Present because the
-        manager calls it over every registered session."""
-        return None
 
     # -- coarse per-cluster lifecycle (the real work) ----------------------
 
@@ -816,7 +787,9 @@ def _snapshot_tag(project: str, box: str, snapshot_name: str) -> str:
 
 
 def _sanitize_project_name(name: str) -> str:
-    """Coerce *name* to a valid compose project name (``[a-z0-9][a-z0-9_-]*``)."""
-    slug = re.sub(r"[^a-z0-9_-]", "_", name.lower())
-    slug = slug.lstrip("_-") or "boxman"
-    return slug
+    """Coerce *name* to a valid compose project name (``[a-z0-9][a-z0-9_-]*``).
+
+    Thin wrapper over :func:`boxman.utils.compose_names.sanitize_project_name`
+    keeping this call site's rule set (underscores kept, ``boxman`` fallback).
+    """
+    return sanitize_project_name(name, allow_underscore=True)

--- a/src/boxman/providers/libvirt/session.py
+++ b/src/boxman/providers/libvirt/session.py
@@ -7,6 +7,7 @@ from xml.etree import ElementTree as ET
 
 from boxman import log
 
+from ..session_base import SessionConfigMixin
 from . import net_reconcile
 from .cdrom import CDROMManager
 from .clone_vm import CloneVM
@@ -24,61 +25,18 @@ from .virsh_edit import VirshEdit
 from .virsh_parse import parse_domblklist, parse_domiflist
 
 
-class LibVirtSession:
-    def __init__(self,
-                 config: dict[str, Any] | None = None):
-        """
-        Initialize the LibVirtSession.
+class LibVirtSession(SessionConfigMixin):
+    """
+    Live session against the libvirt (KVM/QEMU) backend.
 
-        Args:
-            config: Optional configuration dictionary
-        """
-        #: Optional[Dict[str, Any]]: The configuration for this session
-        self.config = config
+    The config surface (``provider_config`` / ``uri`` / ``use_sudo`` /
+    ``update_provider_config``) comes from
+    :class:`~boxman.providers.session_base.SessionConfigMixin`; only the
+    libvirt-specific defaults and the runtime enrichment are set here.
+    """
 
-        #: logging.Logger: the logger instance
-        self.logger = log
-
-        #: Dict[str, Any]: the effective provider config. The CLI hands the
-        #: session an already-merged dict (app-level defaults + runtime
-        #: injection, overlaid by project-level settings via
-        #: :func:`boxman.providers.merge_provider_configs`), so no further
-        #: precedence handling happens here.
-        self.provider_config = dict(
-            (config.get('provider', {}) or {}).get('libvirt', {}) or {})
-
-        #: the boxman manager instance (mainly to get access to the cache)
-        self.manager = None
-
-    @property
-    def uri(self) -> str:
-        return self.provider_config.get('uri', 'qemu:///system')
-
-    @uri.setter
-    def uri(self, value: str) -> None:
-        self.provider_config['uri'] = value
-
-    @property
-    def use_sudo(self) -> bool:
-        return self.provider_config.get('use_sudo', False)
-
-    @use_sudo.setter
-    def use_sudo(self, value: bool) -> None:
-        self.provider_config['use_sudo'] = value
-
-    def update_provider_config(self, new_config: dict[str, Any]) -> None:
-        """
-        Update provider_config with *new_config* (plain last-write-wins).
-
-        Precedence between app-level and project-level settings is resolved
-        upstream by :func:`boxman.providers.merge_provider_configs` before
-        the session is built; this is only used for runtime metadata
-        injection, which never carries project keys.
-
-        Args:
-            new_config: Additional config keys (e.g. runtime injection).
-        """
-        self.provider_config.update(new_config)
+    provider_key = 'libvirt'
+    default_uri = 'qemu:///system'
 
     def update_provider_config_with_runtime(self) -> None:
         """

--- a/src/boxman/providers/session_base.py
+++ b/src/boxman/providers/session_base.py
@@ -1,0 +1,114 @@
+"""
+Shared config surface for provider sessions (#85 item 34).
+
+Every provider session (``LibVirtSession``, ``VirtualBoxSession``,
+``DockerComposeSession``) carries the same small config-resolution
+surface: a constructor that extracts its own block from the project
+config, a mutable ``provider_config``, ``uri`` / ``use_sudo``
+properties, and ``update_provider_config``.
+
+The semantics are uniform across providers:
+
+* The session is handed an **already-merged** config (app-level
+  defaults + runtime injection, overlaid by project-level settings via
+  :func:`boxman.providers.merge_provider_configs`), so no precedence
+  handling happens here.
+* :meth:`SessionConfigMixin.update_provider_config` is a plain
+  last-write-wins dict update, used for runtime metadata injection,
+  which never carries project keys.
+
+Per-provider differences are confined to two class attributes:
+``provider_key`` (which block of ``provider:`` the session reads) and
+``default_uri`` (libvirt defaults to ``qemu:///system``; the other
+providers have no connection URI and default to the empty string).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from boxman import log
+
+
+class SessionConfigMixin:
+    """The shared config surface consumed through ``ProviderSession``."""
+
+    #: str: key of this provider's block under the project's ``provider:``
+    #: mapping (e.g. ``libvirt``, ``docker-compose``).
+    provider_key: str = ''
+
+    #: str: value ``uri`` falls back to when the config does not set one.
+    default_uri: str = ''
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        """
+        Initialize the session config surface.
+
+        Construction is deliberately side-effect free — nothing external
+        is touched (no libvirt connection, no VBoxManage / docker call).
+
+        Args:
+            config: Optional project configuration dictionary. Its
+                ``provider[<provider_key>]`` block is expected to be
+                already merged (see the module docstring).
+        """
+        #: Dict[str, Any]: the configuration for this session
+        self.config: dict[str, Any] = config or {}
+
+        #: logging.Logger: the logger instance
+        self.logger = log
+
+        #: Dict[str, Any]: the effective (already-merged) provider config
+        self._provider_config: dict[str, Any] = dict(
+            ((self.config.get('provider') or {}).get(self.provider_key)) or {})
+
+        #: the boxman manager instance (set by the CLI after construction)
+        self.manager = None
+
+    @property
+    def provider_config(self) -> dict[str, Any]:
+        return self._provider_config
+
+    @provider_config.setter
+    def provider_config(self, value: dict[str, Any]) -> None:
+        self._provider_config = value or {}
+
+    @property
+    def uri(self) -> str:
+        """Connection URI (empty for providers without one)."""
+        return self.provider_config.get('uri', self.default_uri)
+
+    @uri.setter
+    def uri(self, value: str) -> None:
+        self.provider_config['uri'] = value
+
+    @property
+    def use_sudo(self) -> bool:
+        return self.provider_config.get('use_sudo', False)
+
+    @use_sudo.setter
+    def use_sudo(self, value: bool) -> None:
+        self.provider_config['use_sudo'] = value
+
+    def update_provider_config(self, new_config: dict[str, Any]) -> None:
+        """
+        Update provider_config with *new_config* (plain last-write-wins).
+
+        Precedence between app-level and project-level settings is resolved
+        upstream by :func:`boxman.providers.merge_provider_configs` before
+        the session is built; this is only used for runtime metadata
+        injection, which never carries project keys.
+
+        Args:
+            new_config: Additional config keys (e.g. runtime injection).
+        """
+        self.provider_config.update(new_config or {})
+
+    def update_provider_config_with_runtime(self) -> None:
+        """
+        Default no-op: providers that only support the ``local`` runtime
+        have no runtime metadata to inject. ``LibVirtSession`` overrides
+        this with the real enrichment; present here so the manager can
+        call it uniformly across providers.
+        """
+        return None

--- a/src/boxman/providers/virtualbox/session.py
+++ b/src/boxman/providers/virtualbox/session.py
@@ -10,12 +10,14 @@ exactly like :class:`~boxman.providers.libvirt.session.LibVirtSession`).
 Phase 1 status (skeleton / consolidation):
 
 * **Real now** — the config surface (``provider_config`` / ``uri`` /
-  ``use_sudo`` + setters, ``update_provider_config``) and a
+  ``use_sudo`` + setters, ``update_provider_config``), inherited from the
+  shared :class:`~boxman.providers.session_base.SessionConfigMixin`, and a
   side-effect-free constructor. The legacy ``__init__`` eagerly shelled out
   (``vboxmanage natnetwork list``) and raised ``FileNotFoundError`` on any host
   without VirtualBox installed; this one touches nothing external.
 * **No-op now** — ``update_provider_config_with_runtime`` (VirtualBox only
-  supports the ``local`` runtime, so there is no runtime metadata to inject).
+  supports the ``local`` runtime, so there is no runtime metadata to inject;
+  the mixin default is a no-op).
 * **Stubbed now** — every per-VM / network / snapshot / storage operation the
   manager calls raises ``NotImplementedError`` with a "lands in Phase N"
   message, giving later phases a red-to-green target. Real provisioning is
@@ -27,7 +29,7 @@ from __future__ import annotations
 
 from typing import Any, NoReturn
 
-from boxman import log
+from boxman.providers.session_base import SessionConfigMixin
 
 
 def _phase(method: str, phase: int) -> NotImplementedError:
@@ -36,103 +38,13 @@ def _phase(method: str, phase: int) -> NotImplementedError:
         f"VirtualBox provider: {method} lands in Phase {phase}")
 
 
-class VirtualBoxSession:
+class VirtualBoxSession(SessionConfigMixin):
     """A live session against the VirtualBox (VBoxManage) backend."""
 
-    def __init__(self, config: dict[str, Any] | None = None):
-        """
-        Initialize the session.
-
-        NOTE: construction is deliberately side-effect free — it must not shell
-        out to ``VBoxManage`` (that was the core defect in the legacy session,
-        and it is also required so the ``isinstance(x, ProviderSession)``
-        protocol check works on any host).
-
-        Args:
-            config: Optional project configuration dictionary.
-        """
-        #: Optional[Dict[str, Any]]: the configuration for this session
-        self.config = config or {}
-
-        #: logging.Logger: the logger instance
-        self.logger = log
-
-        # provider config from the project configuration — these are
-        # authoritative and must never be overridden by app-level defaults.
-        self._project_provider_config = self.config.get('provider', {}).get('virtualbox', {})
-
-        #: Dict[str, Any]: the base provider config (may be enriched with
-        #: app-level settings, but project-level keys always win via the
-        #: property getter).
-        self._provider_config_base = self._project_provider_config.copy()
-
-        #: the boxman manager instance (set by the CLI after construction)
-        self.manager = None
-
-    # --- config surface -----------------------------------------------------
-
-    @property
-    def provider_config(self) -> dict[str, Any]:
-        """
-        Return the effective provider config.
-
-        Project-level settings (from conf.yml) always take precedence over
-        app-level (boxman.yml) values.
-        """
-        merged = self._provider_config_base.copy()
-        merged.update(self._project_provider_config)
-        return merged
-
-    @provider_config.setter
-    def provider_config(self, value: dict[str, Any]) -> None:
-        """Set the base provider config (project-level keys still win)."""
-        self._provider_config_base = value
-
-    @property
-    def uri(self) -> str:
-        """
-        Connection URI.
-
-        VirtualBox has no libvirt-style connection URI; this exists to satisfy
-        the provider protocol and defaults to an empty string.
-        """
-        return self.provider_config.get('uri', '')
-
-    @uri.setter
-    def uri(self, value: str) -> None:
-        self._provider_config_base['uri'] = value
-
-    @property
-    def use_sudo(self) -> bool:
-        return self.provider_config.get('use_sudo', False)
-
-    @use_sudo.setter
-    def use_sudo(self, value: bool) -> None:
-        self._provider_config_base['use_sudo'] = value
-
-    def update_provider_config(self, new_config: dict[str, Any]) -> None:
-        """
-        Merge *new_config* into the base provider config; project-level
-        settings always win (enforced by the property getter).
-
-        Args:
-            new_config: Additional config keys (e.g. from the boxman.yml
-                ``providers`` section).
-        """
-        merged = self._provider_config_base.copy()
-        merged.update(new_config)
-        self._provider_config_base = merged
-
-    def update_provider_config_with_runtime(self) -> None:
-        """
-        No-op for VirtualBox.
-
-        VirtualBox only supports the ``local`` runtime (VBoxManage runs
-        directly on the host), so there is no runtime metadata to inject into
-        the provider config. Present so the manager can call it uniformly
-        across providers.
-        """
-        return None
+    provider_key = 'virtualbox'
+    #: VirtualBox has no libvirt-style connection URI; the property exists
+    #: to satisfy the provider protocol and defaults to an empty string.
+    default_uri = ''
 
     # --- image import -------------------------------------------------------
 

--- a/src/boxman/runtime/docker_compose.py
+++ b/src/boxman/runtime/docker_compose.py
@@ -9,7 +9,6 @@ directory next to the project's ``conf.yml``.
 
 import hashlib
 import os
-import re
 import shlex
 import shutil
 import sys
@@ -20,6 +19,7 @@ import yaml as pyyaml
 
 from boxman import log
 from boxman.runtime.base import RuntimeBase
+from boxman.utils.compose_names import sanitize_project_name
 from boxman.utils.shell import run as _shell_run
 
 
@@ -76,10 +76,10 @@ class DockerComposeRuntime(RuntimeBase):
         """
         Sanitize a project name for use as a Docker Compose project name.
 
-        Docker Compose project names must be lowercase alphanumeric
-        characters and hyphens only.
+        Thin wrapper over :func:`boxman.utils.compose_names.sanitize_project_name`
+        keeping this call site's rule set (no underscores, no fallback).
         """
-        return re.sub(r'[^a-z0-9-]', '-', name.lower()).strip('-')
+        return sanitize_project_name(name)
 
     @property
     def container_name(self) -> str:

--- a/src/boxman/utils/compose_names.py
+++ b/src/boxman/utils/compose_names.py
@@ -1,0 +1,44 @@
+"""
+Shared project-name sanitizer for docker-compose contexts (#85 item 34).
+
+Two call sites sanitize a project/cluster name into something docker or
+``docker compose -p`` accepts, with **deliberately different rules** —
+changing either one would rename existing compose projects / containers
+and orphan the running state:
+
+* the docker-compose *runtime* (:class:`~boxman.runtime.docker_compose.
+  DockerComposeRuntime`, the libvirt-in-a-container wrapper) maps every
+  disallowed character — including ``_`` — to ``-`` and strips leading
+  and trailing ``-``;
+* the docker-compose *provider* (:mod:`boxman.providers.docker_compose.
+  session`, one compose project per cluster) keeps ``_``, maps other
+  disallowed characters to ``_``, strips leading ``_``/``-`` only, and
+  falls back to ``boxman`` when nothing is left.
+
+:func:`sanitize_project_name` is the single implementation; the
+``allow_underscore`` flag selects the rule set so each call site keeps
+its observable output.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def sanitize_project_name(name: str, *, allow_underscore: bool = False) -> str:
+    """
+    Coerce *name* into a docker-compose-safe project name.
+
+    Args:
+        name: the raw project/cluster name.
+        allow_underscore: select the rule set (see the module docstring):
+
+            - ``False`` (docker-compose *runtime*): ``[^a-z0-9-]`` → ``-``,
+              leading/trailing ``-`` stripped. May return ``""``.
+            - ``True`` (docker-compose *provider*): ``[^a-z0-9_-]`` → ``_``,
+              leading ``_-`` stripped, ``"boxman"`` when empty.
+    """
+    if allow_underscore:
+        slug = re.sub(r"[^a-z0-9_-]", "_", name.lower()).lstrip("_-")
+        return slug or "boxman"
+    return re.sub(r"[^a-z0-9-]", "-", name.lower()).strip("-")

--- a/tests/test_provider_protocol.py
+++ b/tests/test_provider_protocol.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import pytest
 
-from boxman.abstract.providers import Provider, ProviderSession
+from boxman.abstract.providers import ProviderSession
 from boxman.providers.libvirt.session import LibVirtSession
 from boxman.providers.virtualbox.session import VirtualBoxSession
 
@@ -76,18 +76,3 @@ class TestProviderSessionProtocol:
             def clone_vm(self, new_vm_name, src_vm_name, info, workdir): return True
 
         assert not isinstance(NearlyASession(), ProviderSession)
-
-
-class TestProviderProtocol:
-
-    def test_object_with_name_satisfies_provider(self):
-        class P:
-            name = "libvirt"
-
-        assert isinstance(P(), Provider)
-
-    def test_object_without_name_does_not_satisfy_provider(self):
-        class P:
-            pass
-
-        assert not isinstance(P(), Provider)

--- a/tests/test_session_config_mixin.py
+++ b/tests/test_session_config_mixin.py
@@ -1,0 +1,103 @@
+"""
+Cross-provider tests for the shared session config surface (#85 item 34).
+
+``boxman.providers.session_base.SessionConfigMixin`` is the single
+implementation of the config surface for all three provider sessions
+(libvirt / virtualbox / docker-compose). These tests drive each real
+session class and pin the uniform semantics:
+
+  - the constructor extracts only its own ``provider[<key>]`` block
+    (already merged upstream by ``boxman.providers.merge_provider_configs``);
+  - ``update_provider_config`` is plain last-write-wins everywhere;
+  - ``uri`` / ``use_sudo`` read through ``provider_config`` with
+    per-provider defaults, and their setters write straight into it;
+  - ``update_provider_config_with_runtime`` is a no-op for the providers
+    that only support the ``local`` runtime.
+
+The app/project merge itself (union/eviction of the sudo lists) is
+covered by tests/test_provider_config_merge.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from boxman.providers.docker_compose.session import DockerComposeSession
+from boxman.providers.libvirt.session import LibVirtSession
+from boxman.providers.virtualbox.session import VirtualBoxSession
+
+pytestmark = pytest.mark.unit
+
+#: (session class, its provider: block key, default uri) per provider
+SESSIONS = [
+    pytest.param(LibVirtSession, "libvirt", "qemu:///system", id="libvirt"),
+    pytest.param(VirtualBoxSession, "virtualbox", "", id="virtualbox"),
+    pytest.param(DockerComposeSession, "docker-compose", "", id="docker-compose"),
+]
+
+
+class TestSharedConfigSurface:
+
+    @pytest.mark.parametrize("cls,key,_", SESSIONS)
+    def test_reads_only_its_own_provider_block(self, cls, key, _):
+        config = {
+            "provider": {
+                "libvirt": {"uri": "qemu+ssh://hv/system"},
+                "virtualbox": {"vboxmanage_cmd": "vbm"},
+                "docker-compose": {"project_name": "dc"},
+            },
+        }
+        session = cls(config=config)
+        assert session.provider_config == config["provider"][key]
+
+    @pytest.mark.parametrize("cls,key,_", SESSIONS)
+    def test_empty_or_missing_provider_block(self, cls, key, _):
+        assert cls(config={"provider": {key: None}}).provider_config == {}
+        assert cls(config={}).provider_config == {}
+        assert cls(config=None).provider_config == {}
+
+    @pytest.mark.parametrize("cls,key,_", SESSIONS)
+    def test_update_is_last_write_wins(self, cls, key, _):
+        session = cls(config={"provider": {key: {"use_sudo": True}}})
+        session.update_provider_config({"use_sudo": False, "runtime": "local"})
+        assert session.provider_config["use_sudo"] is False
+        assert session.provider_config["runtime"] == "local"
+
+    @pytest.mark.parametrize("cls,key,_", SESSIONS)
+    def test_update_fills_in_missing_keys(self, cls, key, _):
+        session = cls(config={"provider": {key: {"use_sudo": True}}})
+        session.update_provider_config({"extra": 1})
+        assert session.provider_config["use_sudo"] is True
+        assert session.provider_config["extra"] == 1
+
+    @pytest.mark.parametrize("cls,key,_", SESSIONS)
+    def test_provider_config_setter_replaces(self, cls, key, _):
+        session = cls(config={"provider": {key: {"a": 1}}})
+        session.provider_config = {"b": 2}
+        assert session.provider_config == {"b": 2}
+
+    @pytest.mark.parametrize("cls,key,default_uri", SESSIONS)
+    def test_uri_default_and_setter(self, cls, key, default_uri):
+        session = cls(config={"provider": {key: {}}})
+        assert session.uri == default_uri
+        session.uri = "scheme://example"
+        assert session.uri == "scheme://example"
+        assert session.provider_config["uri"] == "scheme://example"
+
+    @pytest.mark.parametrize("cls,key,_", SESSIONS)
+    def test_use_sudo_default_and_setter(self, cls, key, _):
+        session = cls(config={"provider": {key: {}}})
+        assert session.use_sudo is False
+        session.use_sudo = True
+        assert session.use_sudo is True
+        assert session.provider_config["use_sudo"] is True
+
+    @pytest.mark.parametrize("cls,key,_", [
+        pytest.param(VirtualBoxSession, "virtualbox", "", id="virtualbox"),
+        pytest.param(DockerComposeSession, "docker-compose", "", id="docker-compose"),
+    ])
+    def test_update_with_runtime_is_noop_for_local_only_providers(
+            self, cls, key, _):
+        session = cls(config={"provider": {key: {"x": 1}}})
+        assert session.update_provider_config_with_runtime() is None
+        assert session.provider_config == {"x": 1}

--- a/tests/test_virtualbox_provider.py
+++ b/tests/test_virtualbox_provider.py
@@ -96,12 +96,14 @@ class TestConstructionSideEffectFree:
 
 class TestConfigSurface:
 
-    def test_project_provider_config_wins(self):
+    def test_update_provider_config_is_last_write_wins(self):
+        """Same post-#110 semantics as the libvirt session: the constructor
+        receives an already-merged config, and ``update_provider_config`` is
+        a plain last-write-wins update (runtime metadata injection only)."""
         session = VirtualBoxSession(
             config={"provider": {"virtualbox": {"use_sudo": True}}})
-        # app-level default should not override the project-level value
         session.update_provider_config({"use_sudo": False, "vboxmanage_cmd": "vbm"})
-        assert session.use_sudo is True
+        assert session.use_sudo is False
         assert session.provider_config["vboxmanage_cmd"] == "vbm"
 
     def test_uri_defaults_to_empty_string(self):


### PR DESCRIPTION
Refs #85 (item 34). Behavior-preserving refactor; full unit suite green (1884 passed), ruff at the 8 known violations.

## What changed

**1. Shared config-surface mixin** — new `src/boxman/providers/session_base.py` with `SessionConfigMixin`, now inherited by all three provider sessions. It carries the surface each session used to copy: constructor extraction of its own `provider[<key>]` block, `provider_config` property + setter, `uri` / `use_sudo` properties + setters, `update_provider_config`, and a default no-op `update_provider_config_with_runtime`. Per-provider differences are two class attributes (`provider_key`, `default_uri` — libvirt defaults to `qemu:///system`, the others to `''`). `LibVirtSession` keeps its real `update_provider_config_with_runtime` override.

**Semantics unified to libvirt (post-#110) — deliberate divergence fix:** `VirtualBoxSession` still carried its own project-wins overlay (`_project_provider_config` / `_provider_config_base`), a leftover from before PR #110. It now gets the same semantics as libvirt/docker-compose: the session receives an **already-merged** config from `boxman.providers.merge_provider_configs`, and `update_provider_config` is plain last-write-wins everywhere (used only for runtime-metadata injection, which never carries project keys). `tests/test_virtualbox_provider.py::test_project_provider_config_wins` was pinning the old overlay semantics and is rewritten as `test_update_provider_config_is_last_write_wins`. Incidental: `DockerComposeSession.use_sudo` no longer wraps the raw value in `bool()` (truthiness-identical); `LibVirtSession(config=None)` no longer raises.

**2. Compose-name sanitizers ×2** — `runtime/docker_compose.py` (`[^a-z0-9-]`→`-`, strip both ends) and `providers/docker_compose/session.py` (`[^a-z0-9_-]`→`_`, lstrip, `boxman` fallback) genuinely produce different project names. Both now delegate to one helper, `boxman.utils.compose_names.sanitize_project_name`, with an `allow_underscore` flag selecting the rule set. **Each call site's observable output is preserved exactly** — unifying the rules would rename existing `docker compose -p` projects and orphan running containers/state. Both wrappers document why the divergence stays.

**3. Protocol docstring honesty** — `abstract/providers.py` claimed "only the methods actually consumed by BoxmanManager and the CLI are listed", but the manager drives 40+ methods beyond the ~12 listed. Chose the cheaper honest option: trimmed the claim (the docstring now scopes the protocol to the cross-provider-uniform surface) and deleted the unused `Provider` protocol (nothing imported it).

## Tests

- New `tests/test_session_config_mixin.py`: parametrized over all three real session classes, pinning own-block extraction, last-write-wins update, uri/use_sudo defaults + setters, and the no-op runtime enrichment for local-only providers. Union/eviction merge semantics remain covered by `tests/test_provider_config_merge.py` (unchanged).
- `tests/test_provider_protocol.py`: dropped the `Provider` protocol tests.
- No integration/e2e tests were run.