### PR TITLE
Route remaining raw multiprocessing through _run_parallel, guard update prompt EOF (#85 items 4, 16)

### DIFF
--- a/src/boxman/manager_parts/flows.py
+++ b/src/boxman/manager_parts/flows.py
@@ -5,7 +5,6 @@ import os
 import shutil
 import subprocess
 import time
-from multiprocessing import Process
 
 from boxman import log
 from boxman.exceptions import ConfigError, ProvisionError
@@ -309,15 +308,11 @@ class FlowsMixin:
                     f"attempting to start...")
                 session.start_vm(vm_name)
 
-        processes = [
-            Process(
-                target=_bring_up,
-                args=(vm_name, state, vm_workdir_map.get(vm_name, ''))
-            )
-            for vm_name, state in non_running.items()
-        ]
-        [p.start() for p in processes]
-        [p.join() for p in processes]
+        self._run_parallel(
+            [(vm_name, _bring_up,
+              (vm_name, state, vm_workdir_map.get(vm_name, '')))
+             for vm_name, state in non_running.items()],
+            op_label='bring up vm')
 
         # Wait for IP addresses
         self.wait_for_vm_ips(self._get_project_vm_names(), max_wait=300)

--- a/src/boxman/manager_parts/vms.py
+++ b/src/boxman/manager_parts/vms.py
@@ -474,26 +474,20 @@ class VMsMixin:
                 if full in new_vm_names:
                     clone_tasks.append((cluster, vm_info, full))
 
-        processes = [
-            Process(target=_clone_with_retry,
-                    args=(self.provider, cluster, vm_info, new_vm_name))
-            for cluster, vm_info, new_vm_name in clone_tasks
-        ]
-        [p.start() for p in processes]
-        [p.join() for p in processes]
-
-        # Abort the update if any clone subprocess exited non-zero — same
-        # guard as :meth:`clone_vms` to prevent downstream configure/start
-        # steps from running against VMs that were never defined.
-        failed = [
-            (task[2], p.exitcode)
-            for task, p in zip(clone_tasks, processes)
-            if p.exitcode != 0
-        ]
-        if failed:
-            names = ', '.join(name for name, _ in failed)
+        # Abort the update if any clone worker fails — same guard as
+        # :meth:`clone_vms` to prevent downstream configure/start steps
+        # from running against VMs that were never defined. _run_parallel
+        # reports raised/killed workers as failures, not just non-zero
+        # exitcodes.
+        _results, failures = self._run_parallel(
+            [(new_vm_name, _clone_with_retry,
+              (self.provider, cluster, vm_info, new_vm_name))
+             for cluster, vm_info, new_vm_name in clone_tasks],
+            op_label='clone vm')
+        if failures:
+            names = ', '.join(sorted(failures))
             raise RuntimeError(
-                f"clone failed for {len(failed)} new VM(s) ({names}); "
+                f"clone failed for {len(failures)} new VM(s) ({names}); "
                 f"aborting update. See the virt-clone error logged above.")
 
         # configure and start new VMs (parallel)
@@ -504,15 +498,11 @@ class VMsMixin:
                 if full in new_vm_names:
                     configure_tasks.append((cluster_name, cluster, vm_name, vm_info))
 
