### PR TITLE
Raise on config/restore/update abort paths instead of exit 0 (#85 items 3, 17)

### DIFF
--- a/src/boxman/manager_parts/config.py
+++ b/src/boxman/manager_parts/config.py
@@ -38,6 +38,9 @@ class ConfigMixin:
 
         Returns:
             Dict containing the configuration
+
+        Raises:
+            ConfigError: If the configuration file does not exist.
         """
         # get the directory and filename for jinja template loading
         config_dir = os.path.dirname(os.path.abspath(config_path))
@@ -64,8 +67,12 @@ class ConfigMixin:
         # would have {{ suffix }} converted to {suffix} before Jinja2 runs,
         # leaving the literal string "disk{suffix}" in the output.
         raw_path = os.path.join(config_dir, config_filename)
-        with open(raw_path) as fobj:
-            raw_content = fobj.read()
+        try:
+            with open(raw_path) as fobj:
+                raw_content = fobj.read()
+        except FileNotFoundError as exc:
+            raise ConfigError(
+                f"project config not found: {raw_path}") from exc
 
         # collect all variable names introduced by jinja2 control flow
         jinja_ctrl_vars: set = set()

--- a/src/boxman/manager_parts/snapshots.py
+++ b/src/boxman/manager_parts/snapshots.py
@@ -353,7 +353,7 @@ class SnapshotsMixin:
                     "no VMs or containers matched the given "
                     "--cluster/--vms selection")
             if dc_abort:
-                self.logger.error(
+                raise SnapshotError(
                     "aborting restore — one or more snapshots have errors "
                     "(see above)")
             return
@@ -361,10 +361,9 @@ class SnapshotsMixin:
         if not selected:
             # containers only: nothing to pre-validate on the libvirt side
             if dc_abort:
-                self.logger.error(
+                raise SnapshotError(
                     "aborting restore — one or more snapshots have errors "
                     "(see above)")
-                return
             self._exit_if_dc_failed(self._restore_dc_plan(dc_plan), 'restore')
             return
 
@@ -439,10 +438,10 @@ class SnapshotsMixin:
                 self.logger.info(f"{len(failed)} VM(s) failed, retrying in 3s...")
                 time.sleep(3)
 
-        self.logger.error(
+        self._exit_if_dc_failed(dc_failed, 'restore')
+        raise SnapshotError(
             f"restore gave up after {max_rounds} rounds. "
             f"still failing: {[vm for vm, _ in pending]}")
-        self._exit_if_dc_failed(dc_failed, 'restore')
 
     def snapshot_delete(self, cli_args):
         """
@@ -455,8 +454,7 @@ class SnapshotsMixin:
         self._update_sessions_with_runtime()
 
         if not cli_args.snapshot_name:
-            self.logger.error("error: Snapshot name is required")
-            return
+            raise SnapshotError("snapshot name is required for delete")
 
         # docker-compose clusters (cluster-scoped, D3), failures isolated so
         # one cluster can't strand the others or the VMs.

--- a/src/boxman/manager_parts/vms.py
+++ b/src/boxman/manager_parts/vms.py
@@ -8,6 +8,7 @@ from multiprocessing import Process, Queue
 from typing import Any
 
 from boxman import log
+from boxman.exceptions import ConfigError, ProvisionError
 from boxman.loggers.logger import suppressed
 from boxman.manager_parts.images import ImagesMixin
 from boxman.providers.libvirt.commands import VirshCommand
@@ -807,14 +808,12 @@ class VMsMixin:
                 # ensure templates exist -- cloning from one that failed to
                 # build produces VMs whose cloud-init never ran
                 if not self.ensure_templates_exist():
-                    self.logger.error(
+                    raise ProvisionError(
                         "aborting: not every template could be created")
-                    return
                 try:
                     self.validate_base_images()
                 except ValueError as exc:
-                    self.logger.error(str(exc))
-                    return
+                    raise ConfigError(str(exc)) from exc
 
                 self._clone_and_configure_new_vms(new_vm_names)
 

--- a/tests/test_docker_compose_provider.py
+++ b/tests/test_docker_compose_provider.py
@@ -1379,13 +1379,15 @@ class TestSnapshotDcWiring:
 
     def test_restore_validates_before_mutating(self):
         """An invalid container snapshot must abort *before* the destructive
-        up --force-recreate (mher: partial-restore ordering)."""
+        up --force-recreate (mher: partial-restore ordering), and must raise
+        so the CLI exits non-zero (#85 item 3)."""
         m = self._mgr()
         sess = self._restore_session(valid=False, errors=["image missing: x"])
         m.session_for_cluster = lambda c: sess
         args = SimpleNamespace(snapshot_name="v1", cluster=None, vms="all")
         with mock.patch.object(BoxmanManager, "_select_vm_targets", lambda self, a: []):
-            m.snapshot_restore(args)
+            with pytest.raises(SnapshotError, match="aborting restore"):
+                m.snapshot_restore(args)
         sess.validate_snapshot_cluster.assert_called_once()
         sess.snapshot_restore_cluster.assert_not_called()
 

--- a/tests/test_failure_exit_codes.py
+++ b/tests/test_failure_exit_codes.py
@@ -137,3 +137,78 @@ class TestSnapshotFailuresRaise:
         ns = types.SimpleNamespace(snapshot_name="s1", vms="all", cluster=None)
         with pytest.raises(SnapshotError, match="aborting restore"):
             mgr.snapshot_restore(ns)
+
+    def test_restore_gives_up_after_max_rounds(self, monkeypatch):
+        """Workers that keep failing every round must surface as a raised
+        SnapshotError, not a logged error with exit 0 (#85 item 3)."""
+        mgr = _manager()
+        mgr.provider.validate_snapshot.return_value = (True, [])
+        monkeypatch.setattr(
+            BoxmanManager, "_run_parallel",
+            lambda self, tasks, op_label='parallel task':
+                ({}, {task[0]: "worker died" for task in tasks}))
+        monkeypatch.setattr("time.sleep", lambda *_: None)
+        ns = types.SimpleNamespace(snapshot_name="s1", vms="all", cluster=None)
+        with pytest.raises(SnapshotError, match="gave up after 20 rounds"):
+            mgr.snapshot_restore(ns)
+
+    def test_delete_requires_snapshot_name(self):
+        mgr = _manager()
+        ns = types.SimpleNamespace(snapshot_name=None, vms="all", cluster=None)
+        with pytest.raises(SnapshotError, match="snapshot name is required"):
+            mgr.snapshot_delete(ns)
+
+
+class TestUpdateFailuresRaise:
+    """``update()`` abort paths must raise, mirroring ``provision`` (#85 item 3)."""
+
+    @staticmethod
+    def _update_ready(mgr, monkeypatch):
+        """Stub everything ``update()`` touches before the new-VM template
+        checks so the test reaches them with two VMs to add."""
+        monkeypatch.setattr(
+            BoxmanManager, "_update_sessions_with_runtime", lambda cls: None)
+        monkeypatch.setattr(
+            BoxmanManager, "ensure_shared_bridges", lambda cls: None)
+        monkeypatch.setattr(
+            BoxmanManager, "reconcile_networks",
+            lambda cls, **kwargs: {})
+        monkeypatch.setattr(
+            BoxmanManager, "report_network_results", lambda cls, results: None)
+        monkeypatch.setattr(
+            BoxmanManager, "_find_all_existing_project_vms", lambda cls: [])
+        monkeypatch.setattr(
+            BoxmanManager, "_expand_oci_base_images", lambda cls: None)
+        return types.SimpleNamespace(dry_run=False, yes=True)
+
+    def test_ensure_templates_failure(self, monkeypatch):
+        mgr = _manager()
+        ns = self._update_ready(mgr, monkeypatch)
+        monkeypatch.setattr(
+            BoxmanManager, "ensure_templates_exist", lambda cls: False)
+        with pytest.raises(ProvisionError, match="could be created"):
+            mgr.update(ns)
+
+    def test_validate_base_images_failure(self, monkeypatch):
+        mgr = _manager()
+        ns = self._update_ready(mgr, monkeypatch)
+        monkeypatch.setattr(
+            BoxmanManager, "ensure_templates_exist", lambda cls: True)
+
+        def _invalid(cls):
+            raise ValueError("base image 'x' not found")
+
+        monkeypatch.setattr(BoxmanManager, "validate_base_images", _invalid)
+        with pytest.raises(ConfigError, match="base image 'x' not found"):
+            mgr.update(ns)
+
+
+class TestLoadConfigFailuresRaise:
+
+    def test_missing_config_file(self, tmp_path):
+        """A missing conf.yml must surface as ConfigError (exit 2 via the
+        BoxmanError mapping in app.py), not a raw FileNotFoundError
+        traceback (#85 item 17)."""
+        mgr = _manager()
+        with pytest.raises(ConfigError, match="project config not found"):
+            mgr.load_config(str(tmp_path / "conf.yml"))

--- a/tests/test_parallel_failures.py
+++ b/tests/test_parallel_failures.py
@@ -77,13 +77,16 @@ class TestRestoreRetryLoop:
 
     def test_raising_restore_worker_never_reports_success(self, monkeypatch):
         """The old queue-drain loop printed 'all VMs restored successfully'
-        when a worker died before queue.put — it must retry/fail instead."""
+        when a worker died before queue.put — it must retry, then raise
+        SnapshotError after the final round (#85 item 3)."""
+        from boxman.exceptions import SnapshotError
         monkeypatch.setattr("boxman.manager_parts.snapshots.time.sleep", lambda _s: None)
         mgr = _manager()
         mgr.provider.snapshot_restore.side_effect = RuntimeError("libvirt gone")
         mgr.provider.validate_snapshot.return_value = (True, [])
         ns = types.SimpleNamespace(snapshot_name="s1", vms="all", cluster=None)
-        mgr.snapshot_restore(ns)
+        with pytest.raises(SnapshotError, match="gave up after 20 rounds"):
+            mgr.snapshot_restore(ns)
         infos = [c.args[0] for c in mgr.logger.info.call_args_list if c.args]
         assert not any("all VMs restored successfully" in m for m in infos)
         errors = [c.args[0] for c in mgr.logger.error.call_args_list if c.args]


### PR DESCRIPTION
Refs #85 (items 3 and 17).

Final sweep of the deferred exit-0 leftovers:

- **item 17 (manager half)**: `load_config` did a bare `open(raw_path)` — a missing `conf.yml` dumped a raw `FileNotFoundError` traceback. Now raises `ConfigError('project config not found: ...')`, which app.py maps to exit 2.
- **item 3 leftovers** (deferred from #103):
  - `snapshot_restore`'s dc-only `dc_abort` early-returns now raise `SnapshotError`.
  - the give-up-after-20-rounds restore path now raises `SnapshotError` (previously logged and exited 0).
  - `snapshot_delete` without a snapshot name raises `SnapshotError` instead of `log.error` + return.
  - `update()`'s template-rebuild / base-image-validation failures now raise `ProvisionError`/`ConfigError`, mirroring the `provision()` fixes from #103.

Deliberately **not** converted (legitimate partial-failure tolerance, per-VM skip semantics): the `--no-shutdown` skip and per-VM failure paths in snapshot collapse/compact workers, and the per-VM failure summary in `update()`'s diff/apply loop.

Tests: new cases in `tests/test_failure_exit_codes.py` (missing conf.yml, restore give-up, delete-without-name, update template/validate failures); updated `test_parallel_failures.py` and `test_docker_compose_provider.py` for the new raise behavior. Full unit suite: 1889 passed. Ruff: unchanged at the 8 known violations.