### PR TITLE
refactor: name-based CLI dispatch replaces function-identity coupling (#85 item 30)

### DIFF
--- a/src/boxman/scripts/app.py
+++ b/src/boxman/scripts/app.py
@@ -17,6 +17,24 @@ from boxman.providers.libvirt.import_image import ImageImporter
 from boxman.scripts.cli_parser import parse_args, resolve_verbosity
 from boxman.utils.jinja_env import create_jinja_env
 
+#: Names of the :class:`BoxmanManager` methods the CLI may dispatch to.
+#: The parser declares them via ``set_defaults(handler='<name>')`` and
+#: :func:`_main` resolves the bound method with ``getattr`` at dispatch
+#: time, so decorating or aliasing a handler method can never silently
+#: break dispatch (the old ``args.func is BoxmanManager.x`` identity
+#: comparisons did).
+_CLI_HANDLERS = frozenset({
+    'import_image', 'push_image', 'inspect_image', 'create_templates',
+    'list_projects', 'provision', 'up', 'update', 'down',
+    'destroy_runtime', 'destroy', 'deprovision', 'snapshot_take',
+    'snapshot_list', 'snapshot_log', 'snapshot_restore', 'snapshot_delete',
+    'snapshot_collapse', 'storage_df', 'storage_trim', 'storage_compact',
+    'storage_optimize', 'storage_compress_snapshots', 'suspend_vm',
+    'resume_vm', 'save_vm', 'start_vm', 'run_task', 'ps', 'show_conf',
+    'ssh_session', 'exec_container', 'pxe_boot', 'netlab_deploy',
+    'netlab_destroy', 'netlab_inspect', 'netlab_ssh',
+})
+
 
 def ensure_virtualbox_runtime_is_local(runtime: str) -> None:
     """
@@ -183,7 +201,7 @@ def _main():
     # Only the 'run' subcommand accepts dynamic task flags;
     # all other subcommands should reject unknown arguments.
     if remaining and (
-        not hasattr(args, "func") or args.func != BoxmanManager.run_task
+        getattr(args, 'handler', None) != 'run_task'
     ):
         arg_parser.error(f"unrecognized arguments: {' '.join(remaining)}")
 
@@ -203,27 +221,35 @@ def _main():
         print(f'v{boxman.metadata.version}')
         sys.exit(0)
 
-    if not hasattr(args, 'func'):
+    if not hasattr(args, 'handler'):
         arg_parser.print_help()
         sys.exit(1)
 
-    if args.func == BoxmanManager.list_projects:
+    # Defensive allowlist: the parser only ever sets these names, but
+    # dispatch resolves them with getattr — reject anything unexpected
+    # instead of risking an attribute lookup on the manager.
+    if args.handler not in _CLI_HANDLERS:
+        arg_parser.error(f"unknown command handler: {args.handler}")
+
+    if args.handler == 'list_projects':
         manager = BoxmanManager(config=None)
-        args.func(manager, args)
+        getattr(manager, args.handler)(args)
         sys.exit(0)
 
     # Handle 'image push' — provider-agnostic; no project config needed.
-    if args.func == BoxmanManager.push_image:
-        args.func(None, args)
+    if args.handler == 'push_image':
+        manager = BoxmanManager(config=None)
+        getattr(manager, args.handler)(args)
         sys.exit(0)
 
     # Handle 'image inspect' — provider-agnostic; no project config needed.
-    if args.func == BoxmanManager.inspect_image:
-        args.func(None, args)
+    if args.handler == 'inspect_image':
+        manager = BoxmanManager(config=None)
+        getattr(manager, args.handler)(args)
         sys.exit(0)
 
     # Handle 'ps' — needs config and virsh but not a full provider session
-    if args.func == BoxmanManager.ps:
+    if args.handler == 'ps':
         import contextlib
         _ps_json = getattr(args, 'json', False)
         _cm = suppressed() if _ps_json else contextlib.nullcontext()
@@ -244,7 +270,7 @@ def _main():
                     os.path.dirname(args.conf))
                 if 'project' in manager.config:
                     manager.runtime_instance.project_name = manager.config['project']
-            args.func(manager, args)
+            getattr(manager, args.handler)(args)
         sys.exit(0)
 
     # 'snapshot log' is a viewer command — suppress INFO logging across the
@@ -252,11 +278,11 @@ def _main():
     # execute spam from per-VM snapshot-dumpxml/info/current calls would
     # otherwise drown the few lines of actual output. The dispatch then
     # falls through to the regular provider-setup path below.
-    if args.func == BoxmanManager.snapshot_log:
+    if args.handler == 'snapshot_log':
         logging.getLogger('boxman').setLevel(logging.CRITICAL + 1)
 
     # Handle 'conf' — show effective merged configuration
-    if args.func == BoxmanManager.show_conf:
+    if args.handler == 'show_conf':
         manager = BoxmanManager(config=args.conf)
         if not manager.config:
             log.error("no project config found (conf.yml)")
@@ -273,11 +299,11 @@ def _main():
         project_provider = manager.config.get('provider', {}).get(provider_type, {})
         merged_provider = merge_provider_configs(
             provider_conf_with_runtime, project_provider)
-        args.func(manager, args, merged_provider=merged_provider)
+        getattr(manager, args.handler)(args, merged_provider=merged_provider)
         sys.exit(0)
 
     # Handle 'run' — needs config but not a provider session or runtime
-    if args.func == BoxmanManager.run_task:
+    if args.handler == 'run_task':
         manager = BoxmanManager(config=args.conf)
         if not manager.config:
             log.error("no project config found (conf.yml)")
@@ -289,32 +315,32 @@ def _main():
                     "Define tasks or use --cmd for ad-hoc commands."
                 )
                 sys.exit(1)
-        args.func(manager, args)
+        getattr(manager, args.handler)(args)
         sys.exit(0)
 
     # Handle 'ssh' — needs config but not a provider session or runtime
-    if args.func == BoxmanManager.ssh_session:
+    if args.handler == 'ssh_session':
         manager = BoxmanManager(config=args.conf)
         if not manager.config:
             log.error("no project config found (conf.yml)")
             sys.exit(1)
-        args.func(manager, args)
+        getattr(manager, args.handler)(args)
         sys.exit(0)
 
     # Handle 'exec' — container access; needs config but not the full libvirt
     # provider setup (the dc session is created on demand via _dc_session).
-    if args.func == BoxmanManager.exec_container:
+    if args.handler == 'exec_container':
         manager = BoxmanManager(config=args.conf)
         if not manager.config:
             log.error("no project config found (conf.yml)")
             sys.exit(1)
-        args.func(manager, args)
+        getattr(manager, args.handler)(args)
         sys.exit(0)
 
     else:
         # use the config of a deployment specified on the cmd line only if
         # not importing an image
-        config = None if args.func == BoxmanManager.import_image else args.conf
+        config = None if args.handler == 'import_image' else args.conf
         manager = BoxmanManager(config=config)
 
         # load the boxman app configuration
@@ -339,7 +365,7 @@ def _main():
         # before we lock it into the bind-mount list. Skip for destroy
         # (we're about to nuke the workdir anyway — prompting would be
         # absurd, especially with -y).
-        if args.func != BoxmanManager.destroy:
+        if args.handler != 'destroy':
             manager.reconcile_workdirs_with_runtime(
                 manager.runtime_instance.name)
 
@@ -379,25 +405,25 @@ def _main():
 
         # Handle destroy-runtime — tear down Docker resources without
         # starting the container first
-        if args.func == BoxmanManager.destroy_runtime:
-            args.func(manager, args)
+        if args.handler == 'destroy_runtime':
+            getattr(manager, args.handler)(args)
             sys.exit(0)
 
         # Commands that manage the runtime themselves (they start it
         # best-effort rather than hard-requiring it, so they still work
         # when the runtime is broken or unreachable).
-        manages_own_runtime = args.func == BoxmanManager.destroy
+        manages_own_runtime = args.handler == 'destroy'
 
         if not manages_own_runtime:
             # ensure the runtime environment is up and ready before proceeding
             manager.runtime_instance.ensure_ready()
 
         # Handle create-templates — it doesn't need a full provider session
-        if args.func == BoxmanManager.create_templates:
-            args.func(manager, args)
+        if args.handler == 'create_templates':
+            getattr(manager, args.handler)(args)
             sys.exit(0)
 
-        if args.func == BoxmanManager.import_image:
+        if args.handler == 'import_image':
 
             # if the provider is specified in the cmd line, use it
             if args.provider:
@@ -424,7 +450,7 @@ def _main():
         # Build a session for every provider declared in the project config
         # via the registry (import-image keeps its single-provider flow —
         # the provider type comes from the manifest / CLI flag above).
-        if args.func == BoxmanManager.import_image:
+        if args.handler == 'import_image':
             provider_types = [provider_type]
         else:
             provider_types = (
@@ -494,7 +520,7 @@ def _main():
             session.manager = manager
             manager.register_session(_ptype, session)
 
-        args.func(manager, args)
+        getattr(manager, args.handler)(args)
 
 
 if __name__ == '__main__':

--- a/src/boxman/scripts/cli_parser.py
+++ b/src/boxman/scripts/cli_parser.py
@@ -15,7 +15,6 @@ from argparse import RawTextHelpFormatter
 from datetime import datetime, timezone
 
 import boxman
-from boxman.manager import BoxmanManager
 from boxman.providers import PROVIDERS
 
 #: Default snapshot name — current UTC timestamp formatted for display.
@@ -216,7 +215,7 @@ def parse_args():
     # sub parser for importing images
     #
     parser_import_image = subparsers.add_parser('import-image', parents=[common], help='import an image')
-    parser_import_image.set_defaults(func=BoxmanManager.import_image)
+    parser_import_image.set_defaults(handler='import_image')
 
     parser_import_image.add_argument(
         '--uri',
@@ -268,7 +267,7 @@ def parse_args():
     parser_image_push = subparsers_image.add_parser(
         'push', parents=[common],
         help='push a qcow2 image (and optional metadata) to an OCI registry')
-    parser_image_push.set_defaults(func=BoxmanManager.push_image)
+    parser_image_push.set_defaults(handler='push_image')
     parser_image_push.add_argument(
         'image_ref',
         type=str,
@@ -295,7 +294,7 @@ def parse_args():
     parser_image_inspect = subparsers_image.add_parser(
         'inspect', parents=[common],
         help='inspect an OCI image reference (manifest + vmimage.json metadata)')
-    parser_image_inspect.set_defaults(func=BoxmanManager.inspect_image)
+    parser_image_inspect.set_defaults(handler='inspect_image')
     parser_image_inspect.add_argument(
         'image_ref',
         type=str,
@@ -308,7 +307,7 @@ def parse_args():
     parser_create_templates = subparsers.add_parser(
         'create-templates', parents=[common],
         help='create template VMs from cloud images using cloud-init')
-    parser_create_templates.set_defaults(func=BoxmanManager.create_templates)
+    parser_create_templates.set_defaults(handler='create_templates')
     parser_create_templates.add_argument(
         '--templates',
         type=str,
@@ -328,7 +327,7 @@ def parse_args():
     # sub parser for listing the registered projects
     #
     parser_list = subparsers.add_parser('list', parents=[common], help='list all registered projects')
-    parser_list.set_defaults(func=BoxmanManager.list_projects)
+    parser_list.set_defaults(handler='list_projects')
 
     list_format_group = parser_list.add_mutually_exclusive_group()
     list_format_group.add_argument(
@@ -362,7 +361,7 @@ def parse_args():
     # sub parser for provisioning a configuration
     #
     parser_prov = subparsers.add_parser('provision', parents=[common, force_parent, rebuild_templates_parent], help='provision a configuration')
-    parser_prov.set_defaults(func=BoxmanManager.provision)
+    parser_prov.set_defaults(handler='provision')
     parser_prov.add_argument(
         '--docker-compose',
         action='store_true',
@@ -377,7 +376,7 @@ def parse_args():
     parser_up = subparsers.add_parser(
         'up', parents=[common, force_parent, rebuild_templates_parent, recreate_networks_parent],
         help='bring up the infrastructure: provision if not created, start if powered off')
-    parser_up.set_defaults(func=BoxmanManager.up)
+    parser_up.set_defaults(handler='up')
     parser_up.add_argument(
         '--docker-compose',
         action='store_true',
@@ -399,7 +398,7 @@ def parse_args():
     parser_update = subparsers.add_parser(
         'update', parents=[common, recreate_networks_parent],
         help='apply config changes to already-provisioned VMs (CPU, memory, disks, add/remove VMs)')
-    parser_update.set_defaults(func=BoxmanManager.update)
+    parser_update.set_defaults(handler='update')
     parser_update.add_argument(
         '--dry-run',
         action='store_true',
@@ -428,7 +427,7 @@ def parse_args():
     parser_down = subparsers.add_parser(
         'down', parents=[common],
         help='bring down the infrastructure: save or suspend the state of all VMs')
-    parser_down.set_defaults(func=BoxmanManager.down)
+    parser_down.set_defaults(handler='down')
     parser_down.add_argument(
         '--suspend',
         action='store_true',
@@ -446,7 +445,7 @@ def parse_args():
     parser_destroy_rt.add_argument(
         '--auto-accept', '-y', action='store_true', default=False,
         help='skip the confirmation prompt and proceed immediately')
-    parser_destroy_rt.set_defaults(func=BoxmanManager.destroy_runtime)
+    parser_destroy_rt.set_defaults(handler='destroy_runtime')
 
     #
     # sub parser for the full-teardown 'destroy' command
@@ -464,13 +463,13 @@ def parse_args():
         help=('also remove template workdirs (~/boxman-templates by '
               'default, or a per-template workdir override). Off by '
               'default because templates are often shared across projects.'))
-    parser_destroy.set_defaults(func=BoxmanManager.destroy)
+    parser_destroy.set_defaults(handler='destroy')
 
     #
     # sub parser for deprovisioning a configuration
     #
     parser_deprov = subparsers.add_parser('deprovision', parents=[common], help='deprovision a configuration')
-    parser_deprov.set_defaults(func=BoxmanManager.deprovision)
+    parser_deprov.set_defaults(handler='deprovision')
     parser_deprov.add_argument(
         '--docker-compose',
         action='store_true',
@@ -498,7 +497,7 @@ def parse_args():
     # sub parser for the 'snapshot take' subsubcommand
     #
     parser_snap_take = subparsers_snap.add_parser('take', parents=[common, vms_parent], help='take a snapshot')
-    parser_snap_take.set_defaults(func=BoxmanManager.snapshot_take)
+    parser_snap_take.set_defaults(handler='snapshot_take')
     parser_snap_take.add_argument(
         '--cluster',
         type=str,
@@ -549,7 +548,7 @@ def parse_args():
     # sub parser for the 'snapshot list' subsubcommand
     #
     parser_snap_list = subparsers_snap.add_parser('list', parents=[common, vms_parent], help='list snapshots')
-    parser_snap_list.set_defaults(func=BoxmanManager.snapshot_list)
+    parser_snap_list.set_defaults(handler='snapshot_list')
 
     #
     # sub parser for the 'snapshot log' subsubcommand
@@ -557,7 +556,7 @@ def parse_args():
     parser_snap_log = subparsers_snap.add_parser(
         'log', parents=[common, vms_parent],
         help='git-log-style aggregated snapshot view across all vms')
-    parser_snap_log.set_defaults(func=BoxmanManager.snapshot_log)
+    parser_snap_log.set_defaults(handler='snapshot_log')
     parser_snap_log.add_argument(
         '-n', '--max',
         type=int,
@@ -589,7 +588,7 @@ def parse_args():
     # sub parser for the 'snapshot restore' subsubcommand
     #
     parser_snap_restore = subparsers_snap.add_parser('restore', parents=[common, vms_parent], help='restore the state of vms from snapshot')
-    parser_snap_restore.set_defaults(func=BoxmanManager.snapshot_restore)
+    parser_snap_restore.set_defaults(handler='snapshot_restore')
     parser_snap_restore.add_argument(
         '--cluster',
         type=str,
@@ -609,7 +608,7 @@ def parse_args():
     # sub parser for the 'snapshot delete' subsubcommand
     #
     parser_snap_delete = subparsers_snap.add_parser('delete', parents=[common, vms_parent], help='delete a snapshot')
-    parser_snap_delete.set_defaults(func=BoxmanManager.snapshot_delete)
+    parser_snap_delete.set_defaults(handler='snapshot_delete')
     parser_snap_delete.add_argument(
         '--cluster',
         type=str,
@@ -632,7 +631,7 @@ def parse_args():
         'collapse', parents=[common, vms_parent],
         help='merge snapshots newer than --to into the live head '
              '(target snapshot remains revertable)')
-    parser_snap_collapse.set_defaults(func=BoxmanManager.snapshot_collapse)
+    parser_snap_collapse.set_defaults(handler='snapshot_collapse')
     parser_snap_collapse.add_argument(
         '--to',
         type=str,
@@ -668,7 +667,7 @@ def parse_args():
     parser_restore = subparsers.add_parser(
         'restore', parents=[common],
         help='restore all VMs to their latest snapshot')
-    parser_restore.set_defaults(func=BoxmanManager.snapshot_restore, snapshot_name=None)
+    parser_restore.set_defaults(handler='snapshot_restore', snapshot_name=None)
 
     #
     # sub parser for the 'storage' subcommand
@@ -684,7 +683,7 @@ def parse_args():
     #
     parser_storage_df = subparsers_storage.add_parser(
         'df', parents=[common, vms_parent], help='show per-vm disk usage and reclaim estimate')
-    parser_storage_df.set_defaults(func=BoxmanManager.storage_df)
+    parser_storage_df.set_defaults(handler='storage_df')
 
     #
     # sub parser for the 'storage trim' subsubcommand
@@ -692,7 +691,7 @@ def parse_args():
     parser_storage_trim = subparsers_storage.add_parser(
         'trim', parents=[common, vms_parent],
         help='run fstrim inside running guests via qemu-guest-agent')
-    parser_storage_trim.set_defaults(func=BoxmanManager.storage_trim)
+    parser_storage_trim.set_defaults(handler='storage_trim')
     parser_storage_trim.add_argument(
         '--dry-run',
         action='store_true',
@@ -706,7 +705,7 @@ def parse_args():
     parser_storage_compact = subparsers_storage.add_parser(
         'compact', parents=[common, vms_parent],
         help='reclaim qcow2 space (sparsify or qemu-img convert)')
-    parser_storage_compact.set_defaults(func=BoxmanManager.storage_compact)
+    parser_storage_compact.set_defaults(handler='storage_compact')
     parser_storage_compact.add_argument(
         '--method',
         choices=['auto', 'sparsify', 'convert', 'convert-compressed'],
@@ -741,7 +740,7 @@ def parse_args():
     parser_storage_optimize = subparsers_storage.add_parser(
         'optimize', parents=[common, vms_parent],
         help='trim guests then compact qcow2 files (orchestrator)')
-    parser_storage_optimize.set_defaults(func=BoxmanManager.storage_optimize)
+    parser_storage_optimize.set_defaults(handler='storage_optimize')
     parser_storage_optimize.add_argument(
         '--method',
         choices=['auto', 'sparsify', 'convert', 'convert-compressed'],
@@ -784,7 +783,7 @@ def parse_args():
         'compress-snapshots', parents=[common, vms_parent],
         help='zstd-compress (or decompress) snapshot memory .raw files')
     parser_storage_compress.set_defaults(
-        func=BoxmanManager.storage_compress_snapshots)
+        handler='storage_compress_snapshots')
     parser_storage_compress.add_argument(
         '--level',
         type=int,
@@ -811,25 +810,25 @@ def parse_args():
     # sub parser for the 'control suspend' subsubcommand
     #
     parser_ctrl_suspend = subparsers_ctrl.add_parser('suspend', parents=[common, vms_parent, cluster_parent], help='suspend vms')
-    parser_ctrl_suspend.set_defaults(func=BoxmanManager.suspend_vm)
+    parser_ctrl_suspend.set_defaults(handler='suspend_vm')
 
     #
     # sub parser for the 'control resume' subsubcommand
     #
     parser_ctrl_resume = subparsers_ctrl.add_parser('resume', parents=[common, vms_parent, cluster_parent], help='resume vms')
-    parser_ctrl_resume.set_defaults(func=BoxmanManager.resume_vm)
+    parser_ctrl_resume.set_defaults(handler='resume_vm')
 
     #
     # sub parser for the 'control save' subsubcommand
     #
     parser_ctrl_save = subparsers_ctrl.add_parser('save', parents=[common, vms_parent, cluster_parent], help='save the state of vms')
-    parser_ctrl_save.set_defaults(func=BoxmanManager.save_vm)
+    parser_ctrl_save.set_defaults(handler='save_vm')
 
     #
     # sub parser for the 'control start' subsubcommand
     #
     parser_ctrl_start = subparsers_ctrl.add_parser('start', parents=[common, vms_parent, cluster_parent], help='start the vms')
-    parser_ctrl_start.set_defaults(func=BoxmanManager.start_vm)
+    parser_ctrl_start.set_defaults(handler='start_vm')
     parser_ctrl_start.add_argument(
         '--restore',
         action='store_true',
@@ -863,7 +862,7 @@ def parse_args():
         ),
         formatter_class=RawTextHelpFormatter
     )
-    parser_run.set_defaults(func=BoxmanManager.run_task)
+    parser_run.set_defaults(handler='run_task')
 
     parser_run.add_argument(
         'task_name',
@@ -914,7 +913,7 @@ def parse_args():
         ),
         formatter_class=RawTextHelpFormatter
     )
-    parser_ps.set_defaults(func=BoxmanManager.ps)
+    parser_ps.set_defaults(handler='ps')
     parser_ps.add_argument(
         '-p',
         action='store_true',
@@ -946,7 +945,7 @@ def parse_args():
         ),
         formatter_class=RawTextHelpFormatter
     )
-    parser_conf.set_defaults(func=BoxmanManager.show_conf)
+    parser_conf.set_defaults(handler='show_conf')
     parser_conf.add_argument(
         '--json',
         action='store_true',
@@ -971,7 +970,7 @@ def parse_args():
         ),
         formatter_class=RawTextHelpFormatter
     )
-    parser_ssh.set_defaults(func=BoxmanManager.ssh_session)
+    parser_ssh.set_defaults(handler='ssh_session')
 
     parser_ssh.add_argument(
         'vm_name',
@@ -1000,7 +999,7 @@ def parse_args():
         ),
         formatter_class=RawTextHelpFormatter
     )
-    parser_exec.set_defaults(func=BoxmanManager.exec_container)
+    parser_exec.set_defaults(handler='exec_container')
     parser_exec.add_argument(
         'target',
         type=str,
@@ -1040,7 +1039,7 @@ def parse_args():
         ),
         formatter_class=RawTextHelpFormatter
     )
-    parser_pxe.set_defaults(func=BoxmanManager.pxe_boot)
+    parser_pxe.set_defaults(handler='pxe_boot')
     parser_pxe.add_argument(
         '--vm',
         type=str,
@@ -1093,21 +1092,21 @@ def parse_args():
 
     parser_netlab_deploy = subparsers_netlab.add_parser(
         'deploy', parents=[common], help='render topology and deploy the containerlab lab')
-    parser_netlab_deploy.set_defaults(func=BoxmanManager.netlab_deploy)
+    parser_netlab_deploy.set_defaults(handler='netlab_deploy')
 
     parser_netlab_destroy = subparsers_netlab.add_parser(
         'destroy', parents=[common], help='tear down the containerlab lab (leaves VMs alone)')
-    parser_netlab_destroy.set_defaults(func=BoxmanManager.netlab_destroy)
+    parser_netlab_destroy.set_defaults(handler='netlab_destroy')
 
     parser_netlab_inspect = subparsers_netlab.add_parser(
         'inspect', parents=[common], help='print containerlab inspect --format json')
-    parser_netlab_inspect.set_defaults(func=BoxmanManager.netlab_inspect)
+    parser_netlab_inspect.set_defaults(handler='netlab_inspect')
 
     parser_netlab_ssh = subparsers_netlab.add_parser(
         'ssh', parents=[common],
         help='print the ssh command for a lab node (e.g. $(boxman netlab ssh sw1))'
     )
-    parser_netlab_ssh.set_defaults(func=BoxmanManager.netlab_ssh)
+    parser_netlab_ssh.set_defaults(handler='netlab_ssh')
     parser_netlab_ssh.add_argument(
         'node',
         type=str,

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -97,30 +97,27 @@ class TestSubcommandHelps:
 
 
 class TestStorageDispatch:
-    """Storage subverbs must wire to the correct BoxmanManager methods."""
+    """Storage subverbs must name the correct BoxmanManager handler."""
 
     def test_storage_df_dispatch(self):
-        from boxman.manager import BoxmanManager
         from boxman.scripts.app import parse_args
         parser = parse_args()
         args = parser.parse_args(["storage", "df"])
-        assert args.func is BoxmanManager.storage_df
+        assert args.handler == 'storage_df'
         assert args.vms == "all"
 
     def test_storage_trim_dispatch(self):
-        from boxman.manager import BoxmanManager
         from boxman.scripts.app import parse_args
         parser = parse_args()
         args = parser.parse_args(["storage", "trim"])
-        assert args.func is BoxmanManager.storage_trim
+        assert args.handler == 'storage_trim'
         assert args.dry_run is False
 
     def test_storage_compact_defaults(self):
-        from boxman.manager import BoxmanManager
         from boxman.scripts.app import parse_args
         parser = parse_args()
         args = parser.parse_args(["storage", "compact"])
-        assert args.func is BoxmanManager.storage_compact
+        assert args.handler == 'storage_compact'
         assert args.method == "auto"
         assert args.no_shutdown is False
         assert args.drop_snapshots is False
@@ -142,11 +139,10 @@ class TestStorageDispatch:
         assert args.dry_run is True
 
     def test_storage_optimize_dispatch(self):
-        from boxman.manager import BoxmanManager
         from boxman.scripts.app import parse_args
         parser = parse_args()
         args = parser.parse_args(["storage", "optimize", "--skip-trim"])
-        assert args.func is BoxmanManager.storage_optimize
+        assert args.handler == 'storage_optimize'
         assert args.skip_trim is True
         assert args.skip_compact is False
 
@@ -159,11 +155,10 @@ class TestStorageDispatch:
             parser.parse_args(["storage", "compact", "--method", "nuke-from-orbit"])
 
     def test_storage_compress_snapshots_dispatch(self):
-        from boxman.manager import BoxmanManager
         from boxman.scripts.app import parse_args
         parser = parse_args()
         args = parser.parse_args(["storage", "compress-snapshots"])
-        assert args.func is BoxmanManager.storage_compress_snapshots
+        assert args.handler == 'storage_compress_snapshots'
         assert args.level == 3
         assert args.decompress is False
 
@@ -191,12 +186,11 @@ class TestStorageDispatch:
         assert args.memory_compress_level == 3
 
     def test_snapshot_take_cluster_scope(self):
-        from boxman.manager import BoxmanManager
         from boxman.scripts.app import parse_args
         parser = parse_args()
         args = parser.parse_args(
             ["snapshot", "take", "--cluster", "cluster_2", "--vms", "node01"])
-        assert args.func is BoxmanManager.snapshot_take
+        assert args.handler == 'snapshot_take'
         assert args.cluster == "cluster_2"
         assert args.vms == "node01"
 
@@ -208,22 +202,20 @@ class TestStorageDispatch:
         assert args.vms == "all"
 
     def test_snapshot_restore_cluster_scope(self):
-        from boxman.manager import BoxmanManager
         from boxman.scripts.app import parse_args
         parser = parse_args()
         args = parser.parse_args(
             ["snapshot", "restore", "--cluster", "cluster_1", "--name", "s1"])
-        assert args.func is BoxmanManager.snapshot_restore
+        assert args.handler == 'snapshot_restore'
         assert args.cluster == "cluster_1"
         assert args.snapshot_name == "s1"
 
     def test_snapshot_delete_cluster_scope(self):
-        from boxman.manager import BoxmanManager
         from boxman.scripts.app import parse_args
         parser = parse_args()
         args = parser.parse_args(
             ["snapshot", "delete", "--cluster", "cluster_2", "--name", "s1"])
-        assert args.func is BoxmanManager.snapshot_delete
+        assert args.handler == 'snapshot_delete'
         assert args.cluster == "cluster_2"
 
     def test_snapshot_collapse_requires_to(self):
@@ -235,23 +227,21 @@ class TestStorageDispatch:
             parser.parse_args(["snapshot", "collapse"])
 
     def test_snapshot_collapse_dispatch(self):
-        from boxman.manager import BoxmanManager
         from boxman.scripts.app import parse_args
         parser = parse_args()
         args = parser.parse_args(
             ["snapshot", "collapse", "--to", "before-slurm"])
-        assert args.func is BoxmanManager.snapshot_collapse
+        assert args.handler == 'snapshot_collapse'
         assert args.target == "before-slurm"
         assert args.dry_run is False
         assert args.no_shutdown is False
         assert args.yes is False
 
     def test_snapshot_log_dispatch(self):
-        from boxman.manager import BoxmanManager
         from boxman.scripts.app import parse_args
         parser = parse_args()
         args = parser.parse_args(["snapshot", "log"])
-        assert args.func is BoxmanManager.snapshot_log
+        assert args.handler == 'snapshot_log'
         assert args.vms == "all"
         assert args.max_count is None
         assert args.as_json is False
@@ -371,23 +361,21 @@ class TestConfigDryRun:
 
 
 class TestImageDispatch:
-    """`image` subverbs must wire to the correct BoxmanManager methods."""
+    """`image` subverbs must name the correct BoxmanManager handler."""
 
     def test_image_inspect_dispatch(self):
-        from boxman.manager import BoxmanManager
         from boxman.scripts.app import parse_args
         parser = parse_args()
         args = parser.parse_args(["image", "inspect", "oci://reg/repo:tag"])
-        assert args.func is BoxmanManager.inspect_image
+        assert args.handler == 'inspect_image'
         assert args.image_ref == "oci://reg/repo:tag"
 
     def test_image_push_dispatch(self):
-        from boxman.manager import BoxmanManager
         from boxman.scripts.app import parse_args
         parser = parse_args()
         args = parser.parse_args(
             ["image", "push", "reg/repo:tag", "--qcow2", "/tmp/disk.qcow2"])
-        assert args.func is BoxmanManager.push_image
+        assert args.handler == 'push_image'
         assert args.image_ref == "reg/repo:tag"
         assert args.qcow2 == "/tmp/disk.qcow2"
         assert args.metadata is None

--- a/tests/test_netlab_cli.py
+++ b/tests/test_netlab_cli.py
@@ -11,7 +11,6 @@ from unittest.mock import patch
 
 import pytest
 
-from boxman.manager import BoxmanManager
 from boxman.scripts.app import main, parse_args
 
 pytestmark = pytest.mark.smoke
@@ -51,17 +50,17 @@ class TestNetlabParserWiring:
     def test_deploy_dispatches_to_handler(self):
         parser = parse_args()
         args = parser.parse_args(["netlab", "deploy"])
-        assert args.func is BoxmanManager.netlab_deploy
+        assert args.handler == 'netlab_deploy'
 
     def test_destroy_dispatches_to_handler(self):
         parser = parse_args()
         args = parser.parse_args(["netlab", "destroy"])
-        assert args.func is BoxmanManager.netlab_destroy
+        assert args.handler == 'netlab_destroy'
 
     def test_inspect_dispatches_to_handler(self):
         parser = parse_args()
         args = parser.parse_args(["netlab", "inspect"])
-        assert args.func is BoxmanManager.netlab_inspect
+        assert args.handler == 'netlab_inspect'
 
     def test_ssh_requires_node_arg(self):
         parser = parse_args()
@@ -71,7 +70,7 @@ class TestNetlabParserWiring:
     def test_ssh_dispatches_and_captures_node(self):
         parser = parse_args()
         args = parser.parse_args(["netlab", "ssh", "sw1"])
-        assert args.func is BoxmanManager.netlab_ssh
+        assert args.handler == 'netlab_ssh'
         assert args.node == "sw1"
         assert args.user is None
 

--- a/tests/test_provider_config_merge.py
+++ b/tests/test_provider_config_merge.py
@@ -113,7 +113,7 @@ class TestShowConfMerge:
     def test_show_conf_uses_unified_merge(self, conf_yml: Path):
         captured: dict = {}
 
-        def fake_show_conf(manager, args, merged_provider=None):
+        def fake_show_conf(args, merged_provider=None):
             captured["merged_provider"] = merged_provider
 
         with patch("boxman.manager.BoxmanCache"), \


### PR DESCRIPTION
Refs #85 (item 30, PR 2 of 2). Stacked on #133 (merged).

## What
- `cli_parser.py`: `set_defaults(func=BoxmanManager.x)` → `set_defaults(handler='<name>')` for all 37 subcommands; the parser no longer imports `BoxmanManager`.
- `app.py`: dispatch resolves `getattr(manager, args.handler)(args)` at call time, validated against an explicit `_CLI_HANDLERS` allowlist (37 names, verified to match the parser exactly). All ~15 `args.func == BoxmanManager.x` identity comparisons are now name comparisons. `grep -n 'args.func' src/` returns nothing.
- `image push`/`image inspect` no longer pass `None` as the manager — they dispatch through a config-less manager, same as `list`.

Success criterion met: decorating or aliasing a handler method can no longer silently break dispatch, since the method is resolved by name at dispatch time.

## Tests
- `args.func is BoxmanManager.x` assertions → `args.handler == '<name>'` (test_cli_smoke.py, test_netlab_cli.py).
- The `show_conf` class-level patch in test_provider_config_merge.py drops the `manager` positional — a patched attribute is no longer called with the manager as first arg.

## Verification
- Full unit suite: 1884 passed, 141 deselected (~10s)
- `ruff check src tests scripts`: exactly the 8 known violations
- Manual smoke: `--version`, no-args help (exit 1), unknown-flag rejection, `snapshot take --name` handler resolution