-        processes = [
-            Process(
-                target=self._configure_and_start_vm,
-                args=(cluster_name, cluster, vm_name, vm_info)
-            )
-            for cluster_name, cluster, vm_name, vm_info in configure_tasks
-        ]
-        [p.start() for p in processes]
-        [p.join() for p in processes]
+        self._run_parallel(
+            [(f"{cluster_name}/{vm_name}", self._configure_and_start_vm,
+              (cluster_name, cluster, vm_name, vm_info))
+             for cluster_name, cluster, vm_name, vm_info in configure_tasks],
+            op_label='configure and start vm')
 
     def _update_single_vm(
         self,
@@ -792,7 +782,14 @@ class VMsMixin:
             print(
                 "This will stop the VM(s), remove their disks, and "
                 "clean up all associated resources.\n")
-            answer = input("Proceed? [y/N] ").strip().lower()
+            try:
+                answer = input("Proceed? [y/N] ").strip().lower()
+            except EOFError:
+                # nothing is attached to stdin (a cron run, a pipeline):
+                # treat that as a no rather than a traceback — same guard
+                # as destroy/destroy_runtime (#85 item 16)
+                print("No input available, aborted.")
+                return
             if answer not in ("y", "yes"):
                 print("Aborted.")
                 return
@@ -838,22 +835,26 @@ class VMsMixin:
                         update_tasks.append(
                             (cluster_name, cluster_cfg, vm_name, vm_info))
 
-            processes = [
-                Process(
-                    target=self._update_single_vm,
-                    args=(cluster_name, cluster_cfg, vm_name, vm_info,
-                          result_queue, dry_run)
-                )
-                for cluster_name, cluster_cfg, vm_name, vm_info in update_tasks
-            ]
-            [p.start() for p in processes]
-            [p.join() for p in processes]
+            # _run_parallel reports raised/killed workers as failures;
+            # merge those into the collected results below so a dying
+            # worker lands in the failed summary instead of vanishing.
+            _res, parallel_failures = self._run_parallel(
+                [(f"{cluster_name}/{vm_name}", self._update_single_vm,
+                  (cluster_name, cluster_cfg, vm_name, vm_info,
+                   result_queue, dry_run))
+                 for cluster_name, cluster_cfg, vm_name, vm_info in update_tasks],
+                op_label='update vm')
 
             # collect and print results
             results = {}
             while not result_queue.empty():
                 vm_name, result = result_queue.get()
                 results[vm_name] = result
+            for label, reason in parallel_failures.items():
+                results.setdefault(label.split('/')[-1], {
+                    'status': 'failed',
+                    'details': reason,
+                })
 
             # print summary
             no_change = [n for n, r in results.items() if r['status'] == 'no_change']

--- a/tests/test_destroy_prompt.py
+++ b/tests/test_destroy_prompt.py
@@ -2,7 +2,8 @@
 Regression test for #85 item 16: the ``destroy`` confirmation prompt must
 abort cleanly on EOF (CI / piped stdin) instead of dying with an EOFError
 traceback — same guard its siblings (destroy_runtime, _recreate_network,
-snapshot_collapse) already have.
+snapshot_collapse) already have. ``update``'s removed-VMs prompt got the
+same guard in the final item-16 sweep.
 """
 
 import types
@@ -51,3 +52,36 @@ def test_destroy_prompt_aborts_cleanly_on_eof(monkeypatch, capsys):
     assert "No input available, aborted." in capsys.readouterr().out
     # Nothing destructive ran: the runtime was never started.
     mgr._runtime_instance.ensure_ready.assert_not_called()
+
+
+def test_update_prompt_aborts_cleanly_on_eof(monkeypatch, capsys):
+    """update()'s removed-VMs confirmation must abort cleanly on EOF too."""
+    mgr = _manager()
+    # No VMs left in config, one stale VM in libvirt → the removal prompt.
+    mgr.config = {"project": "demo", "clusters": {}}
+    monkeypatch.setattr(
+        BoxmanManager, "_update_sessions_with_runtime", lambda self: None)
+    monkeypatch.setattr(
+        BoxmanManager, "ensure_shared_bridges", lambda self: None)
+    monkeypatch.setattr(
+        BoxmanManager, "reconcile_networks", lambda self, **kw: {})
+    monkeypatch.setattr(
+        BoxmanManager, "report_network_results", lambda self, r: None)
+    monkeypatch.setattr(
+        BoxmanManager, "_find_all_existing_project_vms",
+        lambda self: ["bprj__demo__bprj_cluster_1_old01"])
+    monkeypatch.setattr(BoxmanManager, "_run_parallel", MagicMock())
+
+    def _eof_input(_prompt):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _eof_input)
+    ns = types.SimpleNamespace(dry_run=False, yes=False,
+                               recreate_networks=False)
+
+    # Must return cleanly, not raise EOFError.
+    mgr.update(ns)
+
+    assert "No input available, aborted." in capsys.readouterr().out
+    # Nothing destructive ran: no VM was destroyed in parallel.
+    mgr._run_parallel.assert_not_called()

--- a/tests/test_manager_core.py
+++ b/tests/test_manager_core.py
@@ -418,18 +418,11 @@ class TestCloneAndConfigureNewVmsExitCodeGuard:
     """
     Mirror of TestCloneVmsExitCodeGuard but for the `update` path
     (_clone_and_configure_new_vms). Same silent-failure bug if any
-    clone subprocess exits non-zero — the configure/start steps would
-    otherwise run against VMs that were never defined.
+    clone worker fails — the configure/start steps would otherwise run
+    against VMs that were never defined. The clone batch runs through
+    ``_run_parallel`` (#85 item 4), which reports raised/killed workers
+    as failures.
     """
-
-    @staticmethod
-    def _fake_process(exitcode: int):
-        from unittest.mock import MagicMock
-        proc = MagicMock()
-        proc.exitcode = exitcode
-        proc.start = MagicMock()
-        proc.join = MagicMock()
-        return proc
 
     def _mgr_with_one_vm(self, tmp_path: Path):
         from unittest.mock import MagicMock
@@ -453,22 +446,22 @@ class TestCloneAndConfigureNewVmsExitCodeGuard:
     def test_raises_when_clone_subprocess_fails(self, tmp_path: Path):
         from unittest.mock import patch as _patch
         m = self._mgr_with_one_vm(tmp_path)
-        fake = self._fake_process(exitcode=1)
         new_vm_names = {'bprj__demo__bprj_cluster_1_node01'}
+        failures = {
+            'bprj__demo__bprj_cluster_1_node01': 'worker exited with code 1'}
         with _patch.object(m, '_ensure_libvirt_storage_pool'), \
