### PR TITLE
chore: silence deliberate ruff leftovers, unred CI lint

### DIFF
--- a/scripts/installer/check_prerequisites.py
+++ b/scripts/installer/check_prerequisites.py
@@ -790,7 +790,7 @@ class Doctor:
 
         def python_version():
             ver = ".".join(str(p) for p in sys.version_info[:3])
-            if sys.version_info[:2] >= (3, 10):
+            if sys.version_info[:2] >= (3, 10):  # noqa: UP036 - standalone installer must parse on end-user Python < 3.10
                 return OK, f"Python {ver} (boxman needs >= 3.10)", None
             fix = Fix(
                 "install Python >= 3.10 (e.g. `conda create -n boxman python=3.12` "

--- a/src/boxman/exceptions.py
+++ b/src/boxman/exceptions.py
@@ -46,7 +46,7 @@ class SnapshotError(BoxmanError):
     callers can decide whether to retry."""
 
 
-class RuntimeUnavailable(BoxmanError):
+class RuntimeUnavailable(BoxmanError):  # noqa: N818 - public API name, renaming is a breaking change
     """Raised when the selected runtime (docker-compose, local libvirt)
     is not reachable — docker daemon down, libvirtd not responding, or
     the runtime container refused to start. Typically retriable."""

--- a/src/boxman/manager_parts/misc.py
+++ b/src/boxman/manager_parts/misc.py
@@ -426,10 +426,10 @@ class MiscMixin:
             max(len(headers[i]), *(len(row[i]) for row in rows))
             for i in range(col_count)
         ]
-        print("  ".join(h.ljust(w) for h, w in zip(headers, widths)))
+        print("  ".join(h.ljust(w) for h, w in zip(headers, widths, strict=False)))
         print("  ".join("-" * w for w in widths))
         for row in rows:
-            print("  ".join(val.ljust(w) for val, w in zip(row, widths)))
+            print("  ".join(val.ljust(w) for val, w in zip(row, widths, strict=False)))
 
     def ssh_session(self, cli_args):
         """

--- a/src/boxman/manager_parts/vms.py
+++ b/src/boxman/manager_parts/vms.py
@@ -141,7 +141,7 @@ class VMsMixin:
         # wait-for-IP loop in particular looks like a hang.
         failed = [
             (task[2], p.exitcode)
-            for task, p in zip(clone_tasks, processes)
+            for task, p in zip(clone_tasks, processes, strict=False)
             if p.exitcode != 0
         ]
         if failed:

--- a/src/boxman/netlab/containerlab.py
+++ b/src/boxman/netlab/containerlab.py
@@ -27,7 +27,7 @@ from boxman import log
 from boxman.utils.shell import run
 
 
-class ContainerlabNotInstalled(RuntimeError):
+class ContainerlabNotInstalled(RuntimeError):  # noqa: N818 - public API name, renaming is a breaking change
     """Raised when the ``containerlab`` binary or Docker isn't available."""
 
 

--- a/src/boxman/runtime/base.py
+++ b/src/boxman/runtime/base.py
@@ -28,7 +28,7 @@ class RuntimeBase(ABC):
     def name(self) -> str:
         """Short identifier, e.g. 'local' or 'docker-compose'."""
 
-    def ensure_ready(self) -> None:
+    def ensure_ready(self) -> None:  # noqa: B027 - intentional no-op default; local runtime needs no setup
         """
         Ensure the runtime environment is up and ready to accept commands.
 


### PR DESCRIPTION
Follow-up to #85 item 40. CI's first run on main failed the lint step on the 7 documented leftover violations (see PR #128 body). B905s get explicit strict=False; the four deliberate ones get justified noqas. Local: ruff clean, 1891 unit passed.