### PR TITLE
Compose VirshCommand instead of inheriting it (#85 item 31)

### DIFF
--- a/src/boxman/providers/libvirt/cdrom.py
+++ b/src/boxman/providers/libvirt/cdrom.py
@@ -3,6 +3,8 @@ import tempfile
 from typing import Any
 from xml.sax.saxutils import escape
 
+from boxman import log
+
 from .commands import VirshCommand
 from .virsh_parse import parse_domblklist
 
@@ -17,7 +19,7 @@ def _xml_attr(value: str) -> str:
     return escape(str(value), {"'": '&apos;', '"': '&quot;'})
 
 
-class CDROMManager(VirshCommand):
+class CDROMManager:
     """
     Class for managing CDROM/ISO device operations in libvirt.
 
@@ -26,7 +28,15 @@ class CDROMManager(VirshCommand):
     """
 
     def __init__(self, vm_name: str, provider_config: dict[str, Any] | None = None):
-        super().__init__(provider_config)
+        #: VirshCommand: Command executor for virsh
+        self.virsh = VirshCommand(provider_config=provider_config)
+
+        #: Dict[str, Any]: Configuration for the libvirt provider
+        self.provider_config = provider_config or {}
+
+        #: logging.Logger: Logger instance
+        self.logger = log
+
         self.vm_name = vm_name
 
     def attach_cdrom(self,
@@ -66,7 +76,7 @@ class CDROMManager(VirshCommand):
             attachment_args = ["--persistent"] if persistent else []
             # warn=True so a failed attach reaches the error branch below
             # instead of raising out of execute (matches change_media)
-            result = self.execute("attach-device", self.vm_name, temp_path,
+            result = self.virsh.execute("attach-device", self.vm_name, temp_path,
                                   *attachment_args, warn=True)
 
             os.unlink(temp_path)
@@ -110,7 +120,7 @@ class CDROMManager(VirshCommand):
             detach_args = ["--persistent"] if persistent else []
             # warn=True so a failed detach reaches the error branch below
             # instead of raising out of execute (matches change_media)
-            result = self.execute("detach-device", self.vm_name, temp_path,
+            result = self.virsh.execute("detach-device", self.vm_name, temp_path,
                                   *detach_args, warn=True)
 
             os.unlink(temp_path)
@@ -145,7 +155,7 @@ class CDROMManager(VirshCommand):
                 self.logger.error(f"ISO file does not exist: {source_path}")
                 return False
 
-            result = self.execute(
+            result = self.virsh.execute(
                 "change-media", self.vm_name, target_dev,
                 source_path, "--live", "--config",
                 warn=True)
@@ -188,7 +198,7 @@ class CDROMManager(VirshCommand):
         Returns a list of dicts with 'target' and 'source' keys.
         Excludes seed ISOs (used for cloud-init).
         """
-        result = self.execute("domblklist", self.vm_name, "--details", warn=True)
+        result = self.virsh.execute("domblklist", self.vm_name, "--details", warn=True)
         if not result.ok:
             return []
 
@@ -252,7 +262,7 @@ class CDROMManager(VirshCommand):
         Returns:
             Device name (e.g., 'hdc') or None if no slot available
         """
-        result = self.execute("domblklist", self.vm_name, "--details", warn=True)
+        result = self.virsh.execute("domblklist", self.vm_name, "--details", warn=True)
 
         used_targets = set()
         if result.ok:

--- a/src/boxman/providers/libvirt/commands.py
+++ b/src/boxman/providers/libvirt/commands.py
@@ -286,7 +286,7 @@ class LibVirtCommandBase:
             raise ValueError(f"unsupported runtime: {self.runtime}")
 
 
-class VirshCommand(LibVirtCommandBase):  # Fixed missing closing parenthesis:
+class VirshCommand(LibVirtCommandBase):
     """
     Class for executing virsh commands for managing libvirt domains,
     networks, storage, etc.

--- a/src/boxman/providers/libvirt/destroy_vm.py
+++ b/src/boxman/providers/libvirt/destroy_vm.py
@@ -16,8 +16,8 @@ def wait_until_shut_off(virsh,
     Poll until *vm_name* reports "shut off", giving up after *timeout* seconds.
 
     Args:
-        virsh: Command executor with an ``execute`` method (e.g.
-            :class:`VirshCommand` or any subclass).
+        virsh: Command executor with an ``execute`` method (a
+            :class:`VirshCommand` instance).
         vm_name: Name of the VM.
         timeout: Maximum seconds to wait.
         poll_interval: Seconds between ``domstate`` polls.
@@ -92,7 +92,7 @@ def shutdown_and_wait(virsh,
     return is_shut_off()
 
 
-class DestroyVM(VirshCommand):
+class DestroyVM:
     """
     Class to destroy (remove) VMs in libvirt using virsh commands.
 
@@ -109,7 +109,11 @@ class DestroyVM(VirshCommand):
             name: Name of the VM to destroy
             provider_config: Configuration for the libvirt provider
         """
-        super().__init__(provider_config=provider_config)
+        #: VirshCommand: Command executor for virsh
+        self.virsh = VirshCommand(provider_config=provider_config)
+
+        #: logging.Logger: Logger instance
+        self.logger = log
 
         #: str: the name of the VM to destroy
         self.name = name
@@ -125,7 +129,7 @@ class DestroyVM(VirshCommand):
             True if VM is running, False otherwise
         """
         try:
-            result = self.execute("domstate", self.name, warn=True)
+            result = self.virsh.execute("domstate", self.name, warn=True)
             return result.ok and "running" in result.stdout
         except RuntimeError:
             return False
@@ -142,7 +146,7 @@ class DestroyVM(VirshCommand):
             True when the domain is "shut off" or no longer exists.
         """
         try:
-            result = self.execute("domstate", self.name, warn=True)
+            result = self.virsh.execute("domstate", self.name, warn=True)
             if not result.ok:
                 return True   # domain gone → effectively stopped
             return "shut off" in result.stdout
@@ -157,7 +161,7 @@ class DestroyVM(VirshCommand):
             True if VM exists, False otherwise
         """
         try:
-            result = self.execute("dominfo", self.name, warn=True)
+            result = self.virsh.execute("dominfo", self.name, warn=True)
             return result.ok
         except RuntimeError:
             return False
@@ -188,12 +192,12 @@ class DestroyVM(VirshCommand):
         try:
             # try graceful shutdown first
             self.logger.info(f"shutting down vm {self.name} gracefully")
-            self.execute("shutdown", self.name)
+            self.virsh.execute("shutdown", self.name)
 
             # wait for vm to reach "shut off" — not just "not running", because
             # a VM in the "in shutdown" state is no longer "running" but the
             # QEMU process is still alive (and storage cannot be removed yet).
-            if shutdown_and_wait(self, self.name, timeout=timeout,
+            if shutdown_and_wait(self.virsh, self.name, timeout=timeout,
                                  force_after=False, poll_interval=1,
                                  logger=self.logger,
                                  is_shut_off=self.is_vm_shut_off):
@@ -232,7 +236,7 @@ class DestroyVM(VirshCommand):
 
         try:
             self.logger.info(f"force shutting down the vm {self.name}")
-            self.execute("destroy", self.name)
+            self.virsh.execute("destroy", self.name)
 
             # verify that the vm is no longer running
             if not self.is_vm_running():
@@ -284,7 +288,7 @@ class DestroyVM(VirshCommand):
         try:
             self.logger.info(f"un-defining vm {self.name}")
 
-            self.execute("undefine", self.name)
+            self.virsh.execute("undefine", self.name)
 
             # verify that the vm is no longer defined
             if not self.is_vm_defined():
@@ -314,7 +318,7 @@ class DestroyVM(VirshCommand):
         if not self.is_vm_shut_off():
             self.logger.warning(
                 f"vm {self.name} is not shut off, force-killing before undefine")
-            self.execute("destroy", self.name, warn=True)
+            self.virsh.execute("destroy", self.name, warn=True)
 
         try:
             self.logger.info(f"**force** un-defining vm {self.name}")
@@ -325,7 +329,7 @@ class DestroyVM(VirshCommand):
             # requires a recent libvirt, so on failure fall back to a
             # plain undefine that only drops snapshot metadata — the
             # domain must always be removable.
-            result = self.execute(
+            result = self.virsh.execute(
                 "undefine", self.name,
                 "--remove-all-storage", "--wipe-storage",
                 "--delete-storage-volume-snapshots", "--snapshots-metadata",
@@ -334,7 +338,7 @@ class DestroyVM(VirshCommand):
                 self.logger.warning(
                     f"undefine with storage removal failed for {self.name} "
                     f"({result.stderr.strip()}) — retrying plain undefine")
-                self.execute("undefine", self.name, "--snapshots-metadata")
+                self.virsh.execute("undefine", self.name, "--snapshots-metadata")
 
             # verify that the vm is no longer defined
             if not self.is_vm_defined():

--- a/src/boxman/providers/libvirt/disk.py
+++ b/src/boxman/providers/libvirt/disk.py
@@ -2,6 +2,8 @@ import os
 import tempfile
 from typing import Any
 
+from boxman import log
+
 from .commands import LibVirtCommandBase, VirshCommand
 
 
@@ -24,7 +26,7 @@ def disk_path_for(workdir: str,
     return os.path.expanduser(disk_path)
 
 
-class DiskManager(VirshCommand):
+class DiskManager:
     """
     Class for managing VM disk operations in libvirt.
 
@@ -39,7 +41,14 @@ class DiskManager(VirshCommand):
             vm_name: Name of the VM to manage disks for
             provider_config: Configuration for the libvirt provider
         """
-        super().__init__(provider_config)
+        #: VirshCommand: Command executor for virsh
+        self.virsh = VirshCommand(provider_config=provider_config)
+
+        #: Dict[str, Any]: Configuration for the libvirt provider
+        self.provider_config = provider_config or {}
+
+        #: logging.Logger: Logger instance
+        self.logger = log
 
         #: str: the name of the VM
         self.vm_name = vm_name
@@ -122,7 +131,7 @@ class DiskManager(VirshCommand):
 
             # Attach the disk
             attachment_args = ["--persistent"] if persistent else []
-            result = self.execute("attach-device", self.vm_name, temp_path,
+            result = self.virsh.execute("attach-device", self.vm_name, temp_path,
                                   *attachment_args, warn=True)
 
             # Clean up the temporary file
@@ -271,7 +280,7 @@ class DiskManager(VirshCommand):
             True if successful, False otherwise
         """
         try:
-            result = self.execute(
+            result = self.virsh.execute(
                 'blockresize', self.vm_name,
                 target_dev, f"--size={new_size_mb}M", warn=True)
 

--- a/src/boxman/providers/libvirt/net.py
+++ b/src/boxman/providers/libvirt/net.py
@@ -17,7 +17,7 @@ from .commands import VirshCommand
 from .virsh_parse import parse_domiflist
 
 
-class Network(VirshCommand):
+class Network:
     """
     Class to define libvirt networks by creating XML definitions and using virsh commands.
     """
@@ -38,7 +38,14 @@ class Network(VirshCommand):
             provider_config: Configuration for the libvirt provider
             cache: Optional cache object for storing network definitions
         """
-        super().__init__(provider_config=provider_config)
+        #: VirshCommand: Command executor for virsh
+        self.virsh = VirshCommand(provider_config=provider_config)
+
+        #: Dict[str, Any]: Configuration for the libvirt provider
+        self.provider_config = provider_config or {}
+
+        #: logging.Logger: Logger instance
+        self.logger = log
 
         #: str: the name of the network
         self.name = name
@@ -417,7 +424,7 @@ class Network(VirshCommand):
     def _listed_networks(self, active_only: bool = False) -> list[str] | None:
         """Names of the networks libvirt knows, or None if it could not be asked."""
         args = ["net-list", "--name"] if active_only else ["net-list", "--all", "--name"]
-        result = self.execute(*args, hide=True, warn=True)
+        result = self.virsh.execute(*args, hide=True, warn=True)
         if not result.ok:
             return None
         return [line.strip() for line in result.stdout.splitlines() if line.strip()]
@@ -442,7 +449,7 @@ class Network(VirshCommand):
             The XML text, or None when it could not be read (undefined, or
             libvirt unreachable -- use :meth:`exists` to tell those apart).
         """
-        result = self.execute("net-dumpxml", self.name, hide=True, warn=True)
+        result = self.virsh.execute("net-dumpxml", self.name, hide=True, warn=True)
         if not result.ok:
             return None
         return result.stdout
@@ -454,14 +461,14 @@ class Network(VirshCommand):
 
     def start(self) -> bool:
         """Start a defined network, and make it come back after a host reboot."""
-        result = self.execute("net-start", self.name, hide=True, warn=True)
+        result = self.virsh.execute("net-start", self.name, hide=True, warn=True)
         if not result.ok:
             self.logger.error(
                 f"network {self.name}: could not be started: "
                 f"{result.stderr.strip()}")
             return False
 
-        autostart = self.execute(
+        autostart = self.virsh.execute(
             "net-autostart", self.name, hide=True, warn=True)
         if not autostart.ok:
             # not fatal, but it means the network is gone again after a reboot
@@ -514,7 +521,7 @@ class Network(VirshCommand):
             if live:
                 args.append("--live")
 
-            result = self.execute(*args, hide=True, warn=True)
+            result = self.virsh.execute(*args, hide=True, warn=True)
             if not result.ok:
                 self.logger.error(
                     f"network {self.name}: {command} {section} failed: "
@@ -574,13 +581,13 @@ class Network(VirshCommand):
 
         Used to tell the user which guests a recreate would disconnect.
         """
-        result = self.execute("list", "--all", "--name", hide=True, warn=True)
+        result = self.virsh.execute("list", "--all", "--name", hide=True, warn=True)
         if not result.ok:
             return []
 
         attached = []
         for domain in [line.strip() for line in result.stdout.splitlines() if line.strip()]:
-            iflist = self.execute(
+            iflist = self.virsh.execute(
                 "domiflist", domain, hide=True, warn=True)
             if not iflist.ok:
                 continue
@@ -726,7 +733,7 @@ class Network(VirshCommand):
 
         # define the network
         try:
-            self.execute("net-define", written_path)
+            self.virsh.execute("net-define", written_path)
 
             # the cache is written only once the network really exists. Written
             # before the define, a failed define (a rejected netmask, a libvirtd
@@ -735,8 +742,8 @@ class Network(VirshCommand):
             # later run -- wedged until projects.json is edited by hand
             self.update_network_cache()
 
-            self.execute("net-start", self.name)
-            self.execute("net-autostart", self.name)
+            self.virsh.execute("net-start", self.name)
+            self.virsh.execute("net-autostart", self.name)
 
             # apply appropriate network configuration based on type. NAT
             # needs nothing from boxman: libvirtd installs the masquerade
@@ -773,7 +780,7 @@ class Network(VirshCommand):
 
             # destroy only when the network itself is active
             if self.is_active():
-                self.execute("net-destroy", self.name)
+                self.virsh.execute("net-destroy", self.name)
                 self.logger.info(f"network {self.name} destroyed successfully")
 
             return True
@@ -800,10 +807,10 @@ class Network(VirshCommand):
                 return True
 
             # disable autostart first if it's enabled
-            self.execute("net-autostart", self.name, "--disable", warn=True)
+            self.virsh.execute("net-autostart", self.name, "--disable", warn=True)
 
             # undefine the network
-            self.execute("net-undefine", self.name)
+            self.virsh.execute("net-undefine", self.name)
             self.logger.info(f"network {self.name} undefined successfully")
             return True
         except RuntimeError as e:
@@ -945,12 +952,12 @@ class Network(VirshCommand):
         Make sure a rule is either present (present=True) or absent (present=False).
 
         Args:
-            instance   : object exposing execute_shell & logger
+            cls        : object with a ``virsh`` executor and a ``logger``
             check_cmd  : iptables -C ... command used to probe rule existence
             action_cmd : command that adds the rule (present) or deletes the rule (absent)
             present    : True -> ensure rule exists, False -> ensure rule is removed
         """
-        chk_res = cls.execute_shell(check_cmd, warn=True)
+        chk_res = cls.virsh.execute_shell(check_cmd, warn=True)
 
         # desired state already reached
         if (present and chk_res.return_code == 0) or (not present and chk_res.return_code != 0):
@@ -958,7 +965,7 @@ class Network(VirshCommand):
             return True
 
         # need an action to reach desired state
-        apply_res = cls.execute_shell(action_cmd, warn=True)
+        apply_res = cls.virsh.execute_shell(action_cmd, warn=True)
         if not apply_res.ok:
             cls.logger.error(f"failed to execute '{action_cmd}': {apply_res.stderr}")
             return False
@@ -1143,7 +1150,7 @@ class Network(VirshCommand):
             return []
 
 
-class NetworkInterface(VirshCommand):
+class NetworkInterface:
     """
     Class to manage network interfaces for libvirt VMs.
     """
@@ -1157,7 +1164,8 @@ class NetworkInterface(VirshCommand):
             vm_name: Name of the VM to manage interfaces for
             provider_config: Configuration for the libvirt provider
         """
-        super().__init__(provider_config=provider_config)
+        #: VirshCommand: Command executor for virsh
+        self.virsh = VirshCommand(provider_config=provider_config)
 
         #: str: Name of the VM
         self.vm_name = vm_name
@@ -1218,7 +1226,7 @@ class NetworkInterface(VirshCommand):
                 temp_path = temp.name
 
             # use virsh to attach the interface
-            self.execute("attach-device", self.vm_name, temp_path, "--persistent")
+            self.virsh.execute("attach-device", self.vm_name, temp_path, "--persistent")
 
             # remove temporary file
             os.unlink(temp_path)

--- a/src/boxman/providers/libvirt/shared_folder.py
+++ b/src/boxman/providers/libvirt/shared_folder.py
@@ -2,11 +2,13 @@ import os
 import tempfile
 from typing import Any
 
+from boxman import log
+
 from .commands import VirshCommand
 from .virsh_edit import VirshEdit
 
 
-class SharedFolderManager(VirshCommand):
+class SharedFolderManager:
     """
     Class for managing shared folder (filesystem passthrough) operations in libvirt.
 
@@ -16,7 +18,15 @@ class SharedFolderManager(VirshCommand):
     """
 
     def __init__(self, vm_name: str, provider_config: dict[str, Any] | None = None):
-        super().__init__(provider_config)
+        #: VirshCommand: Command executor for virsh
+        self.virsh = VirshCommand(provider_config=provider_config)
+
+        #: Dict[str, Any]: Configuration for the libvirt provider
+        self.provider_config = provider_config or {}
+
+        #: logging.Logger: Logger instance
+        self.logger = log
+
         self.vm_name = vm_name
 
     def attach_shared_folder(self,
@@ -54,7 +64,7 @@ class SharedFolderManager(VirshCommand):
 
             # Try live + persistent first
             attachment_args = ["--persistent"] if persistent else []
-            result = self.execute(
+            result = self.virsh.execute(
                 "attach-device", self.vm_name, temp_path, *attachment_args,
                 warn=True)
 
@@ -75,7 +85,7 @@ class SharedFolderManager(VirshCommand):
                 temp.write(xml_content)
                 temp_path = temp.name
 
-            result = self.execute(
+            result = self.virsh.execute(
                 "attach-device", self.vm_name, temp_path, "--config",
                 warn=True)
 
@@ -118,7 +128,7 @@ class SharedFolderManager(VirshCommand):
                 temp_path = temp.name
 
             # Try live + persistent
-            result = self.execute(
+            result = self.virsh.execute(
                 "detach-device", self.vm_name, temp_path, "--persistent",
                 warn=True)
 
@@ -138,7 +148,7 @@ class SharedFolderManager(VirshCommand):
                 temp.write(xml_content)
                 temp_path = temp.name
 
-            result = self.execute(
+            result = self.virsh.execute(
                 "detach-device", self.vm_name, temp_path, "--config",
                 warn=True)
 
@@ -203,7 +213,7 @@ class SharedFolderManager(VirshCommand):
                 return {'success': False, 'restart_needed': False}
 
             # Check if VM is running — if so, the memfd change needs a restart
-            result = self.execute("domstate", self.vm_name, warn=True)
+            result = self.virsh.execute("domstate", self.vm_name, warn=True)
             is_running = result.ok and 'running' in result.stdout
 
             if is_running:

--- a/tests/test_libvirt_cdrom.py
+++ b/tests/test_libvirt_cdrom.py
@@ -65,7 +65,7 @@ class TestBusForTarget:
             written["xml"] = Path(args[2]).read_text()
             return _result()
 
-        with patch.object(cd, "execute", side_effect=capture):
+        with patch.object(cd.virsh, "execute", side_effect=capture):
             assert cd.detach_cdrom("sda") is True
         assert "dev='sda' bus='sata'" in written["xml"]
 
@@ -79,7 +79,7 @@ class TestFindNextAvailableTarget:
     )
 
     def test_returns_hda_when_slots_free(self, cd: CDROMManager):
-        with patch.object(cd, "execute", return_value=_result(stdout=self.DOMBLKLIST)):
+        with patch.object(cd.virsh, "execute", return_value=_result(stdout=self.DOMBLKLIST)):
             # vda is used, so hda is free
             assert cd._find_next_available_target() == "hda"
 
@@ -90,7 +90,7 @@ class TestFindNextAvailableTarget:
             "file  disk    hda     /tmp/x\n"
             "file  disk    hdb     /tmp/y\n"
         )
-        with patch.object(cd, "execute", return_value=_result(stdout=blk)):
+        with patch.object(cd.virsh, "execute", return_value=_result(stdout=blk)):
             assert cd._find_next_available_target() == "hdc"
 
     def test_falls_back_to_sd_when_all_ide_used(self, cd: CDROMManager):
@@ -102,7 +102,7 @@ class TestFindNextAvailableTarget:
             "file  disk    hdc     /tmp/c\n"
             "file  disk    hdd     /tmp/d\n"
         )
-        with patch.object(cd, "execute", return_value=_result(stdout=blk)):
+        with patch.object(cd.virsh, "execute", return_value=_result(stdout=blk)):
             assert cd._find_next_available_target() == "sda"
 
 
@@ -116,7 +116,7 @@ class TestAttachCDROM:
         iso = tmp_path / "ubuntu.iso"
         iso.write_bytes(b"fake iso")
         with patch.object(cd, "_find_next_available_target", return_value="hdc"), \
-             patch.object(cd, "execute", return_value=_result()) as execute:
+             patch.object(cd.virsh, "execute", return_value=_result()) as execute:
             assert cd.attach_cdrom(str(iso)) is True
         args, _kwargs = execute.call_args
         assert args[0] == "attach-device"
@@ -127,7 +127,7 @@ class TestAttachCDROM:
         iso = tmp_path / "ubuntu.iso"
         iso.write_bytes(b"fake iso")
         with patch.object(cd, "_find_next_available_target", return_value="hdc"), \
-             patch.object(cd, "execute", return_value=_result()) as execute:
+             patch.object(cd.virsh, "execute", return_value=_result()) as execute:
             cd.attach_cdrom(str(iso), persistent=False)
         args, _kwargs = execute.call_args
         assert "--persistent" not in args
@@ -142,7 +142,7 @@ class TestAttachCDROM:
         iso = tmp_path / "u.iso"
         iso.write_bytes(b"x")
         with patch.object(cd, "_find_next_available_target", return_value="hdc"), \
-             patch.object(cd, "execute", return_value=_result(ok=False, stderr="nope")) as execute:
+             patch.object(cd.virsh, "execute", return_value=_result(ok=False, stderr="nope")) as execute:
             assert cd.attach_cdrom(str(iso)) is False
         # warn=True keeps the error branch live — without it execute raises
         # and the `if not result.ok` check is dead code (#85 item 38)
@@ -163,7 +163,7 @@ class TestAttachCDROM:
 
         with patch.object(cd, "_find_next_available_target", return_value="hdc"), \
              patch("boxman.providers.libvirt.cdrom.tempfile.NamedTemporaryFile", side_effect=tracker), \
-             patch.object(cd, "execute", side_effect=ValueError("boom")):
+             patch.object(cd.virsh, "execute", side_effect=ValueError("boom")):
             assert cd.attach_cdrom(str(iso)) is False
         # temp file should have been unlinked
         assert recorded_path["path"] is not None
@@ -173,14 +173,14 @@ class TestAttachCDROM:
 class TestDetachCDROM:
 
     def test_success_includes_readonly_xml(self, cd: CDROMManager):
-        with patch.object(cd, "execute", return_value=_result()) as execute:
+        with patch.object(cd.virsh, "execute", return_value=_result()) as execute:
             assert cd.detach_cdrom("hdc") is True
         # first call is detach-device
         args, _kwargs = execute.call_args
         assert args[0] == "detach-device"
 
     def test_failure_returns_false(self, cd: CDROMManager):
-        with patch.object(cd, "execute", return_value=_result(ok=False, stderr="x")) as execute:
+        with patch.object(cd.virsh, "execute", return_value=_result(ok=False, stderr="x")) as execute:
             assert cd.detach_cdrom("hdc") is False
         # warn=True keeps the error branch live — without it execute raises
         # and the `if not result.ok` check is dead code (#85 item 38)
@@ -195,7 +195,7 @@ class TestChangeMedia:
     def test_change_media_happy_path(self, cd: CDROMManager, tmp_path: Path):
         iso = tmp_path / "new.iso"
         iso.write_bytes(b"x")
-        with patch.object(cd, "execute", return_value=_result()) as execute:
+        with patch.object(cd.virsh, "execute", return_value=_result()) as execute:
             assert cd.change_media("hdc", str(iso)) is True
         args, _kwargs = execute.call_args
         assert args[0] == "change-media"
@@ -227,12 +227,12 @@ class TestGetAttachedCDROMs:
             "file  cdrom   hdd     /isos/seed.iso\n"  # seed ISO filtered out
             "file  cdrom   hde     -\n"                # empty source filtered out
         )
-        with patch.object(cd, "execute", return_value=_result(stdout=out)):
+        with patch.object(cd.virsh, "execute", return_value=_result(stdout=out)):
             found = cd.get_attached_cdroms()
         assert found == [{"target": "hdc", "source": "/isos/ubuntu.iso"}]
 
     def test_empty_on_execute_failure(self, cd: CDROMManager):
-        with patch.object(cd, "execute", return_value=_result(ok=False)):
+        with patch.object(cd.virsh, "execute", return_value=_result(ok=False)):
             assert cd.get_attached_cdroms() == []
 
 
@@ -255,7 +255,7 @@ class TestXmlEscaping:
             written["xml"] = Path(args[2]).read_text()
             return _result()
 
-        with patch.object(cd, "execute", side_effect=capture):
+        with patch.object(cd.virsh, "execute", side_effect=capture):
             assert cd.detach_cdrom("hd&c") is True
         assert "dev='hd&amp;c'" in written["xml"]
 

--- a/tests/test_libvirt_destroy_vm.py
+++ b/tests/test_libvirt_destroy_vm.py
@@ -34,40 +34,40 @@ def dv() -> DestroyVM:
 class TestStateProbes:
 
     def test_is_vm_running_true_when_running(self, dv: DestroyVM):
-        with patch.object(dv, "execute", return_value=_result(stdout="running\n")):
+        with patch.object(dv.virsh, "execute", return_value=_result(stdout="running\n")):
             assert dv.is_vm_running() is True
 
     def test_is_vm_running_false_when_shut_off(self, dv: DestroyVM):
-        with patch.object(dv, "execute", return_value=_result(stdout="shut off\n")):
+        with patch.object(dv.virsh, "execute", return_value=_result(stdout="shut off\n")):
             assert dv.is_vm_running() is False
 
     def test_is_vm_running_false_on_runtime_error(self, dv: DestroyVM):
-        with patch.object(dv, "execute", side_effect=RuntimeError("no such domain")):
+        with patch.object(dv.virsh, "execute", side_effect=RuntimeError("no such domain")):
             assert dv.is_vm_running() is False
 
     def test_is_vm_shut_off_true_when_shut_off(self, dv: DestroyVM):
-        with patch.object(dv, "execute", return_value=_result(stdout="shut off\n")):
+        with patch.object(dv.virsh, "execute", return_value=_result(stdout="shut off\n")):
             assert dv.is_vm_shut_off() is True
 
     def test_is_vm_shut_off_false_when_running(self, dv: DestroyVM):
-        with patch.object(dv, "execute", return_value=_result(stdout="running\n")):
+        with patch.object(dv.virsh, "execute", return_value=_result(stdout="running\n")):
             assert dv.is_vm_shut_off() is False
 
     def test_is_vm_shut_off_true_when_domstate_fails(self, dv: DestroyVM):
         """domain gone → effectively stopped per the module's contract."""
-        with patch.object(dv, "execute", return_value=_result(ok=False)):
+        with patch.object(dv.virsh, "execute", return_value=_result(ok=False)):
             assert dv.is_vm_shut_off() is True
 
     def test_is_vm_shut_off_true_on_runtime_error(self, dv: DestroyVM):
-        with patch.object(dv, "execute", side_effect=RuntimeError("x")):
+        with patch.object(dv.virsh, "execute", side_effect=RuntimeError("x")):
             assert dv.is_vm_shut_off() is True
 
     def test_is_vm_defined_true_when_dominfo_ok(self, dv: DestroyVM):
-        with patch.object(dv, "execute", return_value=_result(ok=True)):
+        with patch.object(dv.virsh, "execute", return_value=_result(ok=True)):
             assert dv.is_vm_defined() is True
 
     def test_is_vm_defined_false_when_dominfo_fails(self, dv: DestroyVM):
-        with patch.object(dv, "execute", return_value=_result(ok=False)):
+        with patch.object(dv.virsh, "execute", return_value=_result(ok=False)):
             assert dv.is_vm_defined() is False
 
 
@@ -79,21 +79,21 @@ class TestShutdownVM:
 
     def test_graceful_shutdown_success(self, dv: DestroyVM):
         with patch.object(dv, "is_vm_running", return_value=True), \
-             patch.object(dv, "execute", return_value=_result()), \
+             patch.object(dv.virsh, "execute", return_value=_result()), \
              patch.object(dv, "is_vm_shut_off", side_effect=[False, True]), \
              patch("boxman.providers.libvirt.destroy_vm.time.sleep"):
             assert dv.shutdown_vm(timeout=5) is True
 
     def test_graceful_timeout_without_force_returns_false(self, dv: DestroyVM):
         with patch.object(dv, "is_vm_running", return_value=True), \
-             patch.object(dv, "execute", return_value=_result()), \
+             patch.object(dv.virsh, "execute", return_value=_result()), \
              patch.object(dv, "is_vm_shut_off", return_value=False), \
              patch("boxman.providers.libvirt.destroy_vm.time.sleep"):
             assert dv.shutdown_vm(timeout=2, force=False) is False
 
     def test_graceful_timeout_with_force_calls_force_shutdown(self, dv: DestroyVM):
         with patch.object(dv, "is_vm_running", return_value=True), \
-             patch.object(dv, "execute", return_value=_result()), \
+             patch.object(dv.virsh, "execute", return_value=_result()), \
              patch.object(dv, "is_vm_shut_off", return_value=False), \
              patch("boxman.providers.libvirt.destroy_vm.time.sleep"), \
              patch.object(dv, "force_shutdown_vm", return_value=True) as force:
@@ -102,7 +102,7 @@ class TestShutdownVM:
 
     def test_runtime_error_returns_false(self, dv: DestroyVM):
         with patch.object(dv, "is_vm_running", return_value=True), \
-             patch.object(dv, "execute", side_effect=RuntimeError("boom")):
+             patch.object(dv.virsh, "execute", side_effect=RuntimeError("boom")):
             assert dv.shutdown_vm(timeout=1) is False
 
 
@@ -114,17 +114,17 @@ class TestForceShutdown:
 
     def test_success_when_destroy_stops_the_vm(self, dv: DestroyVM):
         with patch.object(dv, "is_vm_running", side_effect=[True, False]), \
-             patch.object(dv, "execute", return_value=_result()):
+             patch.object(dv.virsh, "execute", return_value=_result()):
             assert dv.force_shutdown_vm() is True
 
     def test_failure_when_vm_still_running_after_destroy(self, dv: DestroyVM):
         with patch.object(dv, "is_vm_running", side_effect=[True, True]), \
-             patch.object(dv, "execute", return_value=_result()):
+             patch.object(dv.virsh, "execute", return_value=_result()):
             assert dv.force_shutdown_vm() is False
 
     def test_runtime_error_returns_false(self, dv: DestroyVM):
         with patch.object(dv, "is_vm_running", return_value=True), \
-             patch.object(dv, "execute", side_effect=RuntimeError("boom")):
+             patch.object(dv.virsh, "execute", side_effect=RuntimeError("boom")):
             assert dv.force_shutdown_vm() is False
 
 
@@ -158,12 +158,12 @@ class TestUndefine:
 
     def test_success_when_undefine_removes_domain(self, dv: DestroyVM):
         with patch.object(dv, "is_vm_defined", side_effect=[True, False]), \
-             patch.object(dv, "execute", return_value=_result()):
+             patch.object(dv.virsh, "execute", return_value=_result()):
             assert dv.undefine_vm() is True
 
     def test_failure_when_domain_still_defined_after(self, dv: DestroyVM):
         with patch.object(dv, "is_vm_defined", side_effect=[True, True]), \
-             patch.object(dv, "execute", return_value=_result()):
+             patch.object(dv.virsh, "execute", return_value=_result()):
             assert dv.undefine_vm() is False
 
 
@@ -172,7 +172,7 @@ class TestForceUndefine:
     def test_kills_running_domain_before_undefine(self, dv: DestroyVM):
         with patch.object(dv, "is_vm_defined", side_effect=[True, False]), \
              patch.object(dv, "is_vm_shut_off", return_value=False), \
-             patch.object(dv, "execute", return_value=_result()) as execute:
+             patch.object(dv.virsh, "execute", return_value=_result()) as execute:
             assert dv.force_undefine_vm() is True
         calls = [c.args[0] for c in execute.call_args_list]
         assert "destroy" in calls  # force-kill first
@@ -183,7 +183,7 @@ class TestForceUndefine:
     def test_skips_kill_when_already_shut_off(self, dv: DestroyVM):
         with patch.object(dv, "is_vm_defined", side_effect=[True, False]), \
              patch.object(dv, "is_vm_shut_off", return_value=True), \
-             patch.object(dv, "execute", return_value=_result()) as execute:
+             patch.object(dv.virsh, "execute", return_value=_result()) as execute:
             dv.force_undefine_vm()
         calls = [c.args[0] for c in execute.call_args_list]
         assert "destroy" not in calls
@@ -193,7 +193,7 @@ class TestForceUndefine:
         args, not one re-split string."""
         with patch.object(dv, "is_vm_defined", side_effect=[True, False]), \
              patch.object(dv, "is_vm_shut_off", return_value=True), \
-             patch.object(dv, "execute", return_value=_result()) as execute:
+             patch.object(dv.virsh, "execute", return_value=_result()) as execute:
             assert dv.force_undefine_vm() is True
         undefine = [c for c in execute.call_args_list
                     if c.args[0] == "undefine"][0]
@@ -217,7 +217,7 @@ class TestForceUndefine:
 
         with patch.object(dv, "is_vm_defined", side_effect=[True, False]), \
              patch.object(dv, "is_vm_shut_off", return_value=True), \
-             patch.object(dv, "execute", side_effect=fake_execute):
+             patch.object(dv.virsh, "execute", side_effect=fake_execute):
             assert dv.force_undefine_vm() is True
         undefines = [args for args, _ in calls if args[0] == "undefine"]
         assert len(undefines) == 2
@@ -231,7 +231,7 @@ class TestForceUndefine:
     def test_no_fallback_when_rich_undefine_succeeds(self, dv: DestroyVM):
         with patch.object(dv, "is_vm_defined", side_effect=[True, False]), \
              patch.object(dv, "is_vm_shut_off", return_value=True), \
-             patch.object(dv, "execute", return_value=_result()) as execute:
+             patch.object(dv.virsh, "execute", return_value=_result()) as execute:
             assert dv.force_undefine_vm() is True
         undefines = [c for c in execute.call_args_list
                      if c.args[0] == "undefine"]
@@ -274,7 +274,7 @@ class TestRemove:
         with patch.object(dv, "is_vm_running", return_value=False), \
              patch.object(dv, "is_vm_defined", side_effect=[True, False]), \
              patch.object(dv, "is_vm_shut_off", return_value=False), \
-             patch.object(dv, "execute", return_value=_result()) as execute:
+             patch.object(dv.virsh, "execute", return_value=_result()) as execute:
             assert dv.remove() is True
         calls = [c.args[0] for c in execute.call_args_list]
         assert "destroy" in calls  # force-killed the paused domain
@@ -285,7 +285,7 @@ class TestRemove:
         with patch.object(dv, "is_vm_running", return_value=False), \
              patch.object(dv, "is_vm_defined", side_effect=[True, False]), \
              patch.object(dv, "is_vm_shut_off", return_value=True), \
-             patch.object(dv, "execute", return_value=_result()) as execute:
+             patch.object(dv.virsh, "execute", return_value=_result()) as execute:
             assert dv.remove() is True
         commands = [c.args[0] for c in execute.call_args_list]
         assert not any(c.startswith("snapshot-delete") for c in commands)

--- a/tests/test_libvirt_disk.py
+++ b/tests/test_libvirt_disk.py
@@ -85,7 +85,7 @@ class TestDeadErrorBranches:
             "warn") is True
 
     def test_attach_disk_failure_returns_false(self, dm: DiskManager):
-        with patch.object(dm, "execute",
+        with patch.object(dm.virsh, "execute",
                           return_value=_result(ok=False, stderr="x")) as exe:
             assert dm.attach_disk("/tmp/d.qcow2", "vdb") is False
         assert exe.call_args.kwargs.get("warn") is True
@@ -102,7 +102,7 @@ class TestDeadErrorBranches:
             "warn") is True
 
     def test_resize_disk_online_failure_returns_false(self, dm: DiskManager):
-        with patch.object(dm, "execute",
+        with patch.object(dm.virsh, "execute",
                           return_value=_result(ok=False, stderr="x")) as exe:
             assert dm.resize_disk_online("vdb", 2048) is False
         assert exe.call_args.kwargs.get("warn") is True

--- a/tests/test_libvirt_net.py
+++ b/tests/test_libvirt_net.py
@@ -370,7 +370,7 @@ class TestNetworkInterfaceAddInterface:
         return NetworkInterface("vm01", provider_config={"use_sudo": False})
 
     def test_success_calls_attach_device(self, ni: NetworkInterface):
-        with patch.object(ni, "execute", return_value=_result()) as execute:
+        with patch.object(ni.virsh, "execute", return_value=_result()) as execute:
             ok = ni.add_interface(
                 network_source="default", mac_address="52:54:00:aa:bb:cc",
             )
@@ -381,7 +381,7 @@ class TestNetworkInterfaceAddInterface:
         assert "--persistent" in args
 
     def test_exception_returns_false(self, ni: NetworkInterface):
-        with patch.object(ni, "execute", side_effect=RuntimeError("boom")):
+        with patch.object(ni.virsh, "execute", side_effect=RuntimeError("boom")):
             assert ni.add_interface(network_source="default") is False
 
 
@@ -438,7 +438,7 @@ class TestDestroyUndefineExactName:
             return ["prod-backup"]
 
         with patch.object(net, "_listed_networks", side_effect=listed), \
-             patch.object(net, "execute",
+             patch.object(net.virsh, "execute",
                           side_effect=lambda *a, **k: calls.append(a) or _result()):
             assert net.destroy_network() is True
         assert not any(args[0] == "net-destroy" for args in calls)
@@ -450,7 +450,7 @@ class TestDestroyUndefineExactName:
             return ["prod", "prod-backup"]
 
         with patch.object(net, "_listed_networks", side_effect=listed), \
-             patch.object(net, "execute",
+             patch.object(net.virsh, "execute",
                           side_effect=lambda *a, **k: calls.append(a) or _result()):
             assert net.destroy_network() is True
         assert ("net-destroy", "prod") in calls
@@ -462,7 +462,7 @@ class TestDestroyUndefineExactName:
             return [] if active_only else ["prod"]
 
         with patch.object(net, "_listed_networks", side_effect=listed), \
-             patch.object(net, "execute",
+             patch.object(net.virsh, "execute",
                           side_effect=lambda *a, **k: calls.append(a) or _result()):
             assert net.destroy_network() is True
         assert not any(args[0] == "net-destroy" for args in calls)
@@ -474,7 +474,7 @@ class TestDestroyUndefineExactName:
     def test_undefine_skips_net_undefine_when_only_superstring_exists(self, net):
         calls = []
         with patch.object(net, "_listed_networks", return_value=["prod-backup"]), \
-             patch.object(net, "execute",
+             patch.object(net.virsh, "execute",
                           side_effect=lambda *a, **k: calls.append(a) or _result()):
             assert net.undefine_network() is True
         assert not any(args[0] == "net-undefine" for args in calls)
@@ -482,7 +482,7 @@ class TestDestroyUndefineExactName:
     def test_undefine_runs_net_undefine_when_name_matches_exactly(self, net):
         calls = []
         with patch.object(net, "_listed_networks", return_value=["prod"]), \
-             patch.object(net, "execute",
+             patch.object(net.virsh, "execute",
                           side_effect=lambda *a, **k: calls.append(a) or _result()):
             assert net.undefine_network() is True
         assert ("net-undefine", "prod") in calls
@@ -515,8 +515,8 @@ class TestNatIsLibvirtdsJob:
         with patch.object(net, "check_network_exists"), \
              patch.object(net, "_get_libvirt_bridges", return_value=set()), \
              patch.object(net, "update_network_cache"), \
-             patch.object(net, "execute", return_value=_result()), \
-             patch.object(net, "execute_shell") as shell:
+             patch.object(net.virsh, "execute", return_value=_result()), \
+             patch.object(net.virsh, "execute_shell") as shell:
             assert net.define_network(str(tmp_path / "net.xml")) is True
         for call in shell.call_args_list:
             assert "iptables" not in call.args[0]
@@ -526,7 +526,7 @@ class TestNatIsLibvirtdsJob:
         net = self._net("nat")
         with patch.object(net, "destroy_network", return_value=True), \
              patch.object(net, "undefine_network", return_value=True), \
-             patch.object(net, "execute_shell") as shell:
+             patch.object(net.virsh, "execute_shell") as shell:
             assert net.remove_network() is True
         shell.assert_not_called()
 
@@ -580,7 +580,7 @@ class TestRouteIsolationRules:
         net = self._net(use_sudo=use_sudo)
         with patch("boxman.providers.libvirt.commands._shell_run",
                    return_value=_result()) as run:
-            net.execute_shell("iptables -C INPUT -i virbr9 -j DROP", warn=True)
+            net.virsh.execute_shell("iptables -C INPUT -i virbr9 -j DROP", warn=True)
         assert run.call_args.args[0].startswith(expected_prefix)
 
 

--- a/tests/test_libvirt_shared_folder.py
+++ b/tests/test_libvirt_shared_folder.py
@@ -77,7 +77,7 @@ class TestAttachSharedFolder:
         assert out == {"success": False, "restart_needed": False}
 
     def test_live_attach_success(self, sf: SharedFolderManager, tmp_path: Path):
-        with patch.object(sf, "execute", return_value=_result()) as execute:
+        with patch.object(sf.virsh, "execute", return_value=_result()) as execute:
             out = sf.attach_shared_folder("tag", str(tmp_path))
         assert out == {"success": True, "restart_needed": False}
         execute.assert_called_once()
@@ -92,7 +92,7 @@ class TestAttachSharedFolder:
             # first call (live) fails, second (config-only) succeeds
             return _result(ok=False, stderr="hotplug unsupported") if len(calls) == 1 else _result()
 
-        with patch.object(sf, "execute", side_effect=fake):
+        with patch.object(sf.virsh, "execute", side_effect=fake):
             out = sf.attach_shared_folder("tag", str(tmp_path))
         assert out == {"success": True, "restart_needed": True}
         assert any("--config" in c for c in calls)
@@ -100,7 +100,7 @@ class TestAttachSharedFolder:
     def test_both_attempts_fail_returns_failure(
         self, sf: SharedFolderManager, tmp_path: Path
     ):
-        with patch.object(sf, "execute", return_value=_result(ok=False, stderr="nope")):
+        with patch.object(sf.virsh, "execute", return_value=_result(ok=False, stderr="nope")):
             out = sf.attach_shared_folder("tag", str(tmp_path))
         assert out == {"success": False, "restart_needed": False}
 
@@ -108,7 +108,7 @@ class TestAttachSharedFolder:
 class TestDetachSharedFolder:
 
     def test_live_detach_success(self, sf: SharedFolderManager):
-        with patch.object(sf, "execute", return_value=_result()):
+        with patch.object(sf.virsh, "execute", return_value=_result()):
             out = sf.detach_shared_folder("tag", "/host")
         assert out == {"success": True, "restart_needed": False}
 
@@ -119,7 +119,7 @@ class TestDetachSharedFolder:
             calls.append(args)
             return _result(ok=False, stderr="x") if len(calls) == 1 else _result()
 
-        with patch.object(sf, "execute", side_effect=fake):
+        with patch.object(sf.virsh, "execute", side_effect=fake):
             out = sf.detach_shared_folder("tag", "/host")
         assert out == {"success": True, "restart_needed": True}
 
@@ -141,7 +141,7 @@ class TestEnsureMemfdBacking:
         mock_editor.redefine_domain.return_value = True
         with patch("boxman.providers.libvirt.shared_folder.VirshEdit",
                    return_value=mock_editor), \
-             patch.object(sf, "execute", return_value=_result(stdout="shut off\n")):
+             patch.object(sf.virsh, "execute", return_value=_result(stdout="shut off\n")):
             out = sf.ensure_memfd_backing()
         assert out == {"success": True, "restart_needed": False}
         mock_editor.redefine_domain.assert_called_once()
@@ -158,7 +158,7 @@ class TestEnsureMemfdBacking:
         mock_editor.redefine_domain.return_value = True
         with patch("boxman.providers.libvirt.shared_folder.VirshEdit",
                    return_value=mock_editor), \
-             patch.object(sf, "execute", return_value=_result(stdout="running\n")):
+             patch.object(sf.virsh, "execute", return_value=_result(stdout="running\n")):
             out = sf.ensure_memfd_backing()
         assert out == {"success": True, "restart_needed": True}
 

--- a/tests/test_libvirt_storage.py
+++ b/tests/test_libvirt_storage.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from boxman.providers.libvirt.destroy_vm import DestroyVM
+from boxman.providers.libvirt.commands import VirshCommand
 from boxman.providers.libvirt.storage import StorageManager, vm_disk_paths
 
 pytestmark = pytest.mark.unit
@@ -324,12 +324,12 @@ class TestConvert:
 class TestIsShutOff:
 
     def test_true_when_shut_off(self, sm: StorageManager):
-        with patch.object(DestroyVM, "execute",
+        with patch.object(VirshCommand, "execute",
                           return_value=_result(stdout="shut off\n")):
             assert sm.is_shut_off("vm01") is True
 
     def test_true_when_domain_gone(self, sm: StorageManager):
-        with patch.object(DestroyVM, "execute",
+        with patch.object(VirshCommand, "execute",
                           return_value=_result(ok=False, stderr="not found")):
             assert sm.is_shut_off("vm01") is True
 
@@ -337,14 +337,14 @@ class TestIsShutOff:
         """Regression for issue #85 item 18: a paused VM reads as 'not
         running' but QEMU still holds the disk — compacting it would
         corrupt the image."""
-        with patch.object(DestroyVM, "execute",
+        with patch.object(VirshCommand, "execute",
                           return_value=_result(stdout="paused\n")):
             assert sm.is_shut_off("vm01") is False
 
     def test_false_when_in_shutdown(self, sm: StorageManager):
         """Regression for issue #85 item 18: 'in shutdown' is not
         'shut off' — QEMU is still alive."""
-        with patch.object(DestroyVM, "execute",
+        with patch.object(VirshCommand, "execute",
                           return_value=_result(stdout="in shutdown\n")):
             assert sm.is_shut_off("vm01") is False
 

--- a/tests/test_net_reconcile.py
+++ b/tests/test_net_reconcile.py
@@ -557,7 +557,7 @@ class TestCacheSelfConflict:
                 raise RuntimeError("boom")
             return _result()
 
-        net.execute = fake_execute
+        net.virsh.execute = fake_execute
         net._get_libvirt_bridges = lambda: set()
         assert net.define_network(str(tmp_path / 'net.xml')) is False
 
@@ -674,7 +674,7 @@ class TestApplyLivePlan:
                 return _result(stdout="demo\n" if active else "")
             return _result()
 
-        net.execute = fake_execute
+        net.virsh.execute = fake_execute
         return net, calls
 
     def test_range_is_applied_before_the_reservations(self):
@@ -750,7 +750,7 @@ class TestApplyLivePlan:
     def test_a_failing_update_is_reported(self):
         net = _network({"mode": "nat",
                         "ip": {"address": "10.5.3.1", "netmask": "255.255.255.0"}})
-        net.execute = lambda *a, **k: (
+        net.virsh.execute = lambda *a, **k: (
             _result(stdout="demo\n") if a[0] == "net-list"
             else _result(ok=False, stderr="boom"))
         assert net.apply_live_plan(

--- a/tests/test_netlab_schema.py
+++ b/tests/test_netlab_schema.py
@@ -98,6 +98,7 @@ class TestInterfaceXmlRendering:
         iface.vm_name = "vm1"
         iface.logger = MagicMock()
         iface.provider_config = {"use_sudo": False}
+        iface.virsh = MagicMock()
 
         captured: dict[str, str] = {}
 
@@ -110,7 +111,7 @@ class TestInterfaceXmlRendering:
             result.ok = True
             return result
 
-        iface.execute = fake_execute
+        iface.virsh.execute = fake_execute
         ok = iface.add_interface(**kwargs)
         assert ok
         return captured["xml"]

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -271,7 +271,7 @@ class TestCdromHotplug36a8a6b:
         cd = CDROMManager("vm01", provider_config={"use_sudo": False})
 
         with patch.object(cd, "_find_next_available_target", return_value="hdc"), \
-             patch.object(cd, "execute", return_value=_result()) as execute:
+             patch.object(cd.virsh, "execute", return_value=_result()) as execute:
             assert cd.attach_cdrom(str(iso)) is True
 
         args = execute.call_args.args
@@ -294,7 +294,7 @@ class TestSharedFolderHotplug36a8a6b:
             # succeed first time
             return _result(ok=True)
 
-        with patch.object(sf, "execute", side_effect=fake):
+        with patch.object(sf.virsh, "execute", side_effect=fake):
             out = sf.attach_shared_folder("tag", str(tmp_path))
 
         assert out["success"] is True
@@ -315,7 +315,7 @@ class TestSharedFolderHotplug36a8a6b:
             # first (live) fails, second (config) succeeds
             return _result(ok=False, stderr="no hotplug") if len(calls) == 1 else _result(ok=True)
 
-        with patch.object(sf, "execute", side_effect=fake):
+        with patch.object(sf.virsh, "execute", side_effect=fake):
             out = sf.attach_shared_folder("tag", str(tmp_path))
 
         assert out == {"success": True, "restart_needed": True}

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -609,6 +609,7 @@ def _make_disk_manager():
     dm.vm_name = 'test-vm'
     dm.logger = MagicMock()
     dm.provider_config = {'uri': 'qemu:///system'}
+    dm.virsh = MagicMock()
     return dm
 
 
@@ -665,11 +666,11 @@ class TestDiskManagerResize:
 
     def test_resize_disk_online_success(self):
         dm = _make_disk_manager()
-        dm.execute = MagicMock(return_value=MagicMock(ok=True))
+        dm.virsh.execute.return_value = MagicMock(ok=True)
 
         result = dm.resize_disk_online('vdb', 4096)
         assert result is True
-        dm.execute.assert_called_once_with(
+        dm.virsh.execute.assert_called_once_with(
             'blockresize', 'test-vm', 'vdb', '--size=4096M', warn=True)
 
     def test_resize_disk_routes_to_online_when_running(self):


### PR DESCRIPTION
Refs #85 (item 31, remainder).

All six classes that subclassed `VirshCommand` purely as an execution mixin are converted to composition, following the existing `SnapshotManager`/`StorageManager` pattern (`self.virsh = VirshCommand(...)` + delegation):

- `SharedFolderManager` (shared_folder.py)
- `DiskManager` (disk.py)
- `Network` + `NetworkInterface` (net.py)
- `CDROMManager` (cdrom.py)
- `DestroyVM` (destroy_vm.py)

Mechanical: `self.execute(...)` → `self.virsh.execute(...)`; `Network._ensure_rule`'s executor argument now routes through `instance.virsh.execute_shell`. Each class explicitly sets the attributes it actually uses (`provider_config`, `logger`) rather than inheriting them.

Beyond-pure-delegation notes:
- `DestroyVM.shut_down_vm` used to pass *`self`* as the virsh executor into `shutdown_and_wait()` (valid only because of the inheritance); it now passes `self.virsh`. The `wait_until_shut_off` docstring was updated to match.
- The stale `# Fixed missing closing parenthesis:` comment on `commands.py`'s `VirshCommand` class line is removed.
- No class overrides `execute`/`build_command` behavior, and no external caller used inherited members on these instances (verified by grep) — after this PR nothing subclasses `VirshCommand` at all.

Tests: mocks moved from `patch.object(inst, "execute")` to `patch.object(inst.virsh, "execute")` (also `execute_shell`); `test_libvirt_storage.py` now patches `VirshCommand.execute` at class level (the `DestroyVM`-level patch target no longer exists); `__new__`-constructed fixtures (`test_update.py`, `test_netlab_schema.py`) set a `virsh` mock explicitly. Full unit suite: 1891 passed. Ruff: 7 known violations, no new ones.