-             _patch("boxman.manager_parts.vms.Process", return_value=fake):
+             _patch.object(m, '_run_parallel', return_value=({}, failures)):
             with pytest.raises(RuntimeError, match="clone failed for 1 new VM"):
                 m._clone_and_configure_new_vms(new_vm_names)
 
     def test_no_raise_when_all_clones_succeed(self, tmp_path: Path):
         """When clones succeed, control should move into the configure
-        phase — patch _configure_and_start_vm so we don't depend on the
-        rest of the orchestration."""
+        phase — _run_parallel is patched out, so no real workers run."""
         from unittest.mock import patch as _patch
         m = self._mgr_with_one_vm(tmp_path)
-        fake = self._fake_process(exitcode=0)
         new_vm_names = {'bprj__demo__bprj_cluster_1_node01'}
         with _patch.object(m, '_ensure_libvirt_storage_pool'), \
-             _patch.object(m, '_configure_and_start_vm'), \
-             _patch("boxman.manager_parts.vms.Process", return_value=fake):
+             _patch.object(m, '_run_parallel', return_value=({}, {})) as par:
             m._clone_and_configure_new_vms(new_vm_names)
+        # clone batch + configure batch
+        assert par.call_count == 2

--- a/tests/test_parallel_failures.py
+++ b/tests/test_parallel_failures.py
@@ -44,6 +44,11 @@ def _dying_worker():
     os._exit(1)
 
 
+def _dying_update_worker(*_args):
+    # Same hard crash, but tolerant of the update-worker's arg list.
+    os._exit(1)
+
+
 class TestRunParallel:
 
     def test_success_collects_results(self):
@@ -91,6 +96,38 @@ class TestRestoreRetryLoop:
         assert not any("all VMs restored successfully" in m for m in infos)
         errors = [c.args[0] for c in mgr.logger.error.call_args_list if c.args]
         assert any("libvirt gone" in m for m in errors)
+
+
+class TestUpdateParallelFailures:
+
+    def test_dying_update_worker_lands_in_failed_summary(self, monkeypatch):
+        """update()'s per-VM diff/apply batch runs through _run_parallel:
+        a worker killed before queue.put must land in the failed summary,
+        not vanish silently (#85 items 4/16)."""
+        mgr = _manager()
+        full = "bprj__demo__bprj_cluster_1_node01"
+        monkeypatch.setattr(
+            BoxmanManager, "_update_sessions_with_runtime", lambda self: None)
+        monkeypatch.setattr(
+            BoxmanManager, "ensure_shared_bridges", lambda self: None)
+        monkeypatch.setattr(
+            BoxmanManager, "reconcile_networks", lambda self, **kw: {})
+        monkeypatch.setattr(
+            BoxmanManager, "report_network_results", lambda self, r: None)
+        monkeypatch.setattr(
+            BoxmanManager, "_find_all_existing_project_vms",
+            lambda self: [full])
+        monkeypatch.setattr(
+            BoxmanManager, "setup_ssh_access", lambda self: None)
+        monkeypatch.setattr(
+            BoxmanManager, "connect_info", lambda self: None)
+        monkeypatch.setattr(
+            BoxmanManager, "_update_single_vm", _dying_update_worker)
+        ns = types.SimpleNamespace(
+            dry_run=False, yes=True, recreate_networks=False)
+        mgr.update(ns)
+        errors = [c.args[0] for c in mgr.logger.error.call_args_list if c.args]
+        assert any("failed" in msg and "node01" in msg for msg in errors)
 
 
 class TestGetConnectInfo:


### PR DESCRIPTION
Refs #85 (items 4 and 16, deferred leftovers).

**item 4 — remaining raw multiprocessing sites converted to `_run_parallel`:**
- `up()`'s `_bring_up` batch (flows.py) — previously raw start/join with *no* exitcode check, so a dying bring-up worker was completely silent.
- `_clone_and_configure_new_vms` (update path): clone batch and configure/start batch. The clone batch kept its abort-on-failure `RuntimeError`, now fed by `_run_parallel`'s failures dict (which also covers killed/no-result workers, not just non-zero exitcodes).
- `update()`'s per-VM diff/apply batch (`_update_single_vm`): worker results still flow through the existing result queue; `_run_parallel` failures are merged into the summary so a dying worker shows up as `failed` instead of disappearing.

Left as-is, deliberately: `clone_vms` (provision path) already checks exitcodes and raises — its regression tests (`TestCloneVmsExitCodeGuard`) pin that contract; `providers/libvirt/session.py`'s disk-configure batch is provider-internal and outside the manager helper's scope.

**item 16 — prompt guard:** `update()`'s removed-VMs confirmation had an unprotected `input()`; it now has the same `EOFError` guard as `destroy`/`destroy_runtime` (#107 pattern) — EOF aborts cleanly with "No input available, aborted." instead of a traceback.

Tests: new dying-worker-reported-failed test for `update()` (test_parallel_failures.py), new EOF-abort test (test_destroy_prompt.py), `TestCloneAndConfigureNewVmsExitCodeGuard` re-pinned to the `_run_parallel` contract. Full unit suite: 1891 passed. Ruff: 7 violations (one known B905 removed by the conversion; no new ones).