### PR TITLE
polish: harden cloning, memory, networking, and runtime compatibility

### DIFF
--- a/containers/docker/Dockerfile
+++ b/containers/docker/Dockerfile
@@ -59,6 +59,19 @@ RUN useradd -m -s /bin/bash qemu_user && \
     chown -R qemu_user:qemu_user /home/qemu_user/.ssh && \
     usermod -aG qemu qemu_user
 
+# Ubuntu 24.04 confines unix_chkpwd with AppArmor and deliberately omits
+# dac_override/dac_read_search. Rocky's mode 0000 /etc/shadow therefore blocks
+# even the setuid-root helper. Give the root owner a read bit so normal DAC is
+# sufficient, while retaining root-only ordinary DAC access and keeping
+# qemu_user out of any shadow-readable group. qemu_user intentionally has
+# passwordless sudo elsewhere in this development image. The final checks make
+# the direct-access invariant fail at image-build time if a base-image or
+# user-creation change breaks it.
+RUN chown root:root /etc/shadow && \
+    chmod 0400 /etc/shadow && \
+    test "$(stat -c '%U:%G:%a' /etc/shadow)" = "root:root:400" && \
+    ! id -Gn qemu_user | grep -qw shadow
+
 # SSH key pair is generated at runtime in entrypoint.sh
 
 # Configure libvirtd: disable unix socket auth for local dev access

--- a/containers/docker/README.md
+++ b/containers/docker/README.md
@@ -358,6 +358,22 @@ make status
 docker exec boxman-libvirt-default cat /var/log/supervisor/sshd.stderr.log
 ```
 
+### Public key accepted, then PAM closes the SSH connection
+
+Older Boxman images inherited Rocky Linux's mode `0000 root:root` for
+`/etc/shadow`. On Ubuntu 24.04 hosts, the enforcing `unix_chkpwd` AppArmor
+profile permits reads of that file but does not grant `dac_override` or
+`dac_read_search`, so PAM account checks failed even after public-key
+authentication succeeded.
+
+Current images use mode `0400 root:root`: the setuid-root helper can use the
+owner read bit while ordinary, unprivileged reads remain unavailable to
+`qemu_user` and other non-root users. (`qemu_user` intentionally has
+passwordless `sudo` in this development image.) No host AppArmor capability
+override is required. If a
+runtime was created with an older Boxman version, redeploy the bundled assets
+and rebuild its image before retrying SSH.
+
 ### libvirtd socket not appearing
 
 ```bash

--- a/containers/docker/README.md
+++ b/containers/docker/README.md
@@ -370,9 +370,8 @@ Current images use mode `0400 root:root`: the setuid-root helper can use the
 owner read bit while ordinary, unprivileged reads remain unavailable to
 `qemu_user` and other non-root users. (`qemu_user` intentionally has
 passwordless `sudo` in this development image.) No host AppArmor capability
-override is required. If a
-runtime was created with an older Boxman version, redeploy the bundled assets
-and rebuild its image before retrying SSH.
+override is required. If a runtime was created with an older Boxman version,
+redeploy the bundled assets and rebuild its image before retrying SSH.
 
 ### libvirtd socket not appearing
 

--- a/containers/docker/README.md
+++ b/containers/docker/README.md
@@ -306,7 +306,8 @@ Rocky Linux 9.6
 - `supervisor` — process manager (libvirtd, virtlogd, sshd, dnsmasq)
 - `openssh-server` — SSH access
 - `dnsmasq`, `bridge-utils`, `iptables`, `nftables` — networking
-- `guestfs-tools` — `virt-sparsify` for `boxman storage compact`
+- `guestfs-tools` — `virt-sysprep` for safe clone machine identities and
+  `virt-sparsify` for `boxman storage compact`
 - `zstd` — snapshot memory compression for
   `boxman snapshot take --compress-memory` and `boxman storage compress-snapshots`
 

--- a/data/dev/test-runner/README.md
+++ b/data/dev/test-runner/README.md
@@ -13,14 +13,7 @@ never touch the host.
   → `Y`). boxman already emits `cpu mode='host-passthrough'` in the domain
   XML, so no post-provisioning CPU change is needed; `make test-vm-up`
   verifies `/dev/kvm` is visible inside the guest.
-- Ubuntu 24.04's enforcing AppArmor profile for `unix_chkpwd` breaks sshd
-  inside the privileged libvirt test container (the Rocky image ships
-  `/etc/shadow` mode 0000, and the profile drops the DAC capabilities the
-  helper needs to read it). cloud-init installs an override in
-  `/etc/apparmor.d/local/unix-chkpwd` granting `dac_override` +
-  `dac_read_search`; without it every SSH login into the container fails
-  with "Access denied by PAM account configuration". See issue #84.
-- Two more host-kernel quirks are handled via cloud-init (see `conf.yml`
+- Two host-kernel quirks are handled via cloud-init (see `conf.yml`
   comments): the libvirtd AppArmor profile only allows the Debian
   `libvirt_iohelper` path (Rocky uses `/usr/libexec/...`), which breaks
   `snapshot-create-as`; and `vm.overcommit_memory=1` is needed because a
@@ -41,3 +34,32 @@ make test-vm-destroy   # full teardown (VM, network, workspace)
 
 After changing code on the host, re-run `make test-vm-sync` before
 `make test-vm-test` — the VM has its own copy of the tree.
+
+## Validate Docker SSH without the legacy AppArmor override
+
+A runner provisioned before issue #84 was fixed may still have the old
+`unix_chkpwd` local include from cloud-init. Temporarily empty it and reload
+the enforcing profile before rebuilding the image, otherwise the stale
+capability grants can hide a regression:
+
+```bash
+# Save and disable the old local include in the existing disposable runner.
+ssh -F ~/workspaces/boxmandev/test-runner/ssh_config cluster_1_runner01 \
+  'sudo cp -a /etc/apparmor.d/local/unix-chkpwd /tmp/unix-chkpwd.boxman-84 && \
+   sudo truncate -s 0 /etc/apparmor.d/local/unix-chkpwd && \
+   sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd'
+
+make test-vm-sync
+ssh -F ~/workspaces/boxmandev/test-runner/ssh_config cluster_1_runner01 \
+  'cd ~/boxman/containers/docker && docker compose down && \
+   docker compose build --no-cache'
+make test-vm-test tier=integration pytest_args="-k test_ssh_into_container"
+
+# Restore the runner's previous local include after the validation.
+ssh -F ~/workspaces/boxmandev/test-runner/ssh_config cluster_1_runner01 \
+  'sudo cp -a /tmp/unix-chkpwd.boxman-84 /etc/apparmor.d/local/unix-chkpwd && \
+   sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd'
+```
+
+Freshly provisioned runners do not install that include and need no special
+handling.

--- a/data/dev/test-runner/conf.yml
+++ b/data/dev/test-runner/conf.yml
@@ -87,6 +87,7 @@ templates:
         - libvirt-daemon-system
         - qemu-kvm
         - virtinst
+        - guestfs-tools
         - genisoimage
 
       write_files:

--- a/data/dev/test-runner/conf.yml
+++ b/data/dev/test-runner/conf.yml
@@ -97,17 +97,6 @@ templates:
             [Service]
             ExecStart=
             ExecStart=/usr/lib/systemd/systemd-networkd-wait-online --any
-        # Ubuntu 24.04 ships an enforcing AppArmor profile for unix_chkpwd
-        # which strips capabilities from the helper. The libvirt test
-        # container (Rocky 9) ships /etc/shadow mode 0000, so the confined
-        # helper cannot read it and sshd rejects every login with
-        # "Access denied by PAM account configuration". Grant the two DAC
-        # capabilities back via the profile's local include.
-        - path: /etc/apparmor.d/local/unix-chkpwd
-          permissions: "0644"
-          content: |
-            capability dac_override,
-            capability dac_read_search,
         # The host's enforcing libvirtd AppArmor profile only whitelists
         # the Debian path /usr/lib/libvirt/libvirt_iohelper; the Rocky test
         # container uses /usr/libexec/..., so snapshot-create-as fails with
@@ -137,8 +126,7 @@ templates:
         - netplan apply || true
         - dhclient -v || true
         - systemctl enable --now docker
-        # apply the AppArmor overrides (see write_files above)
-        - apparmor_parser -r /etc/apparmor.d/unix-chkpwd
+        # apply the libvirtd AppArmor override (see write_files above)
         - apparmor_parser -r /etc/apparmor.d/usr.sbin.libvirtd
         # apply the overcommit sysctl (see write_files above)
         - sysctl --system

--- a/data/templates/boxman.yml
+++ b/data/templates/boxman.yml
@@ -75,6 +75,10 @@ providers:
     virt_install_cmd: virt-install
     # path to virt-clone command
     virt_clone_cmd: virt-clone
+    # path to virt-sysprep (used by clone_machine_id: auto|required)
+    virt_sysprep_cmd: virt-sysprep
+    # maximum offline guest inspection time in seconds
+    virt_sysprep_timeout: 300
     # path to virsh command
     virsh_cmd: virsh
     # specify the verbosity of libvirt commands

--- a/data/templates/conf.libvirt.yml
+++ b/data/templates/conf.libvirt.yml
@@ -53,6 +53,15 @@ clusters:
               end: '10.0.10.254'  #   mandatory (if block is specified)
         enable: True
         autostart: True
+      # migration:
+      #   # Name indirection for an existing host Linux bridge. Libvirt does
+      #   # not create or configure br-migration; create it in the libvirt
+      #   # daemon's namespace and omit ip/mac/stp/delay here.
+      #   mode: bridge
+      #   bridge:
+      #     name: br-migration
+      #   enable: True
+      #   autostart: True
 
     vms:
       boxman01:

--- a/data/templates/conf.libvirt.yml
+++ b/data/templates/conf.libvirt.yml
@@ -55,8 +55,8 @@ clusters:
         autostart: True
       # migration:
       #   # Name indirection for an existing host Linux bridge. Libvirt does
-      #   # not create or configure br-migration; create it in the libvirt
-      #   # daemon's namespace and omit ip/mac/stp/delay here.
+      #   # not create or configure br-migration; create it and set it UP in
+      #   # the libvirt daemon's namespace, and omit ip/mac/stp/delay here.
       #   mode: bridge
       #   bridge:
       #     name: br-migration

--- a/data/templates/conf.libvirt.yml
+++ b/data/templates/conf.libvirt.yml
@@ -57,6 +57,10 @@ clusters:
     vms:
       boxman01:
         hostname: boxman01
+        # Reset inherited Linux machine IDs: auto (default), required, or off.
+        # Use required for supported Linux templates that must never boot with
+        # their source identity; auto preserves opaque-appliance compatibility.
+        # clone_machine_id: auto
         # boot_order: [network, hd]   # PXE boot: boot from network first, then disk
         disks:
           - name: disk01

--- a/doc/ksm.md
+++ b/doc/ksm.md
@@ -1,0 +1,240 @@
+# Host Memory Deduplication with KSM
+
+Kernel Samepage Merging (KSM) can reduce the physical memory used by a
+fleet of similar KVM guests. It is a Linux host policy, not a Boxman VM
+setting: Boxman neither enables KSM nor manages `ksmd`/`ksmtuned`.
+
+Use KSM as a complement to, not a replacement for, virtio-balloon
+free-page reporting:
+
+| Mechanism | Reclaims | Scope | Boxman surface |
+|---|---|---|---|
+| Free-page reporting | Pages the guest has freed | One VM | `memballoon.free_page_reporting: true` |
+| KSM | Identical live anonymous pages in mergeable host processes | The whole host | Operator-managed host policy |
+
+Free-page reporting returns unused guest pages promptly. KSM scans live
+pages which QEMU has marked mergeable, replaces identical pages with one
+write-protected copy, and copies a page again when a guest writes to it.
+The mechanisms can therefore save different parts of the same VM's
+memory footprint.
+
+The [Linux kernel KSM documentation][kernel-ksm] defines the controls,
+counters, and memory-profit calculation used below.
+
+## Decide at the host level
+
+KSM affects every mergeable process on the host, including VMs outside
+the Boxman project being evaluated. Enabling it is an operator decision.
+Before changing anything, record:
+
+```bash
+getconf PAGE_SIZE
+grep -E '^(MemTotal|MemAvailable):' /proc/meminfo
+for value in /sys/kernel/mm/ksm/*; do
+    printf '%s=' "${value##*/}"
+    cat "$value"
+done
+systemctl is-enabled ksmtuned.service ksm.service 2>/dev/null || true
+systemctl is-active ksmtuned.service ksm.service 2>/dev/null || true
+ps -C ksmd -o pid,etime,time,%cpu,cmd
+```
+
+Service and package names vary by distribution. If the distribution
+provides `ksmtuned`, prefer its adaptive policy over an undocumented
+collection of persistent sysfs writes. Do not run `ksmtuned` and a
+manual policy at the same time: the service may replace the manual
+settings while an experiment is running.
+
+Consider these trade-offs before opting in:
+
+- **CPU and latency:** `ksmd` hashes and compares candidate pages.
+  Aggressive scanning can consume a substantial fraction of one CPU and
+  add copy-on-write latency when a guest modifies a merged page.
+- **Temporary memory cost:** KSM allocates reverse-map metadata before it
+  finds profitable sharing. `general_profit` can be negative during an
+  early scan even if later scans save memory.
+- **Unmerge headroom:** setting `run=2` materializes private copies of
+  merged pages. Ensure enough `MemAvailable` exists first; unmerging
+  without headroom can invoke the OOM killer.
+- **NUMA placement:** `merge_across_nodes=1` may save more memory but can
+  place a shared page away from some consumers. Measure workload latency
+  before enabling cross-node merging on a NUMA host.
+- **Trust boundaries:** sharing pages across mutually untrusted tenants
+  can create timing side channels. Copy-on-write and memory-pressure
+  behavior can also become coupled across workloads. Avoid host-wide
+  KSM across trust domains without a security assessment.
+
+## Run a bounded evaluation
+
+Use an idle maintenance window and a representative, stable fleet. Keep
+the guest workload, VM count, free-page-reporting setting, and all other
+memory controls fixed between the KSM-off and KSM-on measurements.
+
+1. With `run=0`, let the workload stabilize and capture the baseline
+   measurements described below.
+2. Choose a conservative scan rate. `pages_to_scan` is the number of
+   pages processed before `ksmd` sleeps for `sleep_millisecs`; their
+   combination determines the upper scan rate. There is no universally
+   safe value. Start low and monitor CPU, `MemAvailable`, and
+   `general_profit`.
+3. Start KSM and wait for a scan-count target rather than an arbitrary
+   delay. At least two increments of `full_scans` let pages initially
+   classified as changing be examined again.
+4. Stop the scanner with `run=0` before the final sample. This freezes
+   scanning but retains already merged pages, making repeated samples
+   easier to compare.
+
+The manual control surface is:
+
+```bash
+# Optional: explicitly set this to the bounded batch size selected for this host.
+printf '%s\n' "$PAGES_PER_BATCH" | sudo tee /sys/kernel/mm/ksm/pages_to_scan
+
+# Start scanning.
+echo 1 | sudo tee /sys/kernel/mm/ksm/run
+
+# Stop scanning but retain merged pages for measurement.
+echo 0 | sudo tee /sys/kernel/mm/ksm/run
+```
+
+Monitor at a fixed interval and set a wall-time limit. Stop early if
+`MemAvailable` approaches the host's safety reserve, `ksmd` CPU is too
+high, or profit remains negative. Do not copy a scan rate from another
+machine without measuring it locally.
+
+## Measure savings and cost
+
+### Host-global counters
+
+```bash
+KSM=/sys/kernel/mm/ksm
+page_size=$(getconf PAGE_SIZE)
+pages_sharing=$(cat "$KSM/pages_sharing")
+
+awk -v sharing="$pages_sharing" -v size="$page_size" \
+    'BEGIN { printf "Ordinary KSM savings: %.1f MiB\n", \
+                    sharing * size / 1048576 }'
+
+if test -r "$KSM/ksm_zero_pages"; then
+    zero_pages=$(cat "$KSM/ksm_zero_pages")
+    awk -v sharing="$pages_sharing" -v zero="$zero_pages" \
+        -v size="$page_size" \
+        'BEGIN { printf "Savings including zero pages: %.1f MiB\n", \
+                        (sharing + zero) * size / 1048576 }'
+else
+    echo 'Savings including zero pages: N/A (counter unavailable)'
+fi
+
+cat "$KSM/general_profit"
+cat "$KSM/full_scans"
+cat "$KSM/pages_shared"
+cat "$KSM/pages_unshared"
+cat "$KSM/pages_volatile"
+ps -C ksmd -o pid,etime,time,%cpu,cmd
+```
+
+The important distinctions are:
+
+- `pages_sharing` is the number of additional mappings sharing KSM
+  pages: multiply it by `PAGE_SIZE` to estimate bytes saved globally.
+  If `use_zero_pages` is or was enabled, add `ksm_zero_pages` before
+  multiplying to include mappings deduplicated against the kernel zero
+  page. Older kernels may not expose that counter; report zero-page-
+  inclusive savings as unavailable rather than assuming it is zero.
+- `pages_shared` is the number of shared KSM pages retained, not the
+  number of pages saved.
+- `general_profit` is the kernel's system-wide estimate after KSM
+  metadata cost. A negative value means the current policy costs more
+  memory than it saves.
+- `full_scans` counts completed passes over all registered mergeable
+  areas. Record elapsed time and the change in `ksmd` CPU time across
+  those passes.
+
+These counters are host-global. They cannot attribute savings to one
+Boxman project when other mergeable workloads are present.
+
+### Project and process attribution
+
+First identify the QEMU PIDs belonging to the target domains. For each
+PID, record proportional set size (PSS) and KSM statistics:
+
+```bash
+sudo awk '/^(Rss|Pss):/' /proc/<qemu-pid>/smaps_rollup
+sudo cat /proc/<qemu-pid>/ksm_stat
+```
+
+Sum PSS across the same target PIDs before and after KSM. RSS is not a
+useful KSM savings measure by itself because a shared page is still
+resident in every process which maps it. On kernels which expose
+`ksm_stat`:
+
+- `ksm_merging_pages + ksm_zero_pages`, multiplied by `PAGE_SIZE`,
+  estimates saved mappings for that process;
+- `ksm_process_profit` reports its estimated benefit after KSM metadata.
+
+Not every supported distribution kernel exposes `/proc/<pid>/ksm_stat`.
+Use aggregate PSS as the project-level measurement when it is absent.
+
+## Controlled Boxman fleet result
+
+A controlled evaluation used six powered-on, same-template 1 GiB Linux
+VMs. Every guest ran the same transient memory workload, free-page
+reporting remained enabled in both arms, and KSM was the only intended
+independent variable. Measurements were taken after at least two full
+scans and repeated with scanning frozen.
+
+- Aggregate QEMU PSS fell from about 3.29 GiB to 1.31 GiB: a **60.3%**
+  reduction, or about **1.98 GiB**.
+- Per-process KSM statistics attributed about **2.09 GiB** of merged
+  mappings and **2.04 GiB** of net process profit to the six VMs.
+- Aggregate RSS changed by only 1.3%, illustrating why PSS and
+  per-process KSM counters are the meaningful attribution measures.
+- The deliberately accelerated scan completed two full passes in about
+  170 seconds but used roughly 68% of one CPU on average. During the
+  first 30 seconds it had not merged pages yet, and host-global profit
+  was negative because reverse-map metadata had already been allocated.
+
+The result supports KSM as a useful operator option for dense,
+same-template fleets. It does not establish a safe default scan policy
+for other kernels, hosts, workloads, NUMA layouts, or trust models.
+
+## Restore the original policy
+
+Record the original values before the experiment and restore them
+exactly afterward. To remove the merged state, not merely stop future
+scans:
+
+```bash
+# Check headroom before unmerging.
+grep '^MemAvailable:' /proc/meminfo
+
+# Stop ksmd and unmerge all currently merged pages.
+echo 2 | sudo tee /sys/kernel/mm/ksm/run
+
+# Set these variables from the values recorded before the evaluation.
+printf '%s\n' "$ORIGINAL_PAGES_TO_SCAN" | \
+    sudo tee /sys/kernel/mm/ksm/pages_to_scan
+printf '%s\n' "$ORIGINAL_RUN_VALUE" | sudo tee /sys/kernel/mm/ksm/run
+```
+
+Also restore the original enabled/active state of any KSM service. After
+an unmerge, verify `pages_shared`, `pages_sharing`, `pages_unshared`,
+`pages_volatile`, and `general_profit` returned to zero. Historical
+counters such as `pages_scanned` and accumulated `ksmd` CPU time do not
+reset through the normal sysfs controls.
+
+## Why Boxman does not automate this yet
+
+The observed project-level saving is large enough to document, but not
+enough to justify an automatic host-preparation helper. A policy helper
+would need to account for distribution-specific service management,
+host-wide workloads, capacity reserve, kernel differences, NUMA
+topology, and security boundaries. It could otherwise make an unrelated
+VM slower or make unmerge unsafe.
+
+A future first step should be a read-only readiness and measurement
+command. Persistent policy enablement should remain explicit and
+operator-owned until results cover more kernels, hosts, and long-running
+workloads.
+
+[kernel-ksm]: https://docs.kernel.org/admin-guide/mm/ksm.html

--- a/doc/ksm.md
+++ b/doc/ksm.md
@@ -76,7 +76,8 @@ memory controls fixed between the KSM-off and KSM-on measurements.
    pages processed before `ksmd` sleeps for `sleep_millisecs`; their
    combination determines the upper scan rate. There is no universally
    safe value. Start low and monitor CPU, `MemAvailable`, and
-   `general_profit`.
+   `general_profit`. On kernels with the scan-time advisor, first choose
+   whether the advisor or the manual batch size will own the scan rate.
 3. Start KSM and wait for a scan-count target rather than an arbitrary
    delay. At least two increments of `full_scans` let pages initially
    classified as changing be examined again.
@@ -87,20 +88,72 @@ memory controls fixed between the KSM-off and KSM-on measurements.
 The manual control surface is:
 
 ```bash
+KSM=/sys/kernel/mm/ksm
+
+# The scan-time advisor owns pages_to_scan while active. Do not mix modes.
+if test -r "$KSM/advisor_mode" && \
+        test "$(cat "$KSM/advisor_mode")" = scan-time; then
+    echo 'scan-time advisor is active; pages_to_scan is advisor-owned' >&2
+    exit 1
+fi
+
 # Optional: explicitly set this to the bounded batch size selected for this host.
-printf '%s\n' "$PAGES_PER_BATCH" | sudo tee /sys/kernel/mm/ksm/pages_to_scan
+printf '%s\n' "$PAGES_PER_BATCH" | sudo tee "$KSM/pages_to_scan"
 
 # Start scanning.
-echo 1 | sudo tee /sys/kernel/mm/ksm/run
+echo 1 | sudo tee "$KSM/run"
 
 # Stop scanning but retain merged pages for measurement.
-echo 0 | sudo tee /sys/kernel/mm/ksm/run
+echo 0 | sudo tee "$KSM/run"
 ```
+
+The kernel rejects writes to `pages_to_scan` while
+`advisor_mode=scan-time`. Do not retry the write or assume the requested
+value took effect. Either leave the advisor active and tune its controls,
+or explicitly switch to `advisor_mode=none` during an operator-approved
+manual experiment. Record and restore the original mode and controls.
+If `ksmtuned` is managing KSM, change its distribution policy instead of
+writing either interface underneath it.
 
 Monitor at a fixed interval and set a wall-time limit. Stop early if
 `MemAvailable` approaches the host's safety reserve, `ksmd` CPU is too
 high, or profit remains negative. Do not copy a scan rate from another
 machine without measuring it locally.
+
+### Built-in scan-time advisor, when available
+
+The upstream scan-time advisor first appears in the
+[Linux 6.8 KSM documentation][kernel-ksm-6.8]. Distribution kernels may
+omit it or backport it to an older version, so the kernel release string
+is not an authoritative availability check. Feature-detect
+`/sys/kernel/mm/ksm/advisor_mode` and the related controls on the running
+host:
+
+```bash
+KSM=/sys/kernel/mm/ksm
+for control in advisor_mode advisor_max_cpu advisor_target_scan_time \
+        advisor_min_pages_to_scan advisor_max_pages_to_scan; do
+    if test -r "$KSM/$control"; then
+        printf '%s=' "$control"
+        cat "$KSM/$control"
+    else
+        printf '%s=N/A\n' "$control"
+    fi
+done
+```
+
+In `scan-time` mode, the kernel recalculates `pages_to_scan` after each
+full scan. `advisor_target_scan_time` sets the target duration,
+`advisor_max_cpu` limits the advisor's CPU budget, and the min/max
+`pages_to_scan` controls bound its batch-size decisions. This is often a
+better starting point for a dynamic fleet than a fixed batch copied from
+another host.
+
+Enabling or retuning the advisor is still an operator-owned policy
+change. Set its limits from a measured host capacity budget, record the
+original values, and monitor the same counters and workload latency as
+with manual scanning. Do not enable it merely because the sysfs files
+exist.
 
 ## Measure savings and cost
 
@@ -178,10 +231,72 @@ Use aggregate PSS as the project-level measurement when it is absent.
 ## Controlled Boxman fleet result
 
 A controlled evaluation used six powered-on, same-template 1 GiB Linux
-VMs. Every guest ran the same transient memory workload, free-page
-reporting remained enabled in both arms, and KSM was the only intended
-independent variable. Measurements were taken after at least two full
-scans and repeated with scanning frozen.
+VMs. Each guest faulted 600 MiB once, the allocation process exited, and
+the fleet then idled for 90 seconds. Free-page reporting remained
+enabled with a five-second statistics period in both arms, and KSM was
+the only intended independent variable. Measurements were taken after
+at least two full scans and repeated with scanning frozen.
+
+This result is **illustrative, not an independently reproducible Boxman
+benchmark**. The repository does not contain a versioned harness or raw
+result artifact for this run. The sanitized raw values below make the
+arithmetic auditable, but operators must repeat the documented workflow
+on their own fleet before choosing a policy.
+
+The host used 4096-byte pages. The fixed KSM controls were:
+
+| Control | Before | Evaluation | Frozen sample |
+|---|---:|---:|---:|
+| `run` | 0 | 1 | 0 |
+| `pages_to_scan` | 100 | 10,000 | 10,000 |
+| `sleep_millisecs` | 20 | 20 | 20 |
+| `merge_across_nodes` | 1 | 1 | 1 |
+| `use_zero_pages` | 0 | 0 | 0 |
+| `max_page_sharing` | 256 | 256 | 256 |
+| `smart_scan` | not exposed | not exposed | not exposed |
+| `advisor_mode` | not exposed | not exposed | not exposed |
+
+The benchmark intentionally accelerated the fixed-batch scan to at most
+500,000 pages per second (`pages_to_scan / sleep interval`). This is a
+record of the experiment, not a recommended setting.
+
+Before scanning, `full_scans`, `pages_scanned`, `pages_shared`,
+`pages_sharing`, `pages_unshared`, `pages_volatile`, `ksm_zero_pages`,
+`general_profit`, and accumulated `ksmd` CPU time were all 0.
+
+Raw host-global sysfs and CPU samples:
+
+| Metric | 30 s | Two scans, 170 s | Frozen, 189 s |
+|---|---:|---:|---:|
+| `full_scans` | 0 | 2 | 2 |
+| `pages_scanned` | 11,290,000 | 26,712,292 | 30,081,102 |
+| `pages_shared` | 0 | 1,000,688 | 1,000,785 |
+| `pages_sharing` | 0 | 6,293,849 | 6,296,298 |
+| `pages_unshared` | 0 | 5,781,709 | 5,778,126 |
+| `pages_volatile` | 11,290,000 | 99,306 | 100,342 |
+| `ksm_zero_pages` | 0 | 0 | 0 |
+| `general_profit` (bytes) | -722,580,864 | 24,936,374,336 | 24,946,401,344 |
+| `ksmd` CPU time (seconds) | 6.63 | 114.76 | 126.80 |
+
+The scanner entered part of a third pass during the 19 seconds between
+the two-scan criterion and the frozen measurement; that is why
+`pages_scanned` increased while `full_scans` remained 2. At the frozen
+point, `6,296,298 * 4096 / 1048576 = 24,594.9 MiB` saved according to
+`pages_sharing`, but that is a **host-global** figure which includes
+mergeable workloads outside the six-VM fleet.
+
+Project attribution used medians of three samples over the same six QEMU
+PIDs:
+
+| Aggregate process metric | KSM off | KSM frozen |
+|---|---:|---:|
+| RSS from `smaps_rollup` (KiB) | 3,578,496 | 3,533,280 |
+| PSS from `smaps_rollup` (KiB) | 3,450,057 | 1,369,932 |
+| `ksm_merging_pages` | 0 | 548,549 |
+| `ksm_zero_pages` | 0 | 0 |
+| `ksm_process_profit` (bytes) | 0 | 2,194,132,864 |
+
+Those raw project values yield the following observations:
 
 - Aggregate QEMU PSS fell from about 3.29 GiB to 1.31 GiB: a **60.3%**
   reduction, or about **1.98 GiB**.
@@ -211,11 +326,16 @@ grep '^MemAvailable:' /proc/meminfo
 # Stop ksmd and unmerge all currently merged pages.
 echo 2 | sudo tee /sys/kernel/mm/ksm/run
 
-# Set these variables from the values recorded before the evaluation.
+# For a manual policy, set these from the values recorded before evaluation.
 printf '%s\n' "$ORIGINAL_PAGES_TO_SCAN" | \
     sudo tee /sys/kernel/mm/ksm/pages_to_scan
 printf '%s\n' "$ORIGINAL_RUN_VALUE" | sudo tee /sys/kernel/mm/ksm/run
 ```
+
+If the original policy used `advisor_mode=scan-time`, restore its
+`advisor_*` limits and mode instead. Do not try to force an old
+`pages_to_scan` value after re-enabling the advisor: it is an advisor-
+managed value and will be recalculated after a full scan.
 
 Also restore the original enabled/active state of any KSM service. After
 an unmerge, verify `pages_shared`, `pages_sharing`, `pages_unshared`,
@@ -238,3 +358,4 @@ operator-owned until results cover more kernels, hosts, and long-running
 workloads.
 
 [kernel-ksm]: https://docs.kernel.org/admin-guide/mm/ksm.html
+[kernel-ksm-6.8]: https://docs.kernel.org/6.8/admin-guide/mm/ksm.html

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -332,7 +332,7 @@ runtime has `zstd` available.
 
 | Tool | Used by | Soft-require behaviour |
 |---|---|---|
-| `virt-sparsify` (from `guestfs-tools` / `libguestfs-tools`) | `compact --method sparsify` and `auto` when snapshots exist | Pre-flight check; clear error before any destructive op: `virt-sparsify not found in the runtime — install guestfs-tools / libguestfs-tools, or pass --method convert` |
+| `virt-sparsify` (from `guestfs-tools`) | `compact --method sparsify` and `auto` when snapshots exist | Pre-flight check; clear error before any destructive op: `virt-sparsify not found in the runtime — install guestfs-tools, or pass --method convert` |
 | `zstd` | Memory compression / decompression | Same — error if missing on first compress; restore-side decompress also surfaces a clear error |
 | `qemu-guest-agent` | `trim` (`virsh domfstrim`) | If unresponsive, `trim` errors with `qemu-guest-agent not responsive. install it in the guest (apt/dnf install qemu-guest-agent) and reboot.` |
 
@@ -381,7 +381,7 @@ boxman storage optimize --dry-run
 | `fstrim failed: … qemu-guest-agent not responsive` | The guest agent isn't installed or the agent channel is missing | In the guest: `sudo apt install qemu-guest-agent && sudo systemctl enable --now qemu-guest-agent` (or `dnf` equivalent). Reboot if the agent channel was added by `boxman update`. |
 | `compact` refuses with "snapshots present and --drop-snapshots not given" | Method `convert`/`convert-compressed` would flatten the chain | Either pass `--drop-snapshots`, or use `--method sparsify` (or default `auto`) which preserves the chain |
 | `compact` refuses with "vm … is running and --no-shutdown was passed" | You opted out of auto-shutdown but the VM is up | Drop `--no-shutdown`, or shut the VM down manually first |
-| `virt-sparsify not found in the runtime` | `guestfs-tools` not installed in the active runtime | `dnf install guestfs-tools` (RHEL/Rocky) or `apt install libguestfs-tools` (Debian/Ubuntu); or use `--method convert`; or switch to the docker runtime which already includes it |
+| `virt-sparsify not found in the runtime` | `guestfs-tools` not installed in the active runtime | Install `guestfs-tools` with `dnf` (RHEL/Rocky) or `apt` (Debian/Ubuntu); or use `--method convert`; or switch to the docker runtime which already includes it |
 | `zstd not found in runtime` (during compress / decompress) | `zstd` missing on the host or in the runtime | Install zstd; the docker runtime image already includes it |
 | `df` shows huge `SNAPMEM` | Snapshot memory dumps not compressed | `boxman storage compress-snapshots` |
 | `df` shows huge `ALLOC` and `CHAIN > 1` | Sparse holes in overlays | `boxman storage compact` (auto picks sparsify) |

--- a/doc/tutorial/README.md
+++ b/doc/tutorial/README.md
@@ -620,9 +620,10 @@ a page stays allocated until the VM stops -- even after the guest frees it.
 
 Free-page reporting needs a Linux guest kernel >= 5.7 (all supported cloud images
 qualify), **libvirt >= 6.9.0**, and **QEMU >= 5.1**. Autodeflate is supported by
-QEMU/KVM with **libvirt >= 1.3.1**. On older or incompatible hosts, `virsh define`
-may reject or silently drop an unsupported setting. The resulting libvirt domain
-gets both settings as attributes on the same balloon device; verify with:
+QEMU/KVM with **libvirt >= 1.3.1** and **QEMU >= 2.9**. On older or incompatible
+hosts, `virsh define` may reject or silently drop an unsupported setting. The
+resulting libvirt domain gets both settings as attributes on the same balloon
+device; verify with:
 
 ```bash
 virsh dumpxml --inactive <vm> | grep -A2 memballoon
@@ -630,12 +631,12 @@ virsh dumpxml --inactive <vm> | grep -A2 memballoon
 #     <stats period='5'/>
 ```
 
-Changes to a running VM are written to the persistent config and
-take effect from the next boot; `boxman update` reports `restart required`
-without restarting the guest automatically. It keeps reporting that live-state
-drift until the guest boots with the new persistent XML, and applies that XML
-idempotently (and removing the `memballoon` block reconciles the VM back to the
-defaults).
+Changes to an active VM (including a paused VM) are written to the persistent
+config and take effect from the next boot; `boxman update` reports
+`restart required` without restarting the guest automatically. It keeps
+reporting that live-state drift until the guest boots with the new persistent
+XML, and applies that XML idempotently (and removing the `memballoon` block
+reconciles the VM back to the defaults).
 
 > For many similar VMs, KSM can also deduplicate identical live pages
 > across guests. KSM is a host-wide, operator-owned policy with CPU,

--- a/doc/tutorial/README.md
+++ b/doc/tutorial/README.md
@@ -637,12 +637,12 @@ virsh dumpxml --inactive <vm> | grep -A2 memballoon
 #     <stats period='5'/>
 ```
 
-Changes to an active VM (including a paused VM) are written to the persistent
-config and take effect from the next boot; `boxman update` reports
-`restart required` without restarting the guest automatically. It keeps
-reporting that live-state drift until the guest boots with the new persistent
-XML, and applies that XML idempotently (and removing the `memballoon` block
-reconciles the VM back to the defaults).
+Changes to an active VM (including a paused or crash-preserved VM) are written
+to the persistent config and take effect from the next boot; `boxman update`
+reports `restart required` without restarting the guest automatically. It
+keeps reporting that live-state drift until the guest boots with the new
+persistent XML, and applies that XML idempotently (and removing the
+`memballoon` block reconciles the VM back to the defaults).
 
 > For many similar VMs, KSM can also deduplicate identical live pages
 > across guests. KSM is a host-wide, operator-owned policy with CPU,

--- a/doc/tutorial/README.md
+++ b/doc/tutorial/README.md
@@ -554,33 +554,40 @@ creation time -- the QEMU process was started with headroom for scaling.
 ### Returning unused memory to the host
 
 KVM only allocates host RAM for pages a guest has actually touched, but once touched,
-a page stays allocated until the VM stops -- even after the guest frees it. The
-`memballoon` option enables virtio-balloon **free-page reporting**, which lets the
-guest continuously hand unused pages back to the host:
+a page stays allocated until the VM stops -- even after the guest frees it.
+`memballoon` configures two complementary virtio-balloon memory-reclaim features:
+
+- **free-page reporting** continuously hands unused guest pages back to the host;
+- **autodeflate** releases ballooned memory as a last-resort safeguard before
+  guest memory pressure triggers the OOM killer.
 
 ```yaml
       node01:
         memory: 2048
         memballoon:
           free_page_reporting: true   # guest returns freed pages to the host
+          autodeflate: true            # release ballooned RAM under guest OOM pressure
           stats_period: 5             # optional; balloon stats sample interval (s)
 ```
 
-No guest-side setup is needed beyond a Linux kernel >= 5.7 (all supported cloud
-images qualify). The host needs **libvirt >= 6.9.0** and **QEMU >= 5.1** — on older
-versions `virsh define` may reject or silently drop the setting. The resulting
-libvirt domain gets a balloon device with
-`<memballoon model='virtio' freePageReporting='on'>`; verify with:
+Free-page reporting needs a Linux guest kernel >= 5.7 (all supported cloud images
+qualify), **libvirt >= 6.9.0**, and **QEMU >= 5.1**. Autodeflate is supported by
+QEMU/KVM with **libvirt >= 1.3.1**. On older or incompatible hosts, `virsh define`
+may reject or silently drop an unsupported setting. The resulting libvirt domain
+gets both settings as attributes on the same balloon device; verify with:
 
 ```bash
 virsh dumpxml --inactive <vm> | grep -A2 memballoon
-#   <memballoon model='virtio' freePageReporting='on'>
+#   <memballoon model='virtio' freePageReporting='on' autodeflate='on'>
 #     <stats period='5'/>
 ```
 
 Changes to a running VM are written to the persistent config and
-take effect from the next boot; `boxman update` applies them idempotently
-(and removing the `memballoon` block reconciles the VM back to the defaults).
+take effect from the next boot; `boxman update` reports `restart required`
+without restarting the guest automatically. It keeps reporting that live-state
+drift until the guest boots with the new persistent XML, and applies that XML
+idempotently (and removing the `memballoon` block reconciles the VM back to the
+defaults).
 
 > For many similar VMs, also consider enabling KSM on the host
 > (`systemctl enable --now ksmd` / `ksmtuned`) to deduplicate identical pages

--- a/doc/tutorial/README.md
+++ b/doc/tutorial/README.md
@@ -259,6 +259,54 @@ graph TD
 | `vms` | Each VM is cloned from the template. `max_vcpus` and `max_memory` set the hot-scaling ceiling (we'll use this in Chapter 2). |
 | `workspace` | Directory where boxman generates SSH configs, ansible inventory, and keys. |
 
+### Libvirt network modes
+
+Per-cluster libvirt networks support `nat`, `route`, and `bridge` modes. `nat`
+and `route` let libvirt create the Linux bridge; they take the `ip`, `mac`,
+`bridge.stp`, and `bridge.delay` settings shown in the examples. Bridge mode is
+different: it creates a named libvirt network that points at an **existing**
+host Linux bridge.
+
+```yaml
+networks:
+  migration:
+    mode: bridge
+    bridge:
+      name: br-migration
+    enable: true
+    autostart: true
+
+vms:
+  node01:
+    network_adapters:
+      - name: migration
+        network_source: migration
+```
+
+Create and bring up `br-migration` in the libvirt daemon's network namespace
+before running Boxman. With a local libvirt URI Boxman checks that namespace
+before defining anything. With a remote URI such as `qemu+ssh://hv/system`,
+the client's `/sys` describes the wrong host, so the remote libvirt daemon is
+the authority and validates the bridge when the network starts. Do not set
+`ip`, `mac`, `bridge.stp`, or `bridge.delay` in this block: addressing and link
+policy belong to the host bridge. Boxman removes only the libvirt network
+definition during teardown; it never deletes the underlying bridge.
+
+Use bridge mode when VMs should reference a stable libvirt network name while
+different hypervisors map that name to their own bridge—for example, live
+migration. Use top-level `shared_networks` when Boxman should create/manage a
+shared Linux bridge on the **Boxman host** for direct VM, containerlab, or
+Docker attachment instead. That can supply a bridge-mode network only with the
+local runtime. A docker-compose libvirt runtime has a separate network
+namespace: create its bridge inside that runtime (for example in a custom
+runtime image/startup), not with host-level `shared_networks`.
+
+Changing between `nat`/`route` and `bridge` also crosses bridge ownership:
+libvirt deletes a managed `nat`/`route` bridge, while it preserves a host-owned
+bridge. Use different bridge names for that transition (or omit the managed
+side's `bridge.name` so Boxman reserves a safe automatic name before recreating
+the network).
+
 ## 1.4 Provision
 
 ```bash

--- a/doc/tutorial/README.md
+++ b/doc/tutorial/README.md
@@ -637,9 +637,11 @@ drift until the guest boots with the new persistent XML, and applies that XML
 idempotently (and removing the `memballoon` block reconciles the VM back to the
 defaults).
 
-> For many similar VMs, also consider enabling KSM on the host
-> (`systemctl enable --now ksmd` / `ksmtuned`) to deduplicate identical pages
-> across guests -- it is a host-level setting, complementary to free-page reporting.
+> For many similar VMs, KSM can also deduplicate identical live pages
+> across guests. KSM is a host-wide, operator-owned policy with CPU,
+> capacity, NUMA, and trust-boundary trade-offs; Boxman does not enable it.
+> See [Host Memory Deduplication with KSM](../ksm.md) for a bounded
+> evaluation and measurement workflow.
 
 ## 2.4 Snapshot the Whole Cluster
 

--- a/doc/tutorial/README.md
+++ b/doc/tutorial/README.md
@@ -283,14 +283,20 @@ vms:
         network_source: migration
 ```
 
-Create and bring up `br-migration` in the libvirt daemon's network namespace
-before running Boxman. With a local libvirt URI Boxman checks that namespace
-before defining anything. With a remote URI such as `qemu+ssh://hv/system`,
-the client's `/sys` describes the wrong host, so the remote libvirt daemon is
-the authority and validates the bridge when the network starts. Do not set
-`ip`, `mac`, `bridge.stp`, or `bridge.delay` in this block: addressing and link
-policy belong to the host bridge. Boxman removes only the libvirt network
-definition during teardown; it never deletes the underlying bridge.
+Create and administratively bring up `br-migration` in the libvirt daemon's
+network namespace before running Boxman. For an authority-less URI such as
+`qemu:///system`, Boxman verifies both that it is a Linux bridge and that its
+`IFF_UP` flag is set before defining anything. It deliberately does not use
+`operstate`: an up bridge with no attached ports commonly reports `unknown`.
+
+Any authority-bearing URI, including `qemu+ssh://hv/system` and even
+`qemu://localhost/system`, may reach a transport or daemon namespace different
+from the Boxman process. Client-side `/sys` is therefore not authoritative;
+the endpoint's libvirt daemon validates the bridge when the network starts.
+Do not set `ip`, `mac`, `bridge.stp`, or `bridge.delay` in this block:
+addressing and link policy belong to the host bridge. Boxman removes only the
+libvirt network definition during teardown; it never deletes the underlying
+bridge.
 
 Use bridge mode when VMs should reference a stable libvirt network name while
 different hypervisors map that name to their own bridge—for example, live

--- a/doc/tutorial/README.md
+++ b/doc/tutorial/README.md
@@ -36,7 +36,7 @@ Boxman uses libvirt/QEMU under the hood. Install the virtualization stack for yo
 ### Arch Linux
 
 ```bash
-sudo pacman -S libvirt qemu-full virt-install sshpass dnsmasq
+sudo pacman -S libvirt qemu-full virt-install guestfs-tools sshpass dnsmasq
 sudo systemctl enable --now libvirtd
 sudo usermod -aG libvirt,kvm $USER
 ```
@@ -47,7 +47,7 @@ sudo usermod -aG libvirt,kvm $USER
 sudo apt update
 sudo apt install -y \
   libvirt-daemon-system libvirt-clients qemu-kvm \
-  virtinst sshpass bridge-utils cloud-image-utils
+  virtinst guestfs-tools sshpass bridge-utils cloud-image-utils
 sudo systemctl enable --now libvirtd
 sudo usermod -aG libvirt,kvm $USER
 ```
@@ -55,7 +55,7 @@ sudo usermod -aG libvirt,kvm $USER
 ### Fedora / RHEL / Rocky
 
 ```bash
-sudo dnf install -y libvirt qemu-kvm virt-install sshpass genisoimage
+sudo dnf install -y libvirt qemu-kvm virt-install guestfs-tools sshpass genisoimage
 sudo systemctl enable --now libvirtd
 sudo usermod -aG libvirt,kvm $USER
 ```
@@ -64,7 +64,8 @@ sudo usermod -aG libvirt,kvm $USER
 
 ```bash
 sudo emerge --ask app-emulation/libvirt app-emulation/qemu \
-  app-emulation/virt-manager net-dns/dnsmasq app-admin/sudo
+  app-emulation/virt-manager app-emulation/guestfs-tools \
+  net-dns/dnsmasq app-admin/sudo
 sudo systemctl enable --now libvirtd        # systemd profile
 # OpenRC profile instead:
 #   sudo rc-update add libvirtd default && sudo rc-service libvirtd start
@@ -85,7 +86,7 @@ instead of installing packages imperatively:
 ```nix
 virtualisation.libvirtd.enable = true;
 programs.virt-manager.enable = true;
-environment.systemPackages = with pkgs; [ virt-manager qemu cloud-utils ];
+environment.systemPackages = with pkgs; [ virt-manager qemu guestfs-tools cloud-utils ];
 users.users.<you>.extraGroups = [ "libvirtd" "kvm" ];
 ```
 
@@ -196,6 +197,7 @@ clusters:
     vms:
       node01:
         hostname: node01
+        clone_machine_id: auto  # auto (default), required, or off; see below
         cpus: { sockets: 1, cores: 2, threads: 2 }
         memory: 2048
         max_vcpus: 16       # ceiling for live hot-scaling later
@@ -208,6 +210,24 @@ clusters:
           - name: adapter_1
             network_source: 'nat1'
 ```
+
+`virt-clone` assigns a new libvirt UUID and NIC MAC but copies the guest
+filesystem, including Linux's machine ID. Boxman therefore runs the offline
+`virt-sysprep --operations machine-id` reset before changing interfaces or
+starting a normal disk clone. `clone_machine_id` controls failure handling:
+
+- `auto` (default) attempts the reset, but warns and continues if libguestfs
+  cannot inspect an opaque, encrypted, or unsupported appliance;
+- `required` fails closed and removes the new clone if the reset cannot be
+  completed; use this for supported Linux templates that must never boot with
+  the source identity;
+- `off` skips the reset and retains the legacy clone behavior.
+
+The inspection is non-interactive and limited to 300 seconds by default. Set
+`provider.libvirt.virt_sysprep_timeout` in `boxman.yml` to another positive
+number for unusually slow hosts. Guests that do not regenerate empty machine-ID
+files during boot should use `off` unless the template supplies its own
+first-boot identity mechanism.
 
 ### How the pieces fit together
 

--- a/scripts/installer/README.md
+++ b/scripts/installer/README.md
@@ -6,7 +6,8 @@ Distro families covered: Arch, Debian/Ubuntu, Fedora/RHEL/Rocky, Gentoo, and the
 declarative NixOS and Guix System (see the note on declarative distros below).
 
 Boxman drives libvirt/KVM through the `virsh` / `virt-install` / `virt-clone` /
-`qemu-img` command-line tools and needs a handful of host-level things in place
+`qemu-img` command-line tools and uses `virt-sysprep` when available to reset
+cloned Linux machine IDs. It also needs host-level dependencies
 (a running `libvirtd`, group membership, a `default` NAT network, a cloud-init
 seed-ISO tool, `sshpass`, sudo rights, …). Installing the Python package — e.g.
 `pip install boxman` inside a conda env — does **not** set any of that up. This
@@ -84,7 +85,8 @@ imperatively via `nix profile install nixpkgs#<pkg>` / `guix install <pkg>`.
 - **Virtualization hardware** — CPU VT-x/AMD-V, `/dev/kvm` presence and access,
   and nested virt when running inside a VM.
 - **Local runtime** — the `virsh`/`virt-install`/`virt-clone`/`qemu-img`/QEMU
-  tools, `libvirtd` running, `virsh -c qemu:///system` connectivity, `libvirt`
+  tools, optional `virt-sysprep` (`clone_machine_id: required` needs it),
+  `libvirtd` running, `virsh -c qemu:///system` connectivity, `libvirt`
   and `kvm` group membership, the `default` NAT network, a cloud-init seed-ISO
   tool, `sshpass`, `rsync`, the OpenSSH client, and your **sudo rights**
   (including the footgun where cleanup silently no-ops if `sudo qemu-img`/`rm`

--- a/scripts/installer/README.md
+++ b/scripts/installer/README.md
@@ -13,6 +13,12 @@ seed-ISO tool, `sshpass`, sudo rights, …). Installing the Python package — e
 `pip install boxman` inside a conda env — does **not** set any of that up. This
 script checks all of it in one pass.
 
+On supported Debian and Ubuntu releases, the `guestfs-tools` package owns the
+user-facing `virt-sysprep` and `virt-sparsify` executables. The similarly named
+`libguestfs-tools` is a compatibility/meta package; checker remediation names
+`guestfs-tools` directly so installing one optional tool also supplies the
+other.
+
 ## Usage
 
 ```bash

--- a/scripts/installer/check_prerequisites.py
+++ b/scripts/installer/check_prerequisites.py
@@ -113,15 +113,20 @@ def classify_family(osid, id_like):
 # include x86_64 (e.g. QEMU_SOFTMMU_TARGETS="x86_64") to build qemu-system-x86_64;
 # app-emulation/libvirt needs USE="virt-network qemu" for the QEMU/KVM driver and
 # the default NAT network. virt-install / virt-clone ship in
-# app-emulation/virt-manager. Services are systemd or OpenRC depending on the
-# profile (OpenRC: `rc-update add libvirtd default && rc-service libvirtd start`).
+# app-emulation/virt-manager; virt-sysprep ships in app-emulation/guestfs-tools.
+# Services are systemd or OpenRC depending on the profile (OpenRC:
+# `rc-update add libvirtd default && rc-service libvirtd start`).
 _CORE_STACK = {
-    "arch": "sudo pacman -S --needed libvirt qemu-full virt-install sshpass dnsmasq",
+    "arch": ("sudo pacman -S --needed libvirt qemu-full virt-install "
+             "guestfs-tools sshpass dnsmasq"),
     "debian": ("sudo apt update && sudo apt install -y libvirt-daemon-system "
-               "libvirt-clients qemu-kvm virtinst sshpass bridge-utils cloud-image-utils"),
-    "rhel": "sudo dnf install -y libvirt qemu-kvm virt-install sshpass genisoimage",
+               "libvirt-clients qemu-kvm virtinst guestfs-tools sshpass "
+               "bridge-utils cloud-image-utils"),
+    "rhel": ("sudo dnf install -y libvirt qemu-kvm virt-install "
+             "guestfs-tools sshpass genisoimage"),
     "gentoo": ("sudo emerge --ask app-emulation/libvirt app-emulation/qemu "
-               "app-emulation/virt-manager net-dns/dnsmasq app-admin/sudo"),
+               "app-emulation/virt-manager app-emulation/guestfs-tools "
+               "net-dns/dnsmasq app-admin/sudo"),
 }
 
 # Declarative core-stack remediation for NixOS: printed as advisory text, never
@@ -131,7 +136,7 @@ _NIXOS_CORE_ADVICE = (
     "/etc/nixos/configuration.nix:\n"
     "virtualisation.libvirtd.enable = true;\n"
     "programs.virt-manager.enable = true;\n"
-    "environment.systemPackages = with pkgs; [ virt-manager qemu cloud-utils ];\n"
+    "environment.systemPackages = with pkgs; [ virt-manager qemu guestfs-tools cloud-utils ];\n"
     "users.users.<you>.extraGroups = [ \"libvirtd\" \"kvm\" ];\n"
     "then apply with: sudo nixos-rebuild switch"
 )
@@ -145,7 +150,7 @@ _GUIX_CORE_ADVICE = (
     "in your (user-account ...): "
     "(supplementary-groups '(\"libvirt\" \"kvm\" \"wheel\"))\n"
     "then apply with: sudo guix system reconfigure /etc/config.scm\n"
-    "user CLI tools can also be added with: guix install qemu virt-manager"
+    "user CLI tools can also be added with: guix install qemu virt-manager libguestfs"
 )
 
 # Declarative libvirtd-service remediation (advisory) for NixOS.
@@ -177,6 +182,8 @@ _TOOL_PKG = {
              "gentoo": "app-arch/zstd", "nixos": "zstd", "guix": "zstd"},
     "virt-sparsify": {"arch": "guestfs-tools", "debian": "libguestfs-tools", "rhel": "guestfs-tools",
                       "gentoo": "app-emulation/libguestfs", "nixos": "guestfs-tools", "guix": "libguestfs"},
+    "virt-sysprep": {"arch": "guestfs-tools", "debian": "guestfs-tools", "rhel": "guestfs-tools",
+                     "gentoo": "app-emulation/guestfs-tools", "nixos": "guestfs-tools", "guix": "libguestfs"},
     "openssh": {"arch": "openssh", "debian": "openssh-client", "rhel": "openssh-clients",
                 "gentoo": "net-misc/openssh", "nixos": "openssh", "guix": "openssh"},
 }
@@ -915,6 +922,22 @@ class Doctor:
 
         self.check("Nested virtualization", nested)
 
+    def _check_clone_sanitizer(self):
+        """Report virt-sysprep as recommended, not a core runtime gate."""
+        def clone_sanitizer():
+            if have("virt-sysprep"):
+                return OK, "virt-sysprep present for clone machine-ID reset", None
+            package = _TOOL_PKG["virt-sysprep"].get(
+                self.family, "guestfs-tools")
+            return WARN, (
+                "virt-sysprep missing; clone_machine_id=auto will warn and "
+                "continue, while clone_machine_id=required will fail closed"
+            ), self._install_fix(
+                "install virt-sysprep for automatic clone machine-ID resets",
+                package)
+
+        return self.check("Clone machine-ID sanitizer", clone_sanitizer)
+
     # -- LOCAL runtime ----------------------------------------------------- #
     def check_local_runtime(self):
         self.section("libvirt / QEMU (local runtime)")
@@ -926,10 +949,13 @@ class Doctor:
             if not qemu_sys:
                 missing.append("qemu-system-x86_64")
             if not missing:
-                return OK, "virsh, virt-install, virt-clone, qemu-img, qemu-system present", None
+                return OK, ("virsh, virt-install, virt-clone, qemu-img, "
+                            "qemu-system present"), None
             return FAIL, f"missing: {', '.join(missing)}", self._core_stack_fix()
 
         tools = self.check("Core libvirt/QEMU tools", core_tools)
+
+        self._check_clone_sanitizer()
 
         def libvirtd_service():
             active = run_capture(["systemctl", "is-active", "libvirtd"])[1].strip()
@@ -1070,8 +1096,9 @@ class Doctor:
                 fix = Fix(
                     "grant passwordless sudo for the commands boxman runs, e.g. a "
                     "/etc/sudoers.d/boxman line: "
-                    "`%s ALL=(root) NOPASSWD: /usr/bin/virsh, /usr/bin/qemu-img, "
-                    "/usr/sbin/iptables, /usr/sbin/ip, /usr/bin/rsync, /bin/rm`" % (
+                    "`%s ALL=(root) NOPASSWD: /usr/bin/virsh, "
+                    "/usr/bin/virt-sysprep, /usr/bin/qemu-img, /usr/sbin/iptables, "
+                    "/usr/sbin/ip, /usr/bin/rsync, /bin/rm`" % (
                         user_group_names()[1] or "$USER"),
                     commands=[])
                 return WARN, ("passwordless sudo not available; boxman's automatic "
@@ -1079,18 +1106,24 @@ class Doctor:
                               "non-interactively"), fix
             # passwordless sudo exists -- check the scope that bites people.
             iptables_ok = sudo_nopasswd_covers(out, "iptables")
+            sysprep_ok = sudo_nopasswd_covers(out, "virt-sysprep")
             qemu_ok = sudo_nopasswd_covers(out, "qemu-img")
             rm_ok = sudo_nopasswd_covers(out, "rm")
             gaps = []
             if not iptables_ok:
                 gaps.append("iptables/ip (NAT & isolated networks, netlab bridges)")
+            if not sysprep_ok:
+                gaps.append(
+                    "virt-sysprep (clone_machine_id=required needs NOPASSWD)")
             if not (qemu_ok and rm_ok):
                 gaps.append("qemu-img/rm (destroy/cleanup silently no-ops without these)")
             if not gaps:
-                return OK, "passwordless sudo covers virsh/qemu-img/iptables/rm", None
+                return OK, ("passwordless sudo covers "
+                            "virsh/virt-sysprep/qemu-img/iptables/rm"), None
             fix = Fix(
                 "widen NOPASSWD sudo scope in /etc/sudoers.d/boxman to include: "
-                "virsh, qemu-img, iptables, ip, rsync, rm", commands=[])
+                "virsh, virt-sysprep, qemu-img, iptables, ip, rsync, rm",
+                commands=[])
             return WARN, "passwordless sudo present but missing: " + "; ".join(gaps), fix
 
         self.check("sudo rights", sudo_rights)

--- a/scripts/installer/check_prerequisites.py
+++ b/scripts/installer/check_prerequisites.py
@@ -100,6 +100,39 @@ def classify_family(osid, id_like):
     return "unknown"
 
 
+def strip_yaml_comment(line):
+    """Strip a YAML comment without truncating quoted or embedded ``#``.
+
+    YAML starts a plain-scalar comment only when ``#`` is outside quotes and
+    separated from the preceding content. Single-quoted YAML escapes a quote
+    by doubling it; double-quoted strings use backslash escapes.
+    """
+    quote = None
+    escaped = False
+    index = 0
+    while index < len(line):
+        char = line[index]
+        if quote == '"':
+            if escaped:
+                escaped = False
+            elif char == '\\':
+                escaped = True
+            elif char == '"':
+                quote = None
+        elif quote == "'":
+            if char == "'":
+                if index + 1 < len(line) and line[index + 1] == "'":
+                    index += 1
+                else:
+                    quote = None
+        elif char in ('"', "'"):
+            quote = char
+        elif char == '#' and (index == 0 or line[index - 1].isspace()):
+            return line[:index]
+        index += 1
+    return line
+
+
 def configured_libvirt_use_sudo(text, default=False):
     """Read ``providers.libvirt.use_sudo`` from simple YAML without PyYAML.
 
@@ -110,7 +143,7 @@ def configured_libvirt_use_sudo(text, default=False):
     """
     parents = []
     for raw_line in text.splitlines():
-        code = raw_line.split("#", 1)[0].rstrip()
+        code = strip_yaml_comment(raw_line).rstrip()
         if not code.strip():
             continue
         indent = len(code) - len(code.lstrip(" "))
@@ -1136,18 +1169,28 @@ class Doctor:
     def _check_sudo_rights(self):
         def sudo_rights():
             sysprep_uses_sudo = getattr(self, "use_sudo", False)
+            sudo_command_names = ["virsh"]
+            sudo_command_paths = ["/usr/bin/virsh"]
+            if sysprep_uses_sudo:
+                sudo_command_names.append("virt-sysprep")
+                sudo_command_paths.append("/usr/bin/virt-sysprep")
+            sudo_command_names.extend(
+                ["qemu-img", "iptables", "ip", "rsync", "rm"])
+            sudo_command_paths.extend([
+                "/usr/bin/qemu-img", "/usr/sbin/iptables", "/usr/sbin/ip",
+                "/usr/bin/rsync", "/bin/rm",
+            ])
             if not have("sudo"):
                 fix = self._install_fix("install sudo", "sudo")
                 return WARN, "sudo not found; libvirt network/cleanup steps need it", fix
             rc, out = run_capture(["sudo", "-n", "-l"])
             if rc != 0:
+                sudoers_user = user_group_names()[1] or "$USER"
+                sudoers_commands = ", ".join(sudo_command_paths)
                 fix = Fix(
                     "grant passwordless sudo for the commands boxman runs, e.g. a "
                     "/etc/sudoers.d/boxman line: "
-                    "`%s ALL=(root) NOPASSWD: /usr/bin/virsh, "
-                    "/usr/bin/virt-sysprep, /usr/bin/qemu-img, /usr/sbin/iptables, "
-                    "/usr/sbin/ip, /usr/bin/rsync, /bin/rm`" % (
-                        user_group_names()[1] or "$USER"),
+                    f"`{sudoers_user} ALL=(root) NOPASSWD: {sudoers_commands}`",
                     commands=[])
                 return WARN, ("passwordless sudo not available; boxman's automatic "
                               "iptables/NAT and cleanup steps fail when run "
@@ -1175,7 +1218,7 @@ class Doctor:
                 return OK, "passwordless sudo covers " + covered, None
             fix = Fix(
                 "widen NOPASSWD sudo scope in /etc/sudoers.d/boxman to include: "
-                "virsh, virt-sysprep, qemu-img, iptables, ip, rsync, rm",
+                + ", ".join(sudo_command_names),
                 commands=[])
             return WARN, "passwordless sudo present but missing: " + "; ".join(gaps), fix
 

--- a/scripts/installer/check_prerequisites.py
+++ b/scripts/installer/check_prerequisites.py
@@ -100,6 +100,40 @@ def classify_family(osid, id_like):
     return "unknown"
 
 
+def configured_libvirt_use_sudo(text, default=False):
+    """Read ``providers.libvirt.use_sudo`` from simple YAML without PyYAML.
+
+    The prerequisite checker deliberately has no third-party dependencies.
+    This small indentation-aware scalar reader ignores same-named keys in
+    project/provider blocks and falls back safely when the app config is
+    absent, templated, or malformed.
+    """
+    parents = []
+    for raw_line in text.splitlines():
+        code = raw_line.split("#", 1)[0].rstrip()
+        if not code.strip():
+            continue
+        indent = len(code) - len(code.lstrip(" "))
+        match = re.match(
+            r"^([A-Za-z0-9_-]+)\s*:\s*(.*?)\s*$", code.lstrip(" "))
+        if not match:
+            continue
+        while parents and parents[-1][0] >= indent:
+            parents.pop()
+        key, value = match.groups()
+        path = [parent_key for _, parent_key in parents]
+        if path == ["providers", "libvirt"] and key == "use_sudo":
+            value = value.strip().strip("\"'").lower()
+            if value in ("true", "yes", "on", "1"):
+                return True
+            if value in ("false", "no", "off", "0"):
+                return False
+            return default
+        if not value:
+            parents.append((indent, key))
+    return default
+
+
 # Verbatim per-distro core stack lines (from doc/tutorial/README.md), minus the
 # systemctl/usermod steps which the checker handles as their own fixes.
 #
@@ -180,7 +214,11 @@ _TOOL_PKG = {
                 "gentoo": "app-admin/ansible", "nixos": "ansible", "guix": "ansible"},
     "zstd": {"arch": "zstd", "debian": "zstd", "rhel": "zstd",
              "gentoo": "app-arch/zstd", "nixos": "zstd", "guix": "zstd"},
-    "virt-sparsify": {"arch": "guestfs-tools", "debian": "libguestfs-tools", "rhel": "guestfs-tools",
+    # Debian-family releases supported by Boxman, including Ubuntu 22.04 and
+    # Debian 12, ship the standalone virt-* applications in guestfs-tools.
+    # libguestfs-tools is a compatibility/meta package there; keep sysprep and
+    # sparsify guidance aligned on the package that owns both executables.
+    "virt-sparsify": {"arch": "guestfs-tools", "debian": "guestfs-tools", "rhel": "guestfs-tools",
                       "gentoo": "app-emulation/libguestfs", "nixos": "guestfs-tools", "guix": "libguestfs"},
     "virt-sysprep": {"arch": "guestfs-tools", "debian": "guestfs-tools", "rhel": "guestfs-tools",
                      "gentoo": "app-emulation/guestfs-tools", "nixos": "guestfs-tools", "guix": "libguestfs"},
@@ -556,6 +594,7 @@ class Doctor:
         self.os = self._detect_os()
         self.family = self.os["family"]
         self.runtime = self._detect_runtime(opts.runtime)
+        self.use_sudo = self._detect_libvirt_use_sudo()
         self.results = []
         self.manual_steps = []
         self.relogin_needed = False
@@ -726,6 +765,14 @@ class Doctor:
             except OSError:
                 pass
         return "local"
+
+    def _detect_libvirt_use_sudo(self):
+        path = os.path.expanduser("~/.config/boxman/boxman.yml")
+        try:
+            with open(path) as handle:
+                return configured_libvirt_use_sudo(handle.read(), default=False)
+        except OSError:
+            return False
 
     def is_virtualized(self):
         rc, out = run_capture(["systemd-detect-virt"])
@@ -1088,6 +1135,7 @@ class Doctor:
 
     def _check_sudo_rights(self):
         def sudo_rights():
+            sysprep_uses_sudo = getattr(self, "use_sudo", False)
             if not have("sudo"):
                 fix = self._install_fix("install sudo", "sudo")
                 return WARN, "sudo not found; libvirt network/cleanup steps need it", fix
@@ -1106,7 +1154,10 @@ class Doctor:
                               "non-interactively"), fix
             # passwordless sudo exists -- check the scope that bites people.
             iptables_ok = sudo_nopasswd_covers(out, "iptables")
-            sysprep_ok = sudo_nopasswd_covers(out, "virt-sysprep")
+            sysprep_ok = (
+                not sysprep_uses_sudo
+                or sudo_nopasswd_covers(out, "virt-sysprep")
+            )
             qemu_ok = sudo_nopasswd_covers(out, "qemu-img")
             rm_ok = sudo_nopasswd_covers(out, "rm")
             gaps = []
@@ -1118,8 +1169,10 @@ class Doctor:
             if not (qemu_ok and rm_ok):
                 gaps.append("qemu-img/rm (destroy/cleanup silently no-ops without these)")
             if not gaps:
-                return OK, ("passwordless sudo covers "
-                            "virsh/virt-sysprep/qemu-img/iptables/rm"), None
+                covered = "virsh/qemu-img/iptables/rm"
+                if sysprep_uses_sudo:
+                    covered = "virsh/virt-sysprep/qemu-img/iptables/rm"
+                return OK, "passwordless sudo covers " + covered, None
             fix = Fix(
                 "widen NOPASSWD sudo scope in /etc/sudoers.d/boxman to include: "
                 "virsh, virt-sysprep, qemu-img, iptables, ip, rsync, rm",

--- a/src/boxman/assets/network.xml.j2
+++ b/src/boxman/assets/network.xml.j2
@@ -6,6 +6,9 @@
   <name>{{ name|e }}</name>
   <uuid>{{ uuid_val }}</uuid>
   <forward mode='{{ forward_mode }}'/>
+{% if forward_mode == 'bridge' %}
+  <bridge name='{{ bridge_name|e }}'/>
+{% else %}
   <bridge name='{{ bridge_name|e }}' stp='{{ bridge_stp }}' delay='{{ bridge_delay }}'/>
   <mac address='{{ mac_address }}'/>
   <ip address='{{ ip_address|e }}' netmask='{{ netmask|e }}'>
@@ -24,4 +27,5 @@
     </dhcp>
   {% endif %}
   </ip>
+{% endif %}
 </network>

--- a/src/boxman/exceptions.py
+++ b/src/boxman/exceptions.py
@@ -39,7 +39,7 @@ class CloneSanitizerError(ProvisionError):
     """
 
 
-class CloneSanitizerUnavailable(CloneSanitizerError):
+class CloneSanitizerUnavailableError(CloneSanitizerError):
     """Raised when a clone cannot be made safe because its offline guest
     sanitizer is unavailable. This is a host/runtime prerequisite failure,
     not a transient libvirt failure, so clone retries should fail fast."""

--- a/src/boxman/exceptions.py
+++ b/src/boxman/exceptions.py
@@ -30,6 +30,35 @@ class ProvisionError(BoxmanError):
     definition, SSH injection). Subclass further for granular handling."""
 
 
+class CloneSanitizerError(ProvisionError):
+    """Raised when an offline clone identity reset cannot be completed.
+
+    These failures are terminal when a VM opts into the ``required`` policy,
+    so repeating the complete clone operation cannot turn them into a safe
+    guest.  The default ``auto`` policy handles them as compatibility warnings.
+    """
+
+
+class CloneSanitizerUnavailable(CloneSanitizerError):
+    """Raised when a clone cannot be made safe because its offline guest
+    sanitizer is unavailable. This is a host/runtime prerequisite failure,
+    not a transient libvirt failure, so clone retries should fail fast."""
+
+
+class CloneCleanupError(CloneSanitizerError):
+    """Raised when a required identity reset fails and the unsafe clone
+    cannot be removed.  The message preserves both the sanitizer failure and
+    the cleanup failure so callers do not retry into a misleading
+    ``domain already exists`` error."""
+
+    def __init__(self, message: str,
+                 sanitizer_error: Exception | None = None,
+                 cleanup_error: object | None = None):
+        super().__init__(message)
+        self.sanitizer_error = sanitizer_error
+        self.cleanup_error = cleanup_error
+
+
 class NetworkError(ProvisionError):
     """Raised when a libvirt network cannot be created, destroyed, or
     inspected. Includes bridge collisions and missing NAT config."""

--- a/src/boxman/manager_parts/networks.py
+++ b/src/boxman/manager_parts/networks.py
@@ -8,6 +8,7 @@ import os
 import time
 from typing import Any
 
+from boxman.exceptions import ConfigError
 from boxman.providers.libvirt import net_reconcile
 
 
@@ -83,7 +84,7 @@ class NetworksMixin:
                 try:
                     plan = self.provider.plan_network(
                         name=full_name, info=network_info)
-                except ValueError as exc:
+                except (ConfigError, ValueError) as exc:
                     # the network block itself does not validate (a bad dhcp
                     # reservation, say). Report it against the network it came
                     # from and carry on: the other networks, and the VMs, are
@@ -226,7 +227,7 @@ class NetworksMixin:
         try:
             ok = self.provider.define_network(
                 name=full_name, info=network_info, workdir=workdir)
-        except RuntimeError as exc:
+        except (ConfigError, RuntimeError) as exc:
             self.logger.error(f"network {label}: could not be defined: {exc}")
             return 'failed'
         return 'created' if ok else 'failed'
@@ -318,9 +319,10 @@ class NetworksMixin:
                   f"redefined to apply:")
             for change in plan['structural']:
                 print(f"  - {change}")
-            print("\nIts bridge will be deleted and recreated. These VMs lose "
-                  f"their network link and will be reconnected, by a reboot "
-                  f"if their machine type cannot hot-plug: {attached_text}\n")
+            print("\nThe libvirt network will be deleted and recreated. These "
+                  f"VMs lose their network link and will be reconnected, by "
+                  f"a reboot if their machine type cannot hot-plug: "
+                  f"{attached_text}\n")
             try:
                 answer = input(
                     f"Type '{network_name}' to proceed: ").strip()
@@ -359,9 +361,22 @@ class NetworksMixin:
         self._forget_cached_network(full_name)
 
         self.logger.info(f"network {network_name}: defining again")
+        definition_info = network_info
+        replacement_bridge = plan.get('replacement_bridge_name')
+        if replacement_bridge:
+            # This is an execution-time reservation, not a config pin. The
+            # next reconcile still treats the bridge as auto-assigned and reads
+            # its actual name from libvirt.
+            definition_info = dict(network_info)
+            configured_bridge = network_info.get('bridge')
+            definition_info['bridge'] = {
+                **(configured_bridge if isinstance(configured_bridge, dict)
+                   else {}),
+                'name': replacement_bridge,
+            }
         if self._define_network(
                 label=network_name, full_name=full_name,
-                network_info=network_info,
+                network_info=definition_info,
                 workdir=cluster['workdir']) == 'failed':
             self.logger.error(
                 f"network {network_name}: could not be defined again. The "

--- a/src/boxman/manager_parts/vms.py
+++ b/src/boxman/manager_parts/vms.py
@@ -191,7 +191,7 @@ class VMsMixin:
         else:
             self.logger.warning(f"no cpu or memory configuration for vm {vm_name}, skipping")
 
-        # memballoon (virtio-balloon: free-page reporting, stats)
+        # memballoon (virtio-balloon: free-page reporting, autodeflate, stats)
         memballoon = vm_info.get('memballoon')
         if memballoon:
             self.logger.info(f"configuring memballoon for vm {vm_name}")
@@ -576,7 +576,8 @@ class VMsMixin:
                 diff['new_shared_folders'] or
                 diff['removed_shared_folders'] or
                 diff['changed_shared_folders'] or
-                diff['memballoon_changed']
+                diff['memballoon_changed'] or
+                diff['memballoon_restart_pending']
             )
 
             if not has_changes:
@@ -629,6 +630,10 @@ class VMsMixin:
                 changes.append(
                     f"memballoon: {diff['actual_memballoon']} -> "
                     f"{diff['desired_memballoon']}")
+            elif diff['memballoon_restart_pending']:
+                changes.append(
+                    f"memballoon live state: {diff['live_memballoon']} -> "
+                    f"{diff['desired_memballoon']}")
             self.logger.info(f"VM {vm_name}: changes detected: {'; '.join(changes)}")
 
             if dry_run:
@@ -641,6 +646,7 @@ class VMsMixin:
             # apply changes
             vm_running = diff['vm_state'] == 'running'
             restart_needed = False
+            pending_restart = diff['memballoon_restart_pending']
 
             # CPU / memory / max ceilings
             if (diff['cpu_changed'] or diff['memory_changed'] or
@@ -675,9 +681,9 @@ class VMsMixin:
                         'details': 'memballoon update failed'
                     }))
                     return
-                if vm_running:
-                    self.logger.info(
-                        f"VM {vm_name}: memballoon changes apply from the next boot")
+                if pending_restart:
+                    self.logger.warning(
+                        f"VM {vm_name}: restart required to apply memballoon changes")
 
             # disks
             if diff['new_disks'] or diff['resize_disks']:
@@ -741,6 +747,13 @@ class VMsMixin:
                 result_queue.put((vm_name, {
                     'status': 'updated',
                     'details': '; '.join(changes) + ' (restarted)'
+                }))
+            elif pending_restart:
+                result_queue.put((vm_name, {
+                    'status': 'needs_restart',
+                    'details': (
+                        '; '.join(changes) +
+                        ' (restart required to apply memballoon changes)')
                 }))
             else:
                 result_queue.put((vm_name, {
@@ -901,6 +914,9 @@ class VMsMixin:
             # print summary
             no_change = [n for n, r in results.items() if r['status'] == 'no_change']
             updated = [n for n, r in results.items() if r['status'] == 'updated']
+            needs_restart = [
+                n for n, r in results.items()
+                if r['status'] == 'needs_restart']
             failed = [n for n, r in results.items() if r['status'] == 'failed']
             dry_run_items = [n for n, r in results.items() if r['status'] == 'dry_run']
 
@@ -915,6 +931,12 @@ class VMsMixin:
                 self.logger.info(f"updated: {', '.join(updated)}")
                 for vm_name in updated:
                     self.logger.info(f"  {vm_name}: {results[vm_name]['details']}")
+            if needs_restart:
+                self.logger.warning(
+                    f"restart required: {', '.join(needs_restart)}")
+                for vm_name in needs_restart:
+                    self.logger.warning(
+                        f"  {vm_name}: {results[vm_name]['details']}")
             if failed:
                 self.logger.error(f"failed: {', '.join(failed)}")
                 for vm_name in failed:

--- a/src/boxman/manager_parts/vms.py
+++ b/src/boxman/manager_parts/vms.py
@@ -15,6 +15,7 @@ from boxman.exceptions import (
 )
 from boxman.loggers.logger import suppressed
 from boxman.manager_parts.images import ImagesMixin
+from boxman.providers.libvirt.clone_vm import CLONE_DEGRADATION_NOTICES_KEY
 from boxman.providers.libvirt.commands import VirshCommand
 from boxman.providers.libvirt.virsh_parse import parse_domblklist
 
@@ -31,6 +32,9 @@ def _clone_with_retry(provider, cluster, vm_info, new_vm_name,
     """
     for attempt in range(1, max_retries + 1):
         last_attempt = attempt == max_retries
+        degradation_notices: list[str] = []
+        attempt_info = vm_info.copy()
+        attempt_info[CLONE_DEGRADATION_NOTICES_KEY] = degradation_notices
         # Suppress error-level logs on all retryable attempts so that
         # transient pool-busy failures don't appear as errors; only the
         # final attempt logs errors normally. suppressed() restores the
@@ -48,9 +52,15 @@ def _clone_with_retry(provider, cluster, vm_info, new_vm_name,
                 provider.clone_vm(
                     src_vm_name=src_vm_name,
                     new_vm_name=new_vm_name,
-                    info=vm_info,
+                    info=attempt_info,
                     workdir=cluster['workdir']
                 )
+            # A successful auto-policy clone never reaches a later,
+            # unsuppressed retry. Re-emit only its degradation notice after
+            # leaving the suppression context so duplicate identity is never
+            # silent while transient attempt noise remains hidden.
+            for notice in degradation_notices:
+                log.warning(notice)
             return
         except (CloneSanitizerError, ConfigError):
             # Required sanitizer and invalid-policy failures are permanent.

--- a/src/boxman/manager_parts/vms.py
+++ b/src/boxman/manager_parts/vms.py
@@ -8,7 +8,11 @@ from multiprocessing import Process, Queue
 from typing import Any
 
 from boxman import log
-from boxman.exceptions import ConfigError, ProvisionError
+from boxman.exceptions import (
+    CloneSanitizerError,
+    ConfigError,
+    ProvisionError,
+)
 from boxman.loggers.logger import suppressed
 from boxman.manager_parts.images import ImagesMixin
 from boxman.providers.libvirt.commands import VirshCommand
@@ -48,6 +52,11 @@ def _clone_with_retry(provider, cluster, vm_info, new_vm_name,
                     workdir=cluster['workdir']
                 )
             return
+        except (CloneSanitizerError, ConfigError):
+            # Required sanitizer and invalid-policy failures are permanent.
+            # Retrying would either repeat the same inspection or run into an
+            # unsafe clone whose cleanup already failed.
+            raise
         except Exception:
             if not last_attempt:
                 delay = attempt * 2
@@ -148,9 +157,8 @@ class VMsMixin:
             names = ', '.join(name for name, _ in failed)
             raise RuntimeError(
                 f"clone failed for {len(failed)} VM(s) ({names}); aborting "
-                f"provision. See the virt-clone error logged above for the "
-                f"underlying cause (typically a missing template disk or a "
-                f"libvirt storage pool issue).")
+                f"provision. See the preceding clone or guest-sanitizer log "
+                f"for the underlying cause and remediation.")
 
     ### end vms define / remove / destroy
     def _configure_and_start_vm(
@@ -500,7 +508,9 @@ class VMsMixin:
             names = ', '.join(sorted(failures))
             raise RuntimeError(
                 f"clone failed for {len(failures)} new VM(s) ({names}); "
-                f"aborting update. See the virt-clone error logged above.")
+                f"aborting update. See the preceding clone or "
+                f"guest-sanitizer log for the underlying cause and "
+                f"remediation.")
 
         # configure and start new VMs (parallel)
         configure_tasks = []

--- a/src/boxman/providers/libvirt/clone_vm.py
+++ b/src/boxman/providers/libvirt/clone_vm.py
@@ -7,13 +7,12 @@ from boxman import log
 from boxman.exceptions import (
     CloneCleanupError,
     CloneSanitizerError,
-    CloneSanitizerUnavailable,
+    CloneSanitizerUnavailableError,
     ConfigError,
 )
 
 from .commands import VirshCommand, VirtCloneCommand, VirtSysprepCommand
 from .virsh_parse import parse_domiflist
-
 
 # Internal hand-off used by the retry wrapper. Clone attempts run under log
 # suppression so transient errors stay quiet; successful ``auto`` degradation
@@ -229,7 +228,7 @@ class CloneVM:
                 "nixpkgs#guestfs-tools (NixOS), or libguestfs (Guix), then "
                 "retry."
             )
-            raise CloneSanitizerUnavailable(message)
+            raise CloneSanitizerUnavailableError(message)
         sudo_denied = (
             "sudo:" in detail_lower
             and (
@@ -246,7 +245,7 @@ class CloneVM:
                 "provider.libvirt.use_sudo to false when the active user "
                 "already has libvirt access, then retry."
             )
-            raise CloneSanitizerUnavailable(message)
+            raise CloneSanitizerUnavailableError(message)
 
         raise CloneSanitizerError(
             "virt-sysprep machine-id reset failed for vm "

--- a/src/boxman/providers/libvirt/clone_vm.py
+++ b/src/boxman/providers/libvirt/clone_vm.py
@@ -1,9 +1,17 @@
 import os
 from typing import Any
 
-from boxman import log
+import invoke
 
-from .commands import VirshCommand, VirtCloneCommand
+from boxman import log
+from boxman.exceptions import (
+    CloneCleanupError,
+    CloneSanitizerError,
+    CloneSanitizerUnavailable,
+    ConfigError,
+)
+
+from .commands import VirshCommand, VirtCloneCommand, VirtSysprepCommand
 from .virsh_parse import parse_domiflist
 
 
@@ -11,6 +19,10 @@ class CloneVM:
     """
     Class to clone VMs in libvirt using virt-clone and virsh commands.
     """
+
+    MACHINE_ID_POLICIES = frozenset({'auto', 'required', 'off'})
+    DEFAULT_SYSPREP_TIMEOUT = 300
+    SYSPREP_RUNNER_GRACE = VirtSysprepCommand.TIMEOUT_KILL_GRACE + 5
 
     def __init__(self,
                 src_vm_name: str,
@@ -27,6 +39,8 @@ class CloneVM:
             info: Dictionary containing VM configuration
             provider_config: Configuration for the libvirt provider
         """
+        provider_config = provider_config or {}
+
         #: str: the name of the source vm
         self.src_vm_name = src_vm_name
 
@@ -39,8 +53,31 @@ class CloneVM:
         #: the info of the vm
         self.info = info
 
+        #: str: how an offline machine-ID reset failure is handled
+        self.machine_id_policy = info.get('clone_machine_id', 'auto')
+        if (not isinstance(self.machine_id_policy, str)
+                or self.machine_id_policy not in self.MACHINE_ID_POLICIES):
+            choices = ', '.join(sorted(self.MACHINE_ID_POLICIES))
+            raise ConfigError(
+                f"clone_machine_id for vm '{new_vm_name}' must be one of "
+                f"{choices}, got {self.machine_id_policy!r}")
+
+        #: int: bounded libguestfs inspection time; avoids a wedged appliance
+        #: blocking the parent process forever while it joins clone workers.
+        self.sysprep_timeout = provider_config.get(
+            'virt_sysprep_timeout', self.DEFAULT_SYSPREP_TIMEOUT)
+        if (isinstance(self.sysprep_timeout, bool)
+                or not isinstance(self.sysprep_timeout, int)
+                or self.sysprep_timeout < 1):
+            raise ConfigError(
+                "provider.libvirt.virt_sysprep_timeout must be a positive "
+                f"integer, got {self.sysprep_timeout!r}")
+
         #: VirtCloneCommand: the command executor for virt-clone
         self.virt_clone = VirtCloneCommand(provider_config)
+
+        #: VirtSysprepCommand: offline guest identity sanitizer
+        self.virt_sysprep = VirtSysprepCommand(provider_config)
 
         #: VirshCommand: the command executor for virsh
         self.virsh = VirshCommand(provider_config)
@@ -67,6 +104,13 @@ class CloneVM:
             self.logger.status(f"cloning the vm {self.src_vm_name} to {self.new_vm_name}")
             self.virt_clone.execute(*cmd_args, **cmd_kwargs)
 
+            # virt-clone changes the libvirt UUID and NIC MAC, but copies the
+            # guest filesystem verbatim. Reset standard Linux machine-ID files
+            # while the clone is shut off. ``auto`` preserves compatibility
+            # with opaque/encrypted/unsupported appliances; ``required`` fails
+            # closed; ``off`` deliberately keeps the legacy clone behavior.
+            self.apply_machine_identity_policy()
+
             # after cloning, remove all inherited network interfaces if the machine has network
             # interfaces defined. .. todo:: do this later on when configuring network interfaces
             if 'network_adapters' in self.info:
@@ -78,6 +122,171 @@ class CloneVM:
         except RuntimeError as exc:
             self.logger.error(f"Error cloning the vm: {exc}")
             return False
+
+    def apply_machine_identity_policy(self) -> None:
+        """Apply the configured ``auto|required|off`` clone policy."""
+        if self.machine_id_policy == 'off':
+            self.logger.info(
+                f"skipping machine identity reset for vm {self.new_vm_name} "
+                "(clone_machine_id=off)")
+            return
+
+        try:
+            self.reset_machine_identity()
+        except CloneSanitizerError as sanitizer_error:
+            if self.machine_id_policy == 'auto':
+                self.logger.warning(
+                    f"could not reset inherited machine identity for vm "
+                    f"{self.new_vm_name}; continuing because "
+                    f"clone_machine_id=auto. The guest may retain its "
+                    f"template identity. Set clone_machine_id=required to "
+                    f"fail closed. Cause: {sanitizer_error}")
+                return
+
+            # ``required`` is fail-closed. A cleanup failure is itself
+            # terminal and preserves the sanitizer cause in its message and
+            # exception chain, avoiding misleading clone retries.
+            self.discard_unsafe_clone(sanitizer_error)
+            raise
+
+    def reset_machine_identity(self) -> None:
+        """Clear inherited machine IDs in the shut-off cloned guest.
+
+        Upstream's ``machine-id`` operation truncates regular
+        ``/etc/machine-id`` and ``/var/lib/dbus/machine-id`` files. A normal
+        D-Bus symlink to ``/etc/machine-id`` remains intact. Early boot then
+        generates a new identity before networking starts.
+
+        This offline operation does not require cloud-init or a guest agent,
+        but libguestfs must be able to inspect and write the guest. Opaque,
+        encrypted, and unsupported appliances are handled by the configured
+        clone policy.
+        """
+        try:
+            result = self.virt_sysprep.execute(
+                domain=self.new_vm_name,
+                operations="machine-id",
+                keys_from_stdin=True,
+                warn=True,
+                execution_timeout=self.sysprep_timeout,
+                timeout=self.sysprep_timeout + self.SYSPREP_RUNNER_GRACE,
+            )
+        except invoke.exceptions.CommandTimedOut as exc:
+            raise CloneSanitizerError(
+                f"virt-sysprep timed out after {self.sysprep_timeout}s while "
+                f"resetting vm {self.new_vm_name}") from exc
+        except Exception as exc:
+            raise CloneSanitizerError(
+                f"virt-sysprep could not inspect vm {self.new_vm_name}: "
+                f"{exc}") from exc
+
+        if result.ok:
+            self.logger.info(
+                f"reset inherited machine identity for vm {self.new_vm_name}")
+            return
+
+        if result.return_code == 124:
+            raise CloneSanitizerError(
+                f"virt-sysprep timed out after {self.sysprep_timeout}s while "
+                f"resetting vm {self.new_vm_name}")
+
+        detail = (result.stderr or result.stdout or "unknown error").strip()
+        detail_lower = detail.lower()
+        binary = os.path.basename(str(self.virt_sysprep.command_path)).lower()
+        missing_signature = (
+            "command not found" in detail_lower
+            or f"{binary}: not found" in detail_lower
+            or "no such file or directory" in detail_lower
+        )
+        configured_binary = str(self.virt_sysprep.command_path).lower()
+        sudo_missing = (
+            f"sudo: {configured_binary}: command not found" in detail_lower
+            or f"sudo: {binary}: command not found" in detail_lower
+        )
+        missing = (
+            result.return_code == 127
+            and binary in detail_lower
+            and missing_signature
+        ) or sudo_missing
+        if missing:
+            message = (
+                "virt-sysprep is not installed in the "
+                "active runtime. Install guestfs-tools (Arch/Debian/Ubuntu/"
+                "RHEL), app-emulation/guestfs-tools (Gentoo), "
+                "nixpkgs#guestfs-tools (NixOS), or libguestfs (Guix), then "
+                "retry."
+            )
+            raise CloneSanitizerUnavailable(message)
+        sudo_denied = (
+            "sudo:" in detail_lower
+            and (
+                "password" in detail_lower
+                or "terminal is required" in detail_lower
+                or "askpass" in detail_lower
+            )
+        )
+        if sudo_denied:
+            message = (
+                "virt-sysprep cannot run "
+                "non-interactively with the configured sudo policy. Grant "
+                "passwordless sudo for virt-sysprep, or set "
+                "provider.libvirt.use_sudo to false when the active user "
+                "already has libvirt access, then retry."
+            )
+            raise CloneSanitizerUnavailable(message)
+
+        raise CloneSanitizerError(
+            "virt-sysprep machine-id reset failed for vm "
+            f"{self.new_vm_name}: {detail}")
+
+    def discard_unsafe_clone(
+            self, sanitizer_error: CloneSanitizerError | None = None) -> None:
+        """Remove the newly-created clone after identity sanitization fails.
+
+        If libvirt cannot remove it, raise a terminal error containing both
+        failure causes. A plain-undefine fallback is intentionally avoided:
+        it would leave the known clone disk behind, while deleting individual
+        domain disks risks shared or inherited media.
+        """
+        try:
+            result = self.virsh.execute(
+                "undefine",
+                self.new_vm_name,
+                "--remove-all-storage",
+                warn=True,
+            )
+        except Exception as cleanup_error:
+            sanitizer_detail = (
+                str(sanitizer_error) if sanitizer_error is not None
+                else 'machine identity reset failed')
+            message = (
+                f"{sanitizer_detail}; additionally failed to discard unsafe "
+                f"clone {self.new_vm_name}: {cleanup_error}. The clone "
+                "remains shut off and requires manual cleanup.")
+            raise CloneCleanupError(
+                message,
+                sanitizer_error=sanitizer_error,
+                cleanup_error=cleanup_error,
+            ) from cleanup_error
+
+        if not result.ok:
+            cleanup_detail = (
+                result.stderr or result.stdout or 'unknown error').strip()
+            sanitizer_detail = (
+                str(sanitizer_error) if sanitizer_error is not None
+                else 'machine identity reset failed')
+            message = (
+                f"{sanitizer_detail}; additionally failed to discard unsafe "
+                f"clone {self.new_vm_name}: {cleanup_detail}. The clone "
+                "remains shut off and requires manual cleanup.")
+            error = CloneCleanupError(
+                message,
+                sanitizer_error=sanitizer_error,
+                cleanup_error=cleanup_detail,
+            )
+            if sanitizer_error is not None:
+                raise error from sanitizer_error
+            raise error
 
     def clone(self) -> bool:
         """

--- a/src/boxman/providers/libvirt/clone_vm.py
+++ b/src/boxman/providers/libvirt/clone_vm.py
@@ -15,6 +15,12 @@ from .commands import VirshCommand, VirtCloneCommand, VirtSysprepCommand
 from .virsh_parse import parse_domiflist
 
 
+# Internal hand-off used by the retry wrapper. Clone attempts run under log
+# suppression so transient errors stay quiet; successful ``auto`` degradation
+# notices are collected here and re-emitted after that suppression ends.
+CLONE_DEGRADATION_NOTICES_KEY = '_boxman_clone_degradation_notices'
+
+
 class CloneVM:
     """
     Class to clone VMs in libvirt using virt-clone and virsh commands.
@@ -135,12 +141,19 @@ class CloneVM:
             self.reset_machine_identity()
         except CloneSanitizerError as sanitizer_error:
             if self.machine_id_policy == 'auto':
-                self.logger.warning(
+                message = (
                     f"could not reset inherited machine identity for vm "
                     f"{self.new_vm_name}; continuing because "
                     f"clone_machine_id=auto. The guest may retain its "
                     f"template identity. Set clone_machine_id=required to "
                     f"fail closed. Cause: {sanitizer_error}")
+                notices = self.info.get(CLONE_DEGRADATION_NOTICES_KEY)
+                if isinstance(notices, list):
+                    notices.append(message)
+                else:
+                    # Direct provider callers do not have a retry wrapper to
+                    # re-emit the notice, so retain the normal warning path.
+                    self.logger.warning(message)
                 return
 
             # ``required`` is fail-closed. A cleanup failure is itself
@@ -185,7 +198,7 @@ class CloneVM:
                 f"reset inherited machine identity for vm {self.new_vm_name}")
             return
 
-        if result.return_code == 124:
+        if result.return_code in (124, 137):
             raise CloneSanitizerError(
                 f"virt-sysprep timed out after {self.sysprep_timeout}s while "
                 f"resetting vm {self.new_vm_name}")

--- a/src/boxman/providers/libvirt/commands.py
+++ b/src/boxman/providers/libvirt/commands.py
@@ -120,6 +120,7 @@ class LibVirtCommandBase:
     def execute(self, *args,
                 hide: bool = True,
                 warn: bool = False,
+                timeout: int | None = None,
                 **kwargs) -> invoke.runners.Result:
         """
         Execute a command.
@@ -128,6 +129,8 @@ class LibVirtCommandBase:
             *args: Positional arguments for the command
             hide: Whether to hide command output
             warn: Whether to warn instead of raising exceptions
+            timeout: Optional wall-clock limit passed to the command runner;
+                     this controls execution and is not rendered as a CLI flag
             **kwargs: Keyword arguments to be passed as command options
 
         Returns:
@@ -143,7 +146,10 @@ class LibVirtCommandBase:
             self.logger.info(f"executing: {command}")
 
         try:
-            result = _shell_run(command, hide=hide, warn=warn)
+            run_kwargs: dict[str, Any] = {'hide': hide, 'warn': warn}
+            if timeout is not None:
+                run_kwargs['timeout'] = timeout
+            result = _shell_run(command, **run_kwargs)
 
             if not result.ok and not warn:
                 error_message = (
@@ -441,3 +447,52 @@ class VirtCloneCommand(LibVirtCommandBase):
             kwargs['connect'] = self.uri
 
         return super().build_command(*args, **kwargs)
+
+
+class VirtSysprepCommand(LibVirtCommandBase):
+    """Execute ``virt-sysprep`` against a domain on the configured URI."""
+
+    TIMEOUT_KILL_GRACE = 10
+
+    def __init__(self, provider_config: dict[str, Any] | None = None):
+        super().__init__(provider_config=provider_config)
+        self.command_path = self.provider_config.get(
+            'virt_sysprep_cmd', 'virt-sysprep')
+        self.uri = self.provider_config.get('uri', 'qemu:///system')
+
+    def build_command(self, *args,
+                      execution_timeout: int | None = None,
+                      **kwargs) -> str:
+        """Build an optionally bounded command inside the active runtime.
+
+        The generic runner timeout can only terminate the outer
+        ``docker exec`` client. GNU ``timeout`` is therefore placed inside
+        the runtime so a timed-out sanitizer cannot keep modifying the guest
+        disk after Boxman continues. The outer runner deadline remains a
+        final guard for a wedged runtime wrapper.
+        """
+        if 'connect' not in kwargs:
+            kwargs['connect'] = self.uri
+        command = super().build_command(*args, **kwargs)
+
+        if execution_timeout is None:
+            return command
+        if (isinstance(execution_timeout, bool)
+                or not isinstance(execution_timeout, int)
+                or execution_timeout < 1):
+            raise ConfigError(
+                "virt-sysprep execution_timeout must be a positive integer, "
+                f"got {execution_timeout!r}")
+
+        timeout_prefix = (
+            "timeout --signal=TERM "
+            f"--kill-after={self.TIMEOUT_KILL_GRACE}s "
+            f"{execution_timeout}s")
+        if command.startswith("sudo "):
+            # Keep timeout outside sudo: allowing ``sudo timeout`` in a
+            # command-specific NOPASSWD rule would permit arbitrary root
+            # commands. GNU timeout's default process-group mode includes
+            # descendants, while ``sudo -n`` rejects credential prompts
+            # immediately for non-interactive clone workers.
+            command = f"sudo -n {command[len('sudo '):]}"
+        return f"{timeout_prefix} {command}"

--- a/src/boxman/providers/libvirt/commands.py
+++ b/src/boxman/providers/libvirt/commands.py
@@ -475,6 +475,11 @@ class VirtSysprepCommand(LibVirtCommandBase):
             kwargs['connect'] = self.uri
         command = super().build_command(*args, **kwargs)
 
+        if command.startswith("sudo "):
+            # Sysprep is always non-interactive, even for direct callers that
+            # do not request an execution timeout.
+            command = f"sudo -n {command[len('sudo '):]}"
+
         if execution_timeout is None:
             return command
         if (isinstance(execution_timeout, bool)
@@ -488,11 +493,7 @@ class VirtSysprepCommand(LibVirtCommandBase):
             "timeout --signal=TERM "
             f"--kill-after={self.TIMEOUT_KILL_GRACE}s "
             f"{execution_timeout}s")
-        if command.startswith("sudo "):
-            # Keep timeout outside sudo: allowing ``sudo timeout`` in a
-            # command-specific NOPASSWD rule would permit arbitrary root
-            # commands. GNU timeout's default process-group mode includes
-            # descendants, while ``sudo -n`` rejects credential prompts
-            # immediately for non-interactive clone workers.
-            command = f"sudo -n {command[len('sudo '):]}"
+        # Keep timeout outside sudo: allowing ``sudo timeout`` in a
+        # command-specific NOPASSWD rule would permit arbitrary root commands.
+        # GNU timeout's default process-group mode includes descendants.
         return f"{timeout_prefix} {command}"

--- a/src/boxman/providers/libvirt/net.py
+++ b/src/boxman/providers/libvirt/net.py
@@ -7,10 +7,13 @@ import uuid
 import xml.etree.ElementTree as ET
 from importlib import resources as importlib_resources
 from typing import Any
+from urllib.parse import urlsplit
 
 from jinja2 import Environment, FileSystemLoader
 
 from boxman import log
+from boxman.exceptions import ConfigError
+from boxman.netlab.shared_bridges import BRIDGE_NAME_RE
 
 from . import net_reconcile
 from .commands import VirshCommand
@@ -21,6 +24,8 @@ class Network:
     """
     Class to define libvirt networks by creating XML definitions and using virsh commands.
     """
+    SUPPORTED_FORWARD_MODES = frozenset({'nat', 'route', 'bridge'})
+
     def __init__(self,
                 name: str,
                 info: dict[str, Any],
@@ -50,6 +55,9 @@ class Network:
         #: str: the name of the network
         self.name = name
 
+        #: dict: original network block, retained for presence validation
+        self.info = info
+
         #: str: the uuid of the network, generated if not provided
         self.uuid_val = str(uuid.uuid4())
 
@@ -57,7 +65,9 @@ class Network:
         self.forward_mode = info.get('mode', 'nat')
 
         # extract bridge configuration
-        bridge_info = info.get('bridge', {})
+        self._raw_bridge_info = info.get('bridge')
+        bridge_info = (self._raw_bridge_info
+                       if isinstance(self._raw_bridge_info, dict) else {})
 
         #: the cache object to be used to store network information
         self.manager = manager
@@ -67,7 +77,11 @@ class Network:
         #: tell "the config asked for virbr42" apart from "boxman picked one"
         self.pinned_bridge_name = bridge_info.get('name')
 
-        if assign_new_bridge:
+        if self.forward_mode == 'bridge':
+            # A bridge-mode libvirt network is only a named indirection to an
+            # existing host bridge. Libvirt neither creates nor configures it.
+            bridge_name = self.pinned_bridge_name
+        elif assign_new_bridge:
             # handle the bridge name - if not specified, find the first available virbrX
             bridge_name = self.pinned_bridge_name
             if not bridge_name:
@@ -87,9 +101,11 @@ class Network:
         self.bridge_name = bridge_name
 
         #: str: use stp on/off for the bridge
-        self.bridge_stp = self._normalise_stp(bridge_info.get('stp', 'on'))
+        self.bridge_stp = (None if self.forward_mode == 'bridge' else
+                           self._normalise_stp(bridge_info.get('stp', 'on')))
         #: str: the delay for the stp
-        self.bridge_delay = str(bridge_info.get('delay', '0'))
+        self.bridge_delay = (None if self.forward_mode == 'bridge' else
+                             str(bridge_info.get('delay', '0')))
 
         #: str: set the mac address for the bridge
         #: canonicalised because libvirt zero-pads this one when it stores it
@@ -98,8 +114,9 @@ class Network:
         #: would rebuild the network -- rebooting its guests -- on every run.
         #: Reservation macs are deliberately *not* padded: libvirt stores those
         #: verbatim, so padding them would create the mismatch instead
-        self.mac_address = self._canonical_mac(info.get(
-            'mac', f"52:54:00:{':'.join(['%02x' % (i + 10) for i in range(3)])}"))
+        self.mac_address = None if self.forward_mode == 'bridge' else \
+            self._canonical_mac(info.get(
+                'mac', f"52:54:00:{':'.join(['%02x' % (i + 10) for i in range(3)])}"))
 
         #: bool: whether the ip has been provided or dummy values are injected
         self.ip_provided = 'ip' in info
@@ -129,10 +146,16 @@ class Network:
         # `or {}` throughout: yaml turns an empty or explicitly null block
         # (`ip:`, `dhcp: null`) into None rather than into a missing key, and a
         # bare .get() default does not cover that
-        ip_info = info.get('ip') or {}
+        # Every ``ip`` field is forbidden in bridge mode, so do not descend
+        # into a malformed nested value before validation can report the
+        # useful bridge-mode error.
+        ip_info = ({} if self.forward_mode == 'bridge'
+                   else info.get('ip') or {})
 
-        self.ip_address = ip_info.get('address', '192.168.254.1')
-        self.netmask = ip_info.get('netmask', '255.255.255.0')
+        self.ip_address = (None if self.forward_mode == 'bridge' else
+                           ip_info.get('address', '192.168.254.1'))
+        self.netmask = (None if self.forward_mode == 'bridge' else
+                        ip_info.get('netmask', '255.255.255.0'))
 
         dhcp_conf = ip_info.get('dhcp') or {}
         dhcp_info = dhcp_conf.get('range') or {}
@@ -142,10 +165,89 @@ class Network:
         # a reservation may sit inside or outside the dynamic range: dnsmasq
         # excludes reserved addresses from the pool either way. keeping them
         # outside is still the clearer convention
-        self.dhcp_hosts = self._parse_dhcp_hosts(dhcp_conf.get('hosts') or [])
+        self.dhcp_hosts = ([] if self.forward_mode == 'bridge' else
+                           self._parse_dhcp_hosts(dhcp_conf.get('hosts') or []))
 
         #: bool: whether the network should be enabled
         self.enable = info.get('enable', True)
+
+    def validate_definition(self) -> None:
+        """Validate fields needed to define or reconcile this network.
+
+        Kept out of ``__init__`` deliberately: removal needs only the libvirt
+        network name and its old forward mode. Older Boxman versions could
+        leave an otherwise unsupported ``open``/``isolated`` network defined
+        before reporting failure; ``boxman destroy`` must still be able to
+        construct that network and clean it up.
+        """
+        if self.forward_mode not in self.SUPPORTED_FORWARD_MODES:
+            supported = ', '.join(sorted(self.SUPPORTED_FORWARD_MODES))
+            raise ConfigError(
+                f"network {self.name}: unsupported forward mode "
+                f"{self.forward_mode!r}; supported modes: {supported}")
+
+        if (self._raw_bridge_info is not None
+                and not isinstance(self._raw_bridge_info, dict)):
+            raise ConfigError(
+                f"network {self.name}: bridge must be a mapping")
+
+        if self.forward_mode != 'bridge':
+            return
+
+        bridge_info = self._raw_bridge_info or {}
+        bridge_name = bridge_info.get('name')
+        if not bridge_name:
+            raise ConfigError(
+                f"network {self.name}: mode 'bridge' requires an existing "
+                "Linux bridge name at bridge.name")
+        if (not isinstance(bridge_name, str)
+                or not BRIDGE_NAME_RE.fullmatch(bridge_name)):
+            raise ConfigError(
+                f"network {self.name}: invalid bridge name {bridge_name!r}: "
+                f"must match {BRIDGE_NAME_RE.pattern}")
+
+        forbidden = []
+        if 'ip' in self.info:
+            forbidden.append('ip')
+        if 'mac' in self.info:
+            forbidden.append('mac')
+        forbidden.extend(
+            f"bridge.{key}" for key in ('stp', 'delay')
+            if key in bridge_info)
+        if forbidden:
+            raise ConfigError(
+                f"network {self.name}: mode 'bridge' uses addressing and "
+                "link settings from the existing host bridge; remove: "
+                + ', '.join(forbidden))
+
+    def validate_runtime_prerequisites(self) -> None:
+        """Verify runtime-owned resources needed by this definition exist.
+
+        A raw sysfs probe is authoritative only when the libvirt URI has no
+        network authority (``qemu:///system``, ``test:///default``, or a local
+        unix socket).  For ``qemu+ssh://host/system`` and other remote URIs the
+        command would inspect the Boxman client's namespace, not *host*; skip
+        it and let the remote libvirt daemon validate the bridge at
+        ``net-start`` instead.
+        """
+        if self.forward_mode != 'bridge':
+            return
+
+        if urlsplit(self.virsh.uri).netloc:
+            self.logger.debug(
+                f"network {self.name}: deferring bridge {self.bridge_name!r} "
+                f"validation to remote libvirt endpoint {self.virsh.uri}")
+            return
+
+        bridge_path = shlex.quote(
+            f"/sys/class/net/{self.bridge_name}/bridge")
+        result = self.virsh.execute_shell(
+            f"test -d {bridge_path}", hide=True, warn=True)
+        if not result.ok:
+            raise ConfigError(
+                f"network {self.name}: Linux bridge "
+                f"{self.bridge_name!r} does not exist in the active "
+                "runtime; create it and bring it up before running Boxman")
 
     @staticmethod
     def _canonical_mac(value: str) -> str:
@@ -666,12 +768,14 @@ class Network:
                         msg = f"network {self.name} already exists in project {project_name}"
                         conflicts[project_name]['networks'][net_name]['name'] = msg
                         n_conflicts += 1
-                    if net_info.get('bridge_name') == self.bridge_name:
+                    if (self.forward_mode != 'bridge'
+                            and net_info.get('bridge_name') == self.bridge_name):
                         # bridge name conflict
                         msg = f"bridge {self.bridge_name} is already used by network {net_name} in project {project_name}"
                         conflicts[project_name]['networks'][net_name]['bridge'] = msg
                         n_conflicts += 1
-                    if net_info.get('ip_address') == self.ip_address:
+                    if (self.ip_address is not None
+                            and net_info.get('ip_address') == self.ip_address):
                         # ip address conflict
                         msg = f"ip address {self.ip_address} is already used by network {net_name} in project {project_name}"
                         conflicts[project_name]['networks'][net_name]['ip'] = msg
@@ -700,6 +804,11 @@ class Network:
         Returns:
             True if successful, False otherwise
         """
+        # Reject unsupported modes and invalid bridge-mode fields before an
+        # XML file, cache entry or libvirt network can be created.
+        self.validate_definition()
+        self.validate_runtime_prerequisites()
+
         if not file_path:
             file_path = f"/tmp/{self.name}-network.xml"
 
@@ -718,7 +827,8 @@ class Network:
 
         # Verify the bridge is not already in use before defining
         active_bridges = self._get_libvirt_bridges()
-        if self.bridge_name in active_bridges:
+        if (self.forward_mode != 'bridge'
+                and self.bridge_name in active_bridges):
             self.logger.error(
                 f"bridge '{self.bridge_name}' is already in use by another "
                 f"active network. Cannot define network '{self.name}'.")
@@ -731,18 +841,18 @@ class Network:
                 f"bridge '{self.bridge_name}' is already in use by another "
                 f"active network, cannot define network '{self.name}'")
 
-        # define the network
+        # Define transactionally. In particular, a remote bridge cannot be
+        # checked through the client's /sys, so ``net-start`` is the
+        # authoritative prerequisite check. If it fails, do not leave the
+        # definition/autostart/cache debris the caller was told had failed.
+        defined = False
+        started = False
         try:
             self.virsh.execute("net-define", written_path)
-
-            # the cache is written only once the network really exists. Written
-            # before the define, a failed define (a rejected netmask, a libvirtd
-            # blip) would leave the cache claiming a network that is not there,
-            # and check_network_exists() would then refuse to create it on every
-            # later run -- wedged until projects.json is edited by hand
-            self.update_network_cache()
+            defined = True
 
             self.virsh.execute("net-start", self.name)
+            started = True
             self.virsh.execute("net-autostart", self.name)
 
             # apply appropriate network configuration based on type. NAT
@@ -751,11 +861,30 @@ class Network:
             # network starts (and removes them when it stops)
             if self.forward_mode == 'route':
                 self.apply_route_iptables_rule()
-            elif self.forward_mode != 'nat':
-                raise RuntimeError(f"Unsupported forward mode: {self.forward_mode}")
+            # NAT is configured by libvirt. Bridge mode only points at the
+            # pre-existing host bridge, so it needs no firewall setup here.
+
+            # Cache only a definition that completed its whole bring-up. A
+            # failed start (notably a missing bridge on a remote endpoint) is
+            # rolled back below and must never be advertised as provisioned.
+            self.update_network_cache()
 
             return True
         except RuntimeError as exc:
+            if started:
+                stopped = self.virsh.execute(
+                    "net-destroy", self.name, hide=True, warn=True)
+                if not stopped.ok:
+                    self.logger.warning(
+                        f"network {self.name}: rollback could not stop the "
+                        "partially defined network")
+            if defined:
+                undefined = self.virsh.execute(
+                    "net-undefine", self.name, hide=True, warn=True)
+                if not undefined.ok:
+                    self.logger.warning(
+                        f"network {self.name}: rollback could not undefine the "
+                        "partially defined network")
             self.logger.error(f"Error defining network: {exc}")
             return False
 
@@ -830,14 +959,16 @@ class Network:
         if not self.undefine_network():
             return False
 
-        # remove iptables rules if any. NAT needs no cleanup: the rules are
-        # libvirtd's own and go away with the network
+        # Remove Boxman-owned iptables rules, if any.
         if self.forward_mode == 'route':
             return self.remove_route_iptables_rule()
-        elif self.forward_mode == 'nat':
-            return True
-        else:
-            raise RuntimeError(f"Unsupported forward mode: {self.forward_mode}")
+
+        # NAT and bridge mode need no Boxman-owned host-rule cleanup. The same
+        # is true for an unsupported network orphaned by an older release:
+        # libvirt owned any rules, and destroy/undefine above already removed
+        # it. Do not make legacy cleanup impossible just because new
+        # definitions reject its mode.
+        return True
 
     def find_available_bridge_name(self) -> str:
         """

--- a/src/boxman/providers/libvirt/net.py
+++ b/src/boxman/providers/libvirt/net.py
@@ -1,4 +1,6 @@
+import copy
 import ipaddress
+import logging
 import os
 import re
 import shlex
@@ -81,11 +83,14 @@ class Network:
             # A bridge-mode libvirt network is only a named indirection to an
             # existing host bridge. Libvirt neither creates nor configures it.
             bridge_name = self.pinned_bridge_name
-        elif assign_new_bridge:
-            # handle the bridge name - if not specified, find the first available virbrX
+        elif self.pinned_bridge_name:
+            # A configured name is the effective desired name even while
+            # inspecting an existing definition. The live name is parsed from
+            # net-dumpxml separately during reconciliation.
             bridge_name = self.pinned_bridge_name
-            if not bridge_name:
-                bridge_name = self.find_available_bridge_name()
+        elif assign_new_bridge:
+            # No configured name: allocate the first available virbrX.
+            bridge_name = self.find_available_bridge_name()
         else:
             if bridge_name := Network.get_bridge_from_network(name, provider_config=self.provider_config):
                 self.logger.debug(f"found existing bridge {bridge_name} for network {name}")
@@ -225,10 +230,15 @@ class Network:
 
         A raw sysfs probe is authoritative only when the libvirt URI has no
         network authority (``qemu:///system``, ``test:///default``, or a local
-        unix socket).  For ``qemu+ssh://host/system`` and other remote URIs the
-        command would inspect the Boxman client's namespace, not *host*; skip
-        it and let the remote libvirt daemon validate the bridge at
-        ``net-start`` instead.
+        unix socket). Any authority-bearing URI -- even
+        ``qemu://localhost/system`` -- may resolve through a transport or
+        daemon namespace different from the Boxman process. In that case skip
+        client-side sysfs and let the endpoint's libvirt daemon validate the
+        bridge at ``net-start`` instead.
+
+        For a directly-addressed daemon, validate the administrative ``IFF_UP``
+        flag. ``operstate`` is deliberately not used: a perfectly usable bridge
+        with no attached ports commonly reports ``unknown``.
         """
         if self.forward_mode != 'bridge':
             return
@@ -236,7 +246,7 @@ class Network:
         if urlsplit(self.virsh.uri).netloc:
             self.logger.debug(
                 f"network {self.name}: deferring bridge {self.bridge_name!r} "
-                f"validation to remote libvirt endpoint {self.virsh.uri}")
+                "validation to the authority-bearing libvirt endpoint")
             return
 
         bridge_path = shlex.quote(
@@ -248,6 +258,23 @@ class Network:
                 f"network {self.name}: Linux bridge "
                 f"{self.bridge_name!r} does not exist in the active "
                 "runtime; create it and bring it up before running Boxman")
+
+        flags_path = shlex.quote(f"/sys/class/net/{self.bridge_name}/flags")
+        flags_result = self.virsh.execute_shell(
+            f"cat {flags_path}", hide=True, warn=True)
+        try:
+            flags = int(flags_result.stdout.strip(), 0) if flags_result.ok else None
+        except (AttributeError, ValueError):
+            flags = None
+        if flags is None:
+            raise ConfigError(
+                f"network {self.name}: could not read administrative state "
+                f"for Linux bridge {self.bridge_name!r} in the active runtime")
+        if not flags & 0x1:  # Linux IFF_UP
+            raise ConfigError(
+                f"network {self.name}: Linux bridge {self.bridge_name!r} "
+                "exists but is administratively down in the active runtime; "
+                f"run: sudo ip link set dev {self.bridge_name} up")
 
     @staticmethod
     def _canonical_mac(value: str) -> str:
@@ -704,6 +731,7 @@ class Network:
         Write the network information to the cache.
         """
         self.manager.cache.read_projects_cache()
+        previous_projects = copy.deepcopy(self.manager.cache.projects)
         projects_in_cache = self.manager.cache.projects
         project_name = self.manager.config['project']
         project_cache = projects_in_cache[project_name]
@@ -717,7 +745,13 @@ class Network:
             project_cache['networks'][self.name]['ip_address'] = self.ip_address
         project_cache['networks'][self.name]['bridge_name'] = self.bridge_name
 
-        self.manager.cache.write_projects_cache()
+        try:
+            self.manager.cache.write_projects_cache()
+        except Exception:
+            # Cache writes are atomic on disk. Restore the in-memory view too,
+            # while preserving any previous record for this network.
+            self.manager.cache.projects = previous_projects
+            raise
 
     def check_network_exists(self) -> None:
         """
@@ -840,6 +874,9 @@ class Network:
             raise RuntimeError(
                 f"bridge '{self.bridge_name}' is already in use by another "
                 f"active network, cannot define network '{self.name}'")
+        if (self.forward_mode == 'bridge'
+                and self.bridge_name in active_bridges):
+            self._log_bridge_mode_managed_owner()
 
         # Define transactionally. In particular, a remote bridge cannot be
         # checked through the client's /sys, so ``net-start`` is the
@@ -847,6 +884,7 @@ class Network:
         # definition/autostart/cache debris the caller was told had failed.
         defined = False
         started = False
+        route_rules_attempted = False
         try:
             self.virsh.execute("net-define", written_path)
             defined = True
@@ -860,7 +898,11 @@ class Network:
             # and FORWARD rules for <forward mode='nat'/> itself when the
             # network starts (and removes them when it stops)
             if self.forward_mode == 'route':
-                self.apply_route_iptables_rule()
+                route_rules_attempted = True
+                if not self.apply_route_iptables_rule():
+                    raise RuntimeError(
+                        f"network {self.name}: could not apply route "
+                        "isolation rules")
             # NAT is configured by libvirt. Bridge mode only points at the
             # pre-existing host bridge, so it needs no firewall setup here.
 
@@ -870,21 +912,48 @@ class Network:
             self.update_network_cache()
 
             return True
-        except RuntimeError as exc:
+        except Exception as exc:
+            # Catch operational/programming exceptions, including cache
+            # OSError, but deliberately leave BaseException subclasses such as
+            # KeyboardInterrupt and SystemExit alone.
+            if route_rules_attempted:
+                try:
+                    rules_removed = self.remove_route_iptables_rule()
+                except Exception as rollback_exc:
+                    self.logger.warning(
+                        f"network {self.name}: rollback could not remove "
+                        f"route isolation rules: {rollback_exc}")
+                else:
+                    if not rules_removed:
+                        self.logger.warning(
+                            f"network {self.name}: rollback could not remove "
+                            "route isolation rules")
             if started:
-                stopped = self.virsh.execute(
-                    "net-destroy", self.name, hide=True, warn=True)
-                if not stopped.ok:
+                try:
+                    stopped = self.virsh.execute(
+                        "net-destroy", self.name, hide=True, warn=True)
+                except Exception as rollback_exc:
                     self.logger.warning(
                         f"network {self.name}: rollback could not stop the "
-                        "partially defined network")
+                        f"partially defined network: {rollback_exc}")
+                else:
+                    if not stopped.ok:
+                        self.logger.warning(
+                            f"network {self.name}: rollback could not stop the "
+                            "partially defined network")
             if defined:
-                undefined = self.virsh.execute(
-                    "net-undefine", self.name, hide=True, warn=True)
-                if not undefined.ok:
+                try:
+                    undefined = self.virsh.execute(
+                        "net-undefine", self.name, hide=True, warn=True)
+                except Exception as rollback_exc:
                     self.logger.warning(
                         f"network {self.name}: rollback could not undefine the "
-                        "partially defined network")
+                        f"partially defined network: {rollback_exc}")
+                else:
+                    if not undefined.ok:
+                        self.logger.warning(
+                            f"network {self.name}: rollback could not undefine "
+                            "the partially defined network")
             self.logger.error(f"Error defining network: {exc}")
             return False
 
@@ -1073,6 +1142,45 @@ class Network:
                         f"  bridge '{bridge_name}' is used by network '{net_name}'")
         except Exception as exc:
             self.logger.warning(f"failed to enumerate bridge usage: {exc}")
+
+    def _log_bridge_mode_managed_owner(self) -> None:
+        """Diagnose bridge-mode reuse of a libvirt-managed Linux bridge.
+
+        Sharing is legal and can be intentional, so this is not a conflict.
+        It does couple lifecycles, though: destroying a nat/route owner removes
+        its Linux bridge underneath this bridge-mode network. Keep the probe
+        debug-gated because it needs one ``net-dumpxml`` per network.
+        """
+        if not self.logger.isEnabledFor(logging.DEBUG):
+            return
+
+        network_names = self._listed_networks()
+        if network_names is None:
+            self.logger.debug(
+                f"network {self.name}: could not inspect ownership of bridge "
+                f"{self.bridge_name!r}")
+            return
+
+        owners = []
+        for network_name in network_names:
+            result = self.virsh.execute(
+                "net-dumpxml", network_name, hide=True, warn=True)
+            if not result.ok:
+                continue
+            try:
+                state = net_reconcile.parse_network_xml(result.stdout)
+            except (ET.ParseError, ValueError):
+                continue
+            if (state.get('bridge_name') == self.bridge_name
+                    and state.get('mode') in {'nat', 'route'}):
+                owners.append(f"{network_name} ({state['mode']})")
+
+        if owners:
+            self.logger.debug(
+                f"network {self.name}: bridge mode references "
+                f"{self.bridge_name!r}, which is managed by libvirt network(s) "
+                f"{', '.join(owners)}; destroying an owner removes the Linux "
+                "bridge underneath this network")
 
     @staticmethod
     def _ensure_rule(cls,

--- a/src/boxman/providers/libvirt/net_reconcile.py
+++ b/src/boxman/providers/libvirt/net_reconcile.py
@@ -118,7 +118,7 @@ def desired_state(network) -> dict[str, Any]:
     if network.forward_mode == 'bridge':
         return {
             'mode': 'bridge',
-            'bridge_name': network.pinned_bridge_name,
+            'bridge_name': network.bridge_name,
             'bridge_stp': None,
             'bridge_delay': None,
             'mac': None,
@@ -135,11 +135,10 @@ def desired_state(network) -> dict[str, Any]:
 
     return {
         'mode': network.forward_mode,
-        # the *configured* name, not the one in use: when the configuration
-        # does not pin one boxman assigned it and libvirt is authoritative, so
-        # leaving this None is what keeps an auto-assigned virbrX from reading
-        # as drift
-        'bridge_name': network.pinned_bridge_name,
+        # ``bridge_name`` is the effective desired name: a configured pin, a
+        # newly allocated virbrX, or the current libvirt name when reconciling
+        # an unpinned existing network.
+        'bridge_name': network.bridge_name,
         'bridge_stp': str(network.bridge_stp),
         'bridge_delay': str(network.bridge_delay),
         'mac': network.mac_address.lower() if network.mac_address else None,
@@ -279,7 +278,9 @@ def diff_network(desired: dict[str, Any],
 
 
 def bridge_ownership_conflict(desired: dict[str, Any],
-                              actual: dict[str, Any]) -> str | None:
+                              actual: dict[str, Any],
+                              *,
+                              desired_bridge_is_pinned: bool = True) -> str | None:
     """Explain an unsafe same-name managed/external bridge transition.
 
     In nat/route mode libvirt owns the Linux bridge and deletes it with the
@@ -287,7 +288,10 @@ def bridge_ownership_conflict(desired: dict[str, Any],
     alone. Reusing one bridge name while crossing that ownership boundary
     therefore cannot be reconciled by destroy/redefine: one direction deletes
     the desired prerequisite, the other leaves an interface the new managed
-    network cannot claim.
+    network cannot claim. ``desired_bridge_is_pinned`` distinguishes that
+    second case from an unpinned managed network: during planning its resolved
+    name is still the current bridge, but the recreate path reserves a new
+    automatic name before removing anything.
     """
     old_mode = actual.get('mode')
     new_mode = desired.get('mode')
@@ -303,7 +307,8 @@ def bridge_ownership_conflict(desired: dict[str, Any],
             f"reusing {old_bridge!r}: removing the current libvirt network "
             "would delete that managed bridge; create a distinct host bridge "
             "and set bridge.name to it")
-    if old_mode == 'bridge' and new_mode in managed:
+    if (old_mode == 'bridge' and new_mode in managed
+            and desired_bridge_is_pinned):
         return (
             f"cannot change forward mode 'bridge' -> {new_mode!r} while "
             f"reusing {old_bridge!r}: bridge mode preserves that host-owned "

--- a/src/boxman/providers/libvirt/net_reconcile.py
+++ b/src/boxman/providers/libvirt/net_reconcile.py
@@ -115,6 +115,19 @@ def desired_state(network) -> dict[str, Any]:
     Returns:
         A dict shaped like :func:`parse_network_xml`.
     """
+    if network.forward_mode == 'bridge':
+        return {
+            'mode': 'bridge',
+            'bridge_name': network.pinned_bridge_name,
+            'bridge_stp': None,
+            'bridge_delay': None,
+            'mac': None,
+            'ip_address': None,
+            'netmask': None,
+            'dhcp_range': None,
+            'dhcp_hosts': [],
+        }
+
     dhcp_range = None
     if network.dhcp_range_start and network.dhcp_range_end:
         dhcp_range = {'start': network.dhcp_range_start,
@@ -263,6 +276,40 @@ def diff_network(desired: dict[str, Any],
         'host_ops': host_ops,
         'range_ops': range_ops,
     }
+
+
+def bridge_ownership_conflict(desired: dict[str, Any],
+                              actual: dict[str, Any]) -> str | None:
+    """Explain an unsafe same-name managed/external bridge transition.
+
+    In nat/route mode libvirt owns the Linux bridge and deletes it with the
+    network. In bridge mode the host owns it and libvirt deliberately leaves it
+    alone. Reusing one bridge name while crossing that ownership boundary
+    therefore cannot be reconciled by destroy/redefine: one direction deletes
+    the desired prerequisite, the other leaves an interface the new managed
+    network cannot claim.
+    """
+    old_mode = actual.get('mode')
+    new_mode = desired.get('mode')
+    old_bridge = actual.get('bridge_name')
+    new_bridge = desired.get('bridge_name')
+    managed = {'nat', 'route'}
+
+    if not old_bridge or not new_bridge or old_bridge != new_bridge:
+        return None
+    if old_mode in managed and new_mode == 'bridge':
+        return (
+            f"cannot change forward mode {old_mode!r} -> 'bridge' while "
+            f"reusing {old_bridge!r}: removing the current libvirt network "
+            "would delete that managed bridge; create a distinct host bridge "
+            "and set bridge.name to it")
+    if old_mode == 'bridge' and new_mode in managed:
+        return (
+            f"cannot change forward mode 'bridge' -> {new_mode!r} while "
+            f"reusing {old_bridge!r}: bridge mode preserves that host-owned "
+            "interface, so the new managed network cannot claim its name; "
+            "choose a different bridge.name or omit it for auto-allocation")
+    return None
 
 
 def describe_plan(name: str, plan: dict[str, Any]) -> list[str]:

--- a/src/boxman/providers/libvirt/net_reconcile.py
+++ b/src/boxman/providers/libvirt/net_reconcile.py
@@ -249,8 +249,9 @@ def diff_network(desired: dict[str, Any],
         want = desired.get(field)
         have = actual.get(field)
 
-        # boxman picks the bridge name unless the configuration pinned one, so
-        # only a pinned name can be said to have drifted
+        # A missing desired bridge means effective-name discovery failed. Do
+        # not recreate a network based on an unresolved comparison; callers
+        # surface the discovery failure separately.
         if field == 'bridge_name' and not want:
             continue
 

--- a/src/boxman/providers/libvirt/session.py
+++ b/src/boxman/providers/libvirt/session.py
@@ -1505,7 +1505,8 @@ class LibVirtSession(SessionConfigMixin):
         Args:
             vm_name: Name of the vm
             memballoon: memballoon configuration dict
-                (``free_page_reporting``, ``stats_period``) or None to skip
+                (``free_page_reporting``, ``autodeflate``, ``stats_period``)
+                or None to skip
 
         Returns:
             True if successful (or nothing to do), False otherwise

--- a/src/boxman/providers/libvirt/session.py
+++ b/src/boxman/providers/libvirt/session.py
@@ -348,7 +348,8 @@ class LibVirtSession(SessionConfigMixin):
         plan = net_reconcile.diff_network(desired, actual)
 
         ownership_conflict = net_reconcile.bridge_ownership_conflict(
-            desired, actual)
+            desired, actual,
+            desired_bridge_is_pinned=network.pinned_bridge_name is not None)
         if ownership_conflict:
             raise ConfigError(f"network {name}: {ownership_conflict}")
 

--- a/src/boxman/providers/libvirt/session.py
+++ b/src/boxman/providers/libvirt/session.py
@@ -6,6 +6,7 @@ from typing import Any
 from xml.etree import ElementTree as ET
 
 from boxman import log
+from boxman.exceptions import ConfigError
 
 from ..session_base import SessionConfigMixin
 from . import net_reconcile
@@ -317,6 +318,8 @@ class LibVirtSession(SessionConfigMixin):
             provider_config=self.provider_config,
             assign_new_bridge=False,
             manager=self.manager)
+        network.validate_definition()
+        network.validate_runtime_prerequisites()
 
         empty = {'structural': [], 'host_ops': [], 'range_ops': [],
                  'attached_vms': [], 'actual': {}, 'inactive': False}
@@ -341,8 +344,29 @@ class LibVirtSession(SessionConfigMixin):
             return {'action': 'error', **empty}
 
         actual = net_reconcile.parse_network_xml(actual_xml)
-        plan = net_reconcile.diff_network(
-            net_reconcile.desired_state(network), actual)
+        desired = net_reconcile.desired_state(network)
+        plan = net_reconcile.diff_network(desired, actual)
+
+        ownership_conflict = net_reconcile.bridge_ownership_conflict(
+            desired, actual)
+        if ownership_conflict:
+            raise ConfigError(f"network {name}: {ownership_conflict}")
+
+        # When moving from an external bridge to an auto-named managed
+        # nat/route network, reserve the replacement name while the old network
+        # is still visible. Otherwise removal may make an external ``virbr0``
+        # look available and the new managed network will try to claim it.
+        if (plan['action'] == 'recreate'
+                and actual.get('mode') == 'bridge'
+                and desired.get('mode') in {'nat', 'route'}
+                and network.pinned_bridge_name is None):
+            replacement = Network(
+                name=name,
+                info=info,
+                provider_config=self.provider_config,
+                assign_new_bridge=True,
+                manager=self.manager)
+            plan['replacement_bridge_name'] = replacement.bridge_name
 
         # the caller needs the state as it is on disk, not only the diff: a
         # recreate has to tear down the iptables rules belonging to the network

--- a/src/boxman/providers/libvirt/virsh_edit.py
+++ b/src/boxman/providers/libvirt/virsh_edit.py
@@ -249,10 +249,10 @@ class VirshEdit:
         """
         Validate a memballoon config dict, raising ConfigError on bad values.
 
-        ``free_page_reporting`` must be a real bool (a YAML string like
-        ``"false"`` would silently enable it otherwise) and ``stats_period``
-        must be a positive integer (bools excluded) or None to remove the
-        stats element.
+        ``free_page_reporting`` and ``autodeflate`` must be real bools (a
+        YAML string like ``"false"`` would silently enable either setting
+        otherwise). ``stats_period`` must be a positive integer (bools
+        excluded) or None to remove the stats element.
         """
         if not isinstance(config, dict):
             raise ConfigError(
@@ -262,6 +262,11 @@ class VirshEdit:
             raise ConfigError(
                 f"memballoon.free_page_reporting must be a boolean, got "
                 f"{config['free_page_reporting']!r}")
+        if 'autodeflate' in config and not isinstance(
+                config['autodeflate'], bool):
+            raise ConfigError(
+                f"memballoon.autodeflate must be a boolean, got "
+                f"{config['autodeflate']!r}")
         stats_period = config.get('stats_period')
         if stats_period is not None and (
                 isinstance(stats_period, bool)
@@ -282,6 +287,7 @@ class VirshEdit:
 
         - ``free_page_reporting`` (bool): sets the ``freePageReporting='on|off'``
           attribute
+        - ``autodeflate`` (bool): sets the ``autodeflate='on|off'`` attribute
         - ``stats_period`` (int): sets ``<stats period='N'/>``; an explicit
           None removes the ``<stats>`` element
 
@@ -316,6 +322,10 @@ class VirshEdit:
             memballoon.set('freePageReporting',
                            'on' if config['free_page_reporting'] else 'off')
 
+        if 'autodeflate' in config:
+            memballoon.set('autodeflate',
+                           'on' if config['autodeflate'] else 'off')
+
         if 'stats_period' in config:
             stats = memballoon.find('stats')
             if config['stats_period'] is None:
@@ -334,8 +344,8 @@ class VirshEdit:
         """
         Configure the virtio-balloon device for a domain.
 
-        Edits the persistent (inactive) config; ``free_page_reporting``
-        takes effect from the next boot of the VM.
+        Edits the persistent (inactive) config; ``free_page_reporting`` and
+        ``autodeflate`` take effect from the next boot of the VM.
 
         Args:
             domain_name: name of the domain
@@ -518,4 +528,3 @@ class VirshEdit:
         except Exception as exc:
             self.logger.error(f"failed to hot-set memory for {domain_name}: {exc}")
             return False
-

--- a/src/boxman/providers/libvirt/vm_differ.py
+++ b/src/boxman/providers/libvirt/vm_differ.py
@@ -114,22 +114,34 @@ class VMStateDiffer:
             return 0
         return int(memory_values[0]) // 1024
 
-    def get_actual_memballoon(self, domain_name: str) -> dict[str, Any]:
+    def get_actual_memballoon(
+            self, domain_name: str, inactive: bool = True) -> dict[str, Any]:
         """
-        Get the actual memballoon state from the persistent (inactive) XML.
+        Get the actual memballoon state from persistent or live XML.
+
+        Args:
+            domain_name: libvirt domain name.
+            inactive: read persistent XML when True; read the running guest's
+                live XML when False.
 
         Returns:
-            Dict with 'free_page_reporting' (bool; a missing attribute or a
-            missing memballoon element counts as False) and 'stats_period'
-            (int seconds, or None when no <stats> element is present).
+            Dict with 'free_page_reporting' and 'autodeflate' (bools; a
+            missing attribute or memballoon element counts as False), plus
+            'stats_period' (int seconds, or None when no <stats> element is
+            present).
         """
         from lxml import etree
 
-        xml_content = self.virsh_edit.get_domain_xml(domain_name, inactive=True)
+        xml_content = self.virsh_edit.get_domain_xml(
+            domain_name, inactive=inactive)
         tree = etree.fromstring(xml_content.encode('utf-8'))
         matches = tree.xpath('//devices/memballoon')
         if not matches:
-            return {'free_page_reporting': False, 'stats_period': None}
+            return {
+                'free_page_reporting': False,
+                'autodeflate': False,
+                'stats_period': None,
+            }
         memballoon = matches[0]
         stats = memballoon.find('stats')
         stats_period = None
@@ -137,6 +149,7 @@ class VMStateDiffer:
             stats_period = int(stats.get('period'))
         return {
             'free_page_reporting': memballoon.get('freePageReporting') == 'on',
+            'autodeflate': memballoon.get('autodeflate') == 'on',
             'stats_period': stats_period,
         }
 
@@ -147,11 +160,16 @@ class VMStateDiffer:
         Normalize a memballoon config block into a fully-explicit desired
         state. A missing block (None) maps to the libvirt defaults, so
         removing the block from conf.yml reconciles back to
-        ``freePageReporting`` off and no ``<stats>`` element.
+        ``freePageReporting`` and ``autodeflate`` off and no ``<stats>``
+        element. Validate before normalizing so YAML strings and other
+        malformed values cannot be truthiness-coerced during ``update``.
         """
-        config = config or {}
+        if config is None:
+            config = {}
+        VirshEdit.validate_memballoon_config(config)
         return {
-            'free_page_reporting': bool(config.get('free_page_reporting', False)),
+            'free_page_reporting': config.get('free_page_reporting', False),
+            'autodeflate': config.get('autodeflate', False),
             'stats_period': config.get('stats_period'),
         }
 
@@ -284,8 +302,9 @@ class VMStateDiffer:
               - resize_disks: list of dicts with target, source, current_size_mb, desired_size_mb
               - new_cdroms, removed_cdroms, changed_cdroms
               - new_shared_folders, removed_shared_folders, changed_shared_folders
-              - memballoon_changed, desired_memballoon (normalized),
-                actual_memballoon
+              - memballoon_changed, memballoon_restart_pending,
+                desired_memballoon (normalized), actual_memballoon, and
+                live_memballoon
               - vm_state: current VM state string
         """
         vm_state = self.get_vm_state(domain_name)
@@ -330,6 +349,13 @@ class VMStateDiffer:
         actual_memballoon = self.get_actual_memballoon(domain_name)
         normalized_memballoon = self.normalize_memballoon_config(desired_memballoon)
         memballoon_changed = normalized_memballoon != actual_memballoon
+        live_memballoon = actual_memballoon
+        if vm_state == 'running':
+            live_memballoon = self.get_actual_memballoon(
+                domain_name, inactive=False)
+        memballoon_restart_pending = (
+            vm_state == 'running'
+            and normalized_memballoon != live_memballoon)
 
         # --- Disk diff ---
         actual_disks = self.get_actual_disks(domain_name)
@@ -462,7 +488,9 @@ class VMStateDiffer:
             'removed_shared_folders': removed_shared_folders,
             'changed_shared_folders': changed_shared_folders,
             'memballoon_changed': memballoon_changed,
+            'memballoon_restart_pending': memballoon_restart_pending,
             'desired_memballoon': normalized_memballoon,
             'actual_memballoon': actual_memballoon,
+            'live_memballoon': live_memballoon,
             'vm_state': vm_state
         }

--- a/src/boxman/providers/libvirt/vm_differ.py
+++ b/src/boxman/providers/libvirt/vm_differ.py
@@ -14,11 +14,11 @@ class VMStateDiffer:
     and produces a structured diff describing what needs to change.
     """
 
-    # States with an active domain and therefore distinct live XML.  A paused,
-    # blocked, shutting-down, or power-managed guest still needs a later boot
-    # before persistent-only device edits become live.
+    # States with an active domain and therefore distinct live XML. A paused,
+    # blocked, shutting-down, power-managed, or crash-preserved guest still
+    # needs a later boot before persistent-only device edits become live.
     _LIVE_DOMAIN_STATES = frozenset({
-        'running', 'blocked', 'paused', 'in shutdown', 'pmsuspended',
+        'running', 'blocked', 'paused', 'in shutdown', 'pmsuspended', 'crashed',
     })
 
     def __init__(self, provider_config: dict[str, Any] | None = None):

--- a/src/boxman/providers/libvirt/vm_differ.py
+++ b/src/boxman/providers/libvirt/vm_differ.py
@@ -14,6 +14,13 @@ class VMStateDiffer:
     and produces a structured diff describing what needs to change.
     """
 
+    # States with an active domain and therefore distinct live XML.  A paused,
+    # blocked, shutting-down, or power-managed guest still needs a later boot
+    # before persistent-only device edits become live.
+    _LIVE_DOMAIN_STATES = frozenset({
+        'running', 'blocked', 'paused', 'in shutdown', 'pmsuspended',
+    })
+
     def __init__(self, provider_config: dict[str, Any] | None = None):
         self.virsh = VirshCommand(provider_config)
         self.virsh_edit = VirshEdit(provider_config)
@@ -350,11 +357,11 @@ class VMStateDiffer:
         normalized_memballoon = self.normalize_memballoon_config(desired_memballoon)
         memballoon_changed = normalized_memballoon != actual_memballoon
         live_memballoon = actual_memballoon
-        if vm_state == 'running':
+        if vm_state in self._LIVE_DOMAIN_STATES:
             live_memballoon = self.get_actual_memballoon(
                 domain_name, inactive=False)
         memballoon_restart_pending = (
-            vm_state == 'running'
+            vm_state in self._LIVE_DOMAIN_STATES
             and normalized_memballoon != live_memballoon)
 
         # --- Disk diff ---

--- a/src/boxman/providers/virtualbox/commands.py
+++ b/src/boxman/providers/virtualbox/commands.py
@@ -78,9 +78,13 @@ class VBoxManageCommand:
 
         The binary, subcommand, positional ``args``, and keyword values are
         quoted exactly once with :func:`shlex.quote`. Keyword ``kwargs`` become
-        ``--flag value`` pairs (``True`` -> bare ``--flag``; ``False``/``None``
-        -> skipped). Underscores in keys are converted to dashes. Callers must
-        pass raw values rather than values with pre-baked shell quotes.
+        separate ``--flag value`` tokens, matching VBoxManage's native syntax
+        rather than libvirt's provider-specific ``--flag=value`` form
+        (``True`` -> bare ``--flag``; ``False``/``None`` -> skipped).
+        Underscores in keys are converted to dashes. Keyword names are
+        code-controlled option identifiers; all caller-provided data belongs in
+        values and is quoted. Callers must pass raw values rather than values
+        with pre-baked shell quotes.
 
         Args:
             subcommand: The VBoxManage subcommand (e.g. ``list``, ``clonevm``).

--- a/src/boxman/providers/virtualbox/commands.py
+++ b/src/boxman/providers/virtualbox/commands.py
@@ -76,9 +76,11 @@ class VBoxManageCommand:
         """
         Build a complete ``VBoxManage`` command string.
 
-        Positional ``args`` are appended verbatim; keyword ``kwargs`` become
+        The binary, subcommand, positional ``args``, and keyword values are
+        quoted exactly once with :func:`shlex.quote`. Keyword ``kwargs`` become
         ``--flag value`` pairs (``True`` -> bare ``--flag``; ``False``/``None``
-        -> skipped). Underscores in keys are converted to dashes.
+        -> skipped). Underscores in keys are converted to dashes. Callers must
+        pass raw values rather than values with pre-baked shell quotes.
 
         Args:
             subcommand: The VBoxManage subcommand (e.g. ``list``, ``clonevm``).
@@ -93,9 +95,9 @@ class VBoxManageCommand:
         if self.use_sudo:
             parts.append('sudo')
 
-        parts.append(self.command_path)
-        parts.append(str(subcommand))
-        parts.extend(str(arg) for arg in args)
+        parts.append(shlex.quote(str(self.command_path)))
+        parts.append(shlex.quote(str(subcommand)))
+        parts.extend(shlex.quote(str(arg)) for arg in args)
 
         for key, value in kwargs.items():
             flag = f"--{key.replace('_', '-')}"
@@ -105,7 +107,7 @@ class VBoxManageCommand:
                 continue
             else:
                 parts.append(flag)
-                parts.append(str(value))
+                parts.append(shlex.quote(str(value)))
 
         return ' '.join(parts)
 

--- a/src/boxman/providers/virtualbox/modifyvm.py
+++ b/src/boxman/providers/virtualbox/modifyvm.py
@@ -53,5 +53,5 @@ class ModifyVm:
                             rule_name: str = 'guestssh',
                             nic_num: int = 1) -> str:
         """Build ``VBoxManage modifyvm <vm> --natpf<n> "name,tcp,,host,,guest"``."""
-        rule = f'"{rule_name},tcp,,{host_port},,{guest_port}"'
+        rule = f'{rule_name},tcp,,{host_port},,{guest_port}'
         return self.cmd.build_command('modifyvm', vm, f'--natpf{nic_num}', rule)

--- a/src/boxman/providers/virtualbox/modifyvm.py
+++ b/src/boxman/providers/virtualbox/modifyvm.py
@@ -52,6 +52,12 @@ class ModifyVm:
                             guest_port: int,
                             rule_name: str = 'guestssh',
                             nic_num: int = 1) -> str:
-        """Build ``VBoxManage modifyvm <vm> --natpf<n> "name,tcp,,host,,guest"``."""
+        """Build a ``VBoxManage modifyvm <vm> --natpf<n> <rule>`` command.
+
+        ``<rule>`` is passed to the central command builder as an unquoted raw
+        value. The rendered shell string contains quotes only when the rule's
+        contents require them; :meth:`VBoxManageCommand.run` splits it back
+        into one exact argv token before execution.
+        """
         rule = f'{rule_name},tcp,,{host_port},,{guest_port}'
         return self.cmd.build_command('modifyvm', vm, f'--natpf{nic_num}', rule)

--- a/src/boxman/scripts/app.py
+++ b/src/boxman/scripts/app.py
@@ -62,8 +62,9 @@ def _default_boxman_config() -> dict:
     """
     Return the default boxman application configuration.
 
-    Uses system paths for virt-install, virt-clone, and virsh (resolved
-    via ``shutil.which``), with verbose and use_sudo both set to False.
+    Uses system paths for virt-install, virt-clone, virt-sysprep, and virsh
+    (resolved via ``shutil.which``), with verbose and use_sudo both set to
+    False.
     """
     return {
         "runtime": "local",
@@ -84,6 +85,8 @@ def _default_boxman_config() -> dict:
                 "verbose": False,
                 "virt_install_cmd": shutil.which("virt-install") or "virt-install",
                 "virt_clone_cmd": shutil.which("virt-clone") or "virt-clone",
+                "virt_sysprep_cmd": shutil.which("virt-sysprep") or "virt-sysprep",
+                "virt_sysprep_timeout": 300,
                 "virsh_cmd": shutil.which("virsh") or "virsh",
             },
         },

--- a/tests/test_boxman_conf.py
+++ b/tests/test_boxman_conf.py
@@ -104,6 +104,9 @@ class TestBoxmanConfOverride:
         # paths should be the system paths (or bare command names)
         virsh_cmd = loaded["providers"]["libvirt"]["virsh_cmd"]
         assert virsh_cmd == (_shutil.which("virsh") or "virsh")
+        sysprep_cmd = loaded["providers"]["libvirt"]["virt_sysprep_cmd"]
+        assert sysprep_cmd == (_shutil.which("virt-sysprep") or "virt-sysprep")
+        assert loaded["providers"]["libvirt"]["virt_sysprep_timeout"] == 300
 
     def test_global_authorized_keys_resolves_literal(self):
         """Literal SSH keys are returned as-is."""

--- a/tests/test_check_prerequisites.py
+++ b/tests/test_check_prerequisites.py
@@ -82,6 +82,35 @@ def test_classify_family_uses_id_like_when_id_unknown():
 
 
 # --------------------------------------------------------------------------- #
+# minimal app-config scalar parsing                                           #
+# --------------------------------------------------------------------------- #
+def test_configured_libvirt_use_sudo_reads_only_provider_block():
+    text = """
+runtime: local
+clusters:
+  lab:
+    use_sudo: true
+providers:
+  virtualbox:
+    use_sudo: true
+  libvirt:
+    uri: qemu:///system
+    use_sudo: false  # direct group access
+"""
+    assert checker.configured_libvirt_use_sudo(text, default=True) is False
+
+
+def test_configured_libvirt_use_sudo_supports_yaml_boolean_spellings():
+    text = "providers:\n  libvirt:\n    use_sudo: YES\n"
+    assert checker.configured_libvirt_use_sudo(text) is True
+
+
+def test_configured_libvirt_use_sudo_falls_back_for_invalid_value():
+    text = "providers:\n  libvirt:\n    use_sudo: {{ env('SUDO') }}\n"
+    assert checker.configured_libvirt_use_sudo(text, default=False) is False
+
+
+# --------------------------------------------------------------------------- #
 # install_cmd                                                                 #
 # --------------------------------------------------------------------------- #
 def test_install_cmd_per_family():
@@ -139,6 +168,7 @@ def test_doctor_sudo_rights_requires_virt_sysprep(monkeypatch):
     doctor.manual_steps = []
     doctor.use_color = False
     doctor.interactive = False
+    doctor.use_sudo = True
 
     policy = (
         "(root) NOPASSWD: /usr/bin/virsh, /usr/bin/qemu-img, "
@@ -153,6 +183,24 @@ def test_doctor_sudo_rights_requires_virt_sysprep(monkeypatch):
     assert result.status == checker.WARN
     assert "virt-sysprep" in result.detail
     assert "virt-sysprep" in result.fix.description
+
+
+def test_doctor_omits_sysprep_nopasswd_gap_when_use_sudo_is_false(monkeypatch):
+    doctor = _minimal_doctor_for_check()
+    doctor.use_sudo = False
+    policy = (
+        "(root) NOPASSWD: /usr/bin/virsh, /usr/bin/qemu-img, "
+        "/usr/sbin/iptables, /usr/bin/rm\n"
+    )
+    monkeypatch.setattr(checker, "have", lambda command: command == "sudo")
+    monkeypatch.setattr(checker, "run_capture", lambda args: (0, policy))
+
+    doctor._check_sudo_rights()
+
+    result = doctor.results[-1]
+    assert result.status == checker.OK
+    assert "virt-sysprep" not in result.detail
+    assert result.fix is None
 
 
 def _minimal_doctor_for_check():
@@ -840,6 +888,11 @@ def test_core_stack_fix_gentoo_uses_emerge():
 ])
 def test_core_stack_installs_virt_sysprep_package(family, package):
     assert package in checker._CORE_STACK[family]
+
+
+def test_debian_guestfs_tool_remediation_uses_executable_owner_package():
+    assert checker._TOOL_PKG["virt-sysprep"]["debian"] == "guestfs-tools"
+    assert checker._TOOL_PKG["virt-sparsify"]["debian"] == "guestfs-tools"
 
 
 def test_declarative_core_advice_includes_virt_sysprep_package():

--- a/tests/test_check_prerequisites.py
+++ b/tests/test_check_prerequisites.py
@@ -7,6 +7,7 @@ side-effect-free helpers are exercised here -- no libvirt/subprocess/host calls.
 
 import importlib.util
 import os
+from types import SimpleNamespace
 
 import pytest
 
@@ -129,6 +130,64 @@ def test_sudo_nopasswd_covers_specific_binary():
 def test_sudo_nopasswd_covers_ignores_password_required_lines():
     out = "    (ALL : ALL) ALL\n"  # sudo allowed but with a password
     assert checker.sudo_nopasswd_covers(out, "qemu-img") is False
+
+
+def test_doctor_sudo_rights_requires_virt_sysprep(monkeypatch):
+    doctor = checker.Doctor.__new__(checker.Doctor)
+    doctor.opts = SimpleNamespace(check_only=True)
+    doctor.results = []
+    doctor.manual_steps = []
+    doctor.use_color = False
+    doctor.interactive = False
+
+    policy = (
+        "(root) NOPASSWD: /usr/bin/virsh, /usr/bin/qemu-img, "
+        "/usr/sbin/iptables, /bin/rm\n"
+    )
+    monkeypatch.setattr(checker, "have", lambda command: command == "sudo")
+    monkeypatch.setattr(checker, "run_capture", lambda args: (0, policy))
+
+    doctor._check_sudo_rights()
+
+    result = doctor.results[-1]
+    assert result.status == checker.WARN
+    assert "virt-sysprep" in result.detail
+    assert "virt-sysprep" in result.fix.description
+
+
+def _minimal_doctor_for_check():
+    doctor = checker.Doctor.__new__(checker.Doctor)
+    doctor.opts = SimpleNamespace(check_only=True)
+    doctor.results = []
+    doctor.manual_steps = []
+    doctor.use_color = False
+    doctor.interactive = False
+    doctor.family = "debian"
+    doctor.os = {"id": "ubuntu"}
+    return doctor
+
+
+def test_missing_clone_sanitizer_is_optional_warning(monkeypatch):
+    doctor = _minimal_doctor_for_check()
+    monkeypatch.setattr(checker, "have", lambda command: False)
+
+    result = doctor._check_clone_sanitizer()
+
+    assert result.status == checker.WARN
+    assert "clone_machine_id=auto" in result.detail
+    assert "clone_machine_id=required" in result.detail
+    assert "guestfs-tools" in result.fix.commands[0]
+
+
+def test_present_clone_sanitizer_is_ok(monkeypatch):
+    doctor = _minimal_doctor_for_check()
+    monkeypatch.setattr(
+        checker, "have", lambda command: command == "virt-sysprep")
+
+    result = doctor._check_clone_sanitizer()
+
+    assert result.status == checker.OK
+    assert result.fix is None
 
 
 # --------------------------------------------------------------------------- #
@@ -770,6 +829,22 @@ def test_core_stack_fix_gentoo_uses_emerge():
     fix = _doctor_with_family("gentoo")._core_stack_fix()
     assert "emerge" in fix.commands[0]
     assert "app-emulation/libvirt" in fix.commands[0]
+    assert "app-emulation/guestfs-tools" in fix.commands[0]
+
+
+@pytest.mark.parametrize("family,package", [
+    ("arch", "guestfs-tools"),
+    ("debian", "guestfs-tools"),
+    ("rhel", "guestfs-tools"),
+    ("gentoo", "app-emulation/guestfs-tools"),
+])
+def test_core_stack_installs_virt_sysprep_package(family, package):
+    assert package in checker._CORE_STACK[family]
+
+
+def test_declarative_core_advice_includes_virt_sysprep_package():
+    assert "guestfs-tools" in checker._NIXOS_CORE_ADVICE
+    assert "libguestfs" in checker._GUIX_CORE_ADVICE
 
 
 def test_core_stack_fix_unknown_family_falls_back_to_manual_advice():

--- a/tests/test_check_prerequisites.py
+++ b/tests/test_check_prerequisites.py
@@ -110,6 +110,20 @@ def test_configured_libvirt_use_sudo_falls_back_for_invalid_value():
     assert checker.configured_libvirt_use_sudo(text, default=False) is False
 
 
+def test_configured_libvirt_use_sudo_does_not_truncate_quoted_hash():
+    text = 'providers:\n  libvirt:\n    use_sudo: "false#not-a-comment"\n'
+    assert checker.configured_libvirt_use_sudo(text, default=True) is True
+
+
+def test_strip_yaml_comment_preserves_hashes_inside_scalars():
+    assert checker.strip_yaml_comment('key: "a # value" # comment') == (
+        'key: "a # value" ')
+    assert checker.strip_yaml_comment("key: 'a # value' # comment") == (
+        "key: 'a # value' ")
+    assert checker.strip_yaml_comment("key: a#value # comment") == (
+        "key: a#value ")
+
+
 # --------------------------------------------------------------------------- #
 # install_cmd                                                                 #
 # --------------------------------------------------------------------------- #
@@ -201,6 +215,23 @@ def test_doctor_omits_sysprep_nopasswd_gap_when_use_sudo_is_false(monkeypatch):
     assert result.status == checker.OK
     assert "virt-sysprep" not in result.detail
     assert result.fix is None
+
+
+def test_doctor_omits_sysprep_from_fix_when_use_sudo_is_false(monkeypatch):
+    doctor = _minimal_doctor_for_check()
+    doctor.use_sudo = False
+    policy = "(root) NOPASSWD: /usr/sbin/iptables\n"
+    monkeypatch.setattr(checker, "have", lambda command: command == "sudo")
+    monkeypatch.setattr(checker, "run_capture", lambda args: (0, policy))
+
+    doctor._check_sudo_rights()
+
+    result = doctor.results[-1]
+    assert result.status == checker.WARN
+    assert "qemu-img/rm" in result.detail
+    assert "virt-sysprep" not in result.detail
+    assert "virt-sysprep" not in result.fix.description
+    assert "qemu-img" in result.fix.description
 
 
 def _minimal_doctor_for_check():

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 
-
 DOCKERFILE = (
     Path(__file__).resolve().parent.parent
     / "containers" / "docker" / "Dockerfile"

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -1,0 +1,31 @@
+"""Static security guards for the packaged Docker runtime image."""
+
+from pathlib import Path
+
+
+DOCKERFILE = Path(__file__).resolve().parent.parent / "containers" / "docker" / "Dockerfile"
+
+
+def test_shadow_layout_supports_apparmor_confined_unix_chkpwd():
+    """The image must not need host DAC capabilities for PAM account checks.
+
+    Ubuntu 24.04's AppArmor profile permits ``/etc/shadow r`` but strips
+    ``dac_override`` and ``dac_read_search`` from ``unix_chkpwd``. A root
+    owner read bit lets the setuid-root helper pass ordinary DAC without
+    granting the SSH login user direct DAC access or using a readable group.
+    The development image separately grants that user passwordless sudo.
+    """
+    dockerfile = DOCKERFILE.read_text()
+    expected = (
+        "chown root:root /etc/shadow",
+        "chmod 0400 /etc/shadow",
+        "test \"$(stat -c '%U:%G:%a' /etc/shadow)\" = \"root:root:400\"",
+        "! id -Gn qemu_user | grep -qw shadow",
+    )
+
+    for command in expected:
+        assert command in dockerfile
+
+    assert dockerfile.index("useradd -m -s /bin/bash qemu_user") < dockerfile.index(
+        "chown root:root /etc/shadow"
+    )

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -1,9 +1,25 @@
 """Static security guards for the packaged Docker runtime image."""
 
+import shlex
 from pathlib import Path
 
+import pytest
 
-DOCKERFILE = Path(__file__).resolve().parent.parent / "containers" / "docker" / "Dockerfile"
+
+DOCKERFILE = (
+    Path(__file__).resolve().parent.parent
+    / "containers" / "docker" / "Dockerfile"
+)
+pytestmark = pytest.mark.regression
+
+
+def _logical_instructions(dockerfile: str) -> list[str]:
+    """Return Dockerfile instructions with line continuations normalized."""
+    return [
+        " ".join(instruction.split())
+        for instruction in dockerfile.replace("\\\n", " ").splitlines()
+        if instruction.strip() and not instruction.lstrip().startswith("#")
+    ]
 
 
 def test_shadow_layout_supports_apparmor_confined_unix_chkpwd():
@@ -15,17 +31,25 @@ def test_shadow_layout_supports_apparmor_confined_unix_chkpwd():
     granting the SSH login user direct DAC access or using a readable group.
     The development image separately grants that user passwordless sudo.
     """
-    dockerfile = DOCKERFILE.read_text()
-    expected = (
-        "chown root:root /etc/shadow",
-        "chmod 0400 /etc/shadow",
-        "test \"$(stat -c '%U:%G:%a' /etc/shadow)\" = \"root:root:400\"",
-        "! id -Gn qemu_user | grep -qw shadow",
-    )
+    instructions = _logical_instructions(DOCKERFILE.read_text())
+    useradd_index, useradd = next(
+        (index, instruction)
+        for index, instruction in enumerate(instructions)
+        if "useradd" in instruction and "qemu_user" in instruction)
+    shadow_index, shadow = next(
+        (index, instruction)
+        for index, instruction in enumerate(instructions)
+        if "/etc/shadow" in instruction)
 
-    for command in expected:
-        assert command in dockerfile
-
-    assert dockerfile.index("useradd -m -s /bin/bash qemu_user") < dockerfile.index(
-        "chown root:root /etc/shadow"
-    )
+    assert useradd_index < shadow_index
+    assert shlex.split(useradd.removeprefix("RUN ").split(" && ")[0]) == [
+        "useradd", "-m", "-s", "/bin/bash", "qemu_user"]
+    assert [
+        shlex.split(command)
+        for command in shadow.removeprefix("RUN ").split(" && ")
+    ] == [
+        ["chown", "root:root", "/etc/shadow"],
+        ["chmod", "0400", "/etc/shadow"],
+        ["test", "$(stat -c '%U:%G:%a' /etc/shadow)", "=", "root:root:400"],
+        ["!", "id", "-Gn", "qemu_user", "|", "grep", "-qw", "shadow"],
+    ]

--- a/tests/test_libvirt_bridge_network_integration.py
+++ b/tests/test_libvirt_bridge_network_integration.py
@@ -19,7 +19,6 @@ import yaml
 from boxman.manager import BoxmanManager
 from boxman.providers.libvirt.session import LibVirtSession
 
-
 pytestmark = pytest.mark.integration
 
 URI = os.environ.get("BOXMAN_IT_URI", "qemu:///system")

--- a/tests/test_libvirt_bridge_network_integration.py
+++ b/tests/test_libvirt_bridge_network_integration.py
@@ -1,0 +1,130 @@
+"""Real-libvirt coverage for per-cluster ``mode: bridge`` networks.
+
+The test creates one temporary Linux bridge and one libvirt network inside a
+disposable host. It is opt-in because both are host networking resources::
+
+    BOXMAN_INTEGRATION_LIBVIRT=1 pytest \
+        tests/test_libvirt_bridge_network_integration.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import xml.etree.ElementTree as ET
+
+import pytest
+import yaml
+
+from boxman.manager import BoxmanManager
+from boxman.providers.libvirt.session import LibVirtSession
+
+
+pytestmark = pytest.mark.integration
+
+URI = os.environ.get("BOXMAN_IT_URI", "qemu:///system")
+PROJECT = "boxman_it_bridge_mode"
+CLUSTER = "c1"
+NETWORK = "migration"
+FULL_NETWORK = (
+    f"bprj__{PROJECT}__bprj__clstr__{CLUSTER}__clstr__{NETWORK}"
+)
+HOST_BRIDGE = "bxit76br"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(args, capture_output=True, text=True)
+
+
+def _virsh(*args: str) -> subprocess.CompletedProcess:
+    return _run("virsh", "--connect", URI, *args)
+
+
+@pytest.fixture
+def host_bridge():
+    if os.environ.get("BOXMAN_INTEGRATION_LIBVIRT") != "1":
+        pytest.skip(
+            "set BOXMAN_INTEGRATION_LIBVIRT=1 on a disposable host"
+        )
+    if _virsh("net-list", "--all", "--name").returncode != 0:
+        pytest.skip(f"libvirt is not reachable at {URI}")
+    if FULL_NETWORK in _virsh("net-list", "--all", "--name").stdout:
+        pytest.skip(f"remove stale network {FULL_NETWORK} before running")
+    if _run("ip", "link", "show", "dev", HOST_BRIDGE).returncode == 0:
+        pytest.skip(f"host bridge {HOST_BRIDGE} already exists")
+
+    created = _run(
+        "sudo", "-n", "ip", "link", "add", "dev", HOST_BRIDGE,
+        "type", "bridge",
+    )
+    assert created.returncode == 0, created.stderr
+    try:
+        raised = _run(
+            "sudo", "-n", "ip", "link", "set", "dev", HOST_BRIDGE, "up"
+        )
+        assert raised.returncode == 0, raised.stderr
+        yield
+    finally:
+        _virsh("net-destroy", FULL_NETWORK)
+        _virsh("net-undefine", FULL_NETWORK)
+        _run("sudo", "-n", "ip", "link", "delete", "dev", HOST_BRIDGE)
+
+
+def test_bridge_network_round_trip_preserves_host_bridge(
+    host_bridge, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    workdir = tmp_path / "work" / CLUSTER
+    conf = {
+        "version": "1.0",
+        "project": PROJECT,
+        "provider": {
+            "libvirt": {
+                "uri": URI,
+                "virsh_cmd": "/usr/bin/virsh",
+                "use_sudo": True,
+            }
+        },
+        "clusters": {
+            CLUSTER: {
+                "workdir": str(workdir),
+                "networks": {
+                    NETWORK: {
+                        "mode": "bridge",
+                        "bridge": {"name": HOST_BRIDGE},
+                        "enable": True,
+                        "autostart": True,
+                    }
+                },
+                "vms": {},
+            }
+        },
+    }
+    conf_path = tmp_path / "conf.yml"
+    conf_path.write_text(yaml.safe_dump(conf))
+
+    manager = BoxmanManager(config=str(conf_path))
+    manager.load_app_config({})
+    manager.runtime = "local"
+    session = LibVirtSession(manager.config)
+    session.manager = manager
+    manager.provider = session
+    manager.register_project_in_cache()
+
+    manager.define_networks()
+
+    dumped = _virsh("net-dumpxml", FULL_NETWORK)
+    assert dumped.returncode == 0, dumped.stderr
+    root = ET.fromstring(dumped.stdout)
+    assert root.find("forward").attrib == {"mode": "bridge"}
+    assert root.find("bridge").attrib == {"name": HOST_BRIDGE}
+    assert root.find("mac") is None
+    assert root.find("ip") is None
+    assert manager.reconcile_networks() == {}
+
+    assert manager.provider.remove_network(
+        name=FULL_NETWORK,
+        info=conf["clusters"][CLUSTER]["networks"][NETWORK],
+    ) is True
+    assert FULL_NETWORK not in _virsh("net-list", "--all", "--name").stdout
+    assert _run("ip", "link", "show", "dev", HOST_BRIDGE).returncode == 0

--- a/tests/test_libvirt_clone_vm.py
+++ b/tests/test_libvirt_clone_vm.py
@@ -10,8 +10,15 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import invoke
 import pytest
 
+from boxman.exceptions import (
+    CloneCleanupError,
+    CloneSanitizerError,
+    CloneSanitizerUnavailable,
+    ConfigError,
+)
 from boxman.providers.libvirt.clone_vm import CloneVM
 from boxman.providers.libvirt.session import LibVirtSession
 
@@ -62,11 +69,40 @@ class TestConstruction:
         assert "~" not in c.new_image_path
         assert c.new_image_path.endswith("/vm-new.qcow2")
 
+    def test_bundled_docker_runtime_contains_virt_sysprep_package(self):
+        dockerfile = (
+            Path(__file__).resolve().parents[1] / "containers/docker/Dockerfile"
+        ).read_text()
+        assert "guestfs-tools" in dockerfile
+
+    @pytest.mark.parametrize("policy", ["auto", "required", "off"])
+    def test_accepts_machine_id_policies(self, tmp_path: Path, policy: str):
+        c = CloneVM(
+            src_vm_name="base", new_vm_name="vm-new",
+            info={"clone_machine_id": policy}, workdir=str(tmp_path))
+        assert c.machine_id_policy == policy
+
+    @pytest.mark.parametrize("policy", ["strict", True, None, ["auto"]])
+    def test_rejects_invalid_machine_id_policy(self, tmp_path: Path, policy):
+        with pytest.raises(ConfigError, match="clone_machine_id"):
+            CloneVM(
+                src_vm_name="base", new_vm_name="vm-new",
+                info={"clone_machine_id": policy}, workdir=str(tmp_path))
+
+    @pytest.mark.parametrize("timeout", [0, -1, True, "300"])
+    def test_rejects_invalid_sysprep_timeout(self, tmp_path: Path, timeout):
+        with pytest.raises(ConfigError, match="virt_sysprep_timeout"):
+            CloneVM(
+                src_vm_name="base", new_vm_name="vm-new", info={},
+                workdir=str(tmp_path),
+                provider_config={"virt_sysprep_timeout": timeout})
+
 
 class TestCreateClone:
 
     def test_success_path_calls_virt_clone_with_correct_args(self, clone: CloneVM):
         with patch.object(clone.virt_clone, "execute") as virt_clone_exec, \
+             patch.object(clone, "reset_machine_identity", return_value=True), \
              patch.object(clone, "remove_network_interfaces", return_value=True):
             virt_clone_exec.return_value = _result()
             assert clone.create_clone() is True
@@ -86,6 +122,7 @@ class TestCreateClone:
             provider_config=None,
         )
         with patch.object(c.virt_clone, "execute", return_value=_result()) as virt_clone, \
+             patch.object(c, "reset_machine_identity", return_value=True), \
              patch.object(c, "remove_network_interfaces") as remove_ifaces:
             assert c.create_clone() is True
             virt_clone.assert_called_once()
@@ -99,12 +136,246 @@ class TestCreateClone:
         self, clone: CloneVM, captured_logs
     ):
         with patch.object(clone.virt_clone, "execute", return_value=_result()), \
+             patch.object(clone, "reset_machine_identity", return_value=True), \
              patch.object(clone, "remove_network_interfaces", return_value=False):
             assert clone.create_clone() is True
         assert any(
             "failed to remove network interfaces" in rec.message
             for rec in captured_logs.records
         )
+
+    def test_machine_identity_is_reset_before_interface_changes(self, clone: CloneVM):
+        order = []
+        with patch.object(
+            clone.virt_clone, "execute",
+            side_effect=lambda *args, **kwargs: order.append("clone"),
+        ), patch.object(
+            clone, "reset_machine_identity",
+            side_effect=lambda: (order.append("sysprep"), True)[1],
+        ), patch.object(
+            clone, "remove_network_interfaces",
+            side_effect=lambda: (order.append("interfaces"), True)[1],
+        ):
+            assert clone.create_clone() is True
+        assert order == ["clone", "sysprep", "interfaces"]
+
+    def test_auto_sanitizer_failure_warns_and_continues(
+        self, clone: CloneVM, captured_logs
+    ):
+        error = CloneSanitizerError("unsupported guest")
+        with patch.object(clone.virt_clone, "execute", return_value=_result()), \
+             patch.object(clone, "reset_machine_identity", side_effect=error), \
+             patch.object(clone, "discard_unsafe_clone") as discard, \
+             patch.object(
+                 clone, "remove_network_interfaces", return_value=True
+             ) as remove_ifaces:
+            assert clone.create_clone() is True
+        discard.assert_not_called()
+        remove_ifaces.assert_called_once_with()
+        assert any(
+            "clone_machine_id=auto" in rec.message
+            and "unsupported guest" in rec.message
+            for rec in captured_logs.records)
+
+    def test_required_sanitizer_failure_discards_and_propagates(
+        self, clone: CloneVM
+    ):
+        clone.machine_id_policy = "required"
+        error = CloneSanitizerError("inspection failed")
+        with patch.object(clone.virt_clone, "execute", return_value=_result()), \
+             patch.object(
+                 clone,
+                 "reset_machine_identity",
+                 side_effect=error,
+             ), \
+             patch.object(clone, "discard_unsafe_clone") as discard, \
+             patch.object(clone, "remove_network_interfaces") as remove_ifaces:
+            with pytest.raises(CloneSanitizerError, match="inspection failed"):
+                clone.create_clone()
+        discard.assert_called_once_with(error)
+        remove_ifaces.assert_not_called()
+
+    def test_required_cleanup_failure_is_terminal_with_both_causes(
+        self, clone: CloneVM
+    ):
+        clone.machine_id_policy = "required"
+        sanitizer = CloneSanitizerError("unsupported encrypted guest")
+        with patch.object(clone.virt_clone, "execute", return_value=_result()), \
+             patch.object(
+                 clone, "reset_machine_identity", side_effect=sanitizer
+             ), \
+             patch.object(
+                 clone.virsh, "execute",
+                 return_value=_result(
+                     ok=False, stderr="storage pool is busy", return_code=1)
+             ), \
+             patch.object(clone, "remove_network_interfaces") as remove_ifaces:
+            with pytest.raises(CloneCleanupError) as caught:
+                clone.create_clone()
+        assert "unsupported encrypted guest" in str(caught.value)
+        assert "storage pool is busy" in str(caught.value)
+        assert caught.value.__cause__ is sanitizer
+        remove_ifaces.assert_not_called()
+
+    def test_off_skips_sanitizer(self, clone: CloneVM):
+        clone.machine_id_policy = "off"
+        with patch.object(clone.virt_clone, "execute", return_value=_result()), \
+             patch.object(clone, "reset_machine_identity") as reset, \
+             patch.object(clone, "remove_network_interfaces", return_value=True):
+            assert clone.create_clone() is True
+        reset.assert_not_called()
+
+
+class TestResetMachineIdentity:
+
+    def test_runs_only_machine_id_operation_on_the_clone(self, clone: CloneVM):
+        with patch.object(
+            clone.virt_sysprep, "execute", return_value=_result()
+        ) as execute:
+            assert clone.reset_machine_identity() is None
+        execute.assert_called_once_with(
+            domain="vm01", operations="machine-id", keys_from_stdin=True,
+            warn=True, execution_timeout=300, timeout=315)
+
+    def test_nonzero_exit_is_a_typed_failure(self, clone: CloneVM):
+        with patch.object(
+            clone.virt_sysprep,
+            "execute",
+            return_value=_result(
+                ok=False, stderr="inspection failed", return_code=1),
+        ):
+            with pytest.raises(CloneSanitizerError, match="inspection failed"):
+                clone.reset_machine_identity()
+
+    def test_missing_tool_has_actionable_package_guidance(self, clone: CloneVM):
+        with patch.object(
+            clone.virt_sysprep,
+            "execute",
+            return_value=_result(
+                ok=False,
+                stderr="virt-sysprep: not found",
+                return_code=127,
+            ),
+        ):
+            with pytest.raises(CloneSanitizerUnavailable) as caught:
+                clone.reset_machine_identity()
+        assert "virt-sysprep" in str(caught.value)
+        assert "guestfs-tools" in str(caught.value)
+
+    def test_domain_not_found_is_not_misclassified_as_missing_tool(
+        self, clone: CloneVM
+    ):
+        with patch.object(
+            clone.virt_sysprep,
+            "execute",
+            return_value=_result(
+                ok=False,
+                stderr="virt-sysprep: domain 'vm01' not found",
+                return_code=127,
+            ),
+        ):
+            with pytest.raises(CloneSanitizerError) as caught:
+                clone.reset_machine_identity()
+        assert not isinstance(caught.value, CloneSanitizerUnavailable)
+        assert "domain 'vm01' not found" in str(caught.value)
+
+    def test_sudo_missing_tool_signature_is_classified_exactly(
+        self, clone: CloneVM
+    ):
+        with patch.object(
+            clone.virt_sysprep,
+            "execute",
+            return_value=_result(
+                ok=False,
+                stderr="sudo: virt-sysprep: command not found",
+                return_code=1,
+            ),
+        ):
+            with pytest.raises(CloneSanitizerUnavailable, match="not installed"):
+                clone.reset_machine_identity()
+
+    def test_noninteractive_sudo_denial_is_a_permanent_prerequisite_failure(
+        self, clone: CloneVM
+    ):
+        with patch.object(
+            clone.virt_sysprep,
+            "execute",
+            return_value=_result(
+                ok=False,
+                stderr=(
+                    "sudo: a terminal is required to read the password\n"
+                    "sudo: a password is required"
+                ),
+                return_code=1,
+            ),
+        ):
+            with pytest.raises(CloneSanitizerUnavailable) as caught:
+                clone.reset_machine_identity()
+        assert "passwordless sudo" in str(caught.value)
+        assert "use_sudo" in str(caught.value)
+
+    def test_timeout_is_typed_and_bounded(self, clone: CloneVM):
+        timed_out = invoke.exceptions.CommandTimedOut(
+            invoke.runners.Result(command="virt-sysprep", exited=-1),
+            timeout=300,
+        )
+        with patch.object(
+            clone.virt_sysprep, "execute", side_effect=timed_out
+        ) as execute:
+            with pytest.raises(CloneSanitizerError, match="timed out after 300s"):
+                clone.reset_machine_identity()
+        assert execute.call_args.kwargs["execution_timeout"] == 300
+        assert execute.call_args.kwargs["timeout"] == 315
+
+    def test_inner_timeout_exit_is_typed(self, clone: CloneVM):
+        with patch.object(
+            clone.virt_sysprep,
+            "execute",
+            return_value=_result(ok=False, return_code=124),
+        ):
+            with pytest.raises(CloneSanitizerError, match="timed out after 300s"):
+                clone.reset_machine_identity()
+
+
+class TestDiscardUnsafeClone:
+
+    def test_undefines_only_the_failed_clone_and_its_storage(self, clone: CloneVM):
+        with patch.object(clone.virsh, "execute", return_value=_result()) as execute:
+            clone.discard_unsafe_clone()
+        execute.assert_called_once_with(
+            "undefine", "vm01", "--remove-all-storage", warn=True)
+
+    def test_cleanup_failure_is_terminal_and_preserves_sanitizer_cause(
+        self, clone: CloneVM
+    ):
+        sanitizer = CloneSanitizerError("inspection failed")
+        with patch.object(
+            clone.virsh,
+            "execute",
+            return_value=_result(ok=False, stderr="domain is busy"),
+        ):
+            with pytest.raises(CloneCleanupError) as caught:
+                clone.discard_unsafe_clone(sanitizer)
+        assert "inspection failed" in str(caught.value)
+        assert "domain is busy" in str(caught.value)
+        assert "manual cleanup" in str(caught.value)
+        assert caught.value.__cause__ is sanitizer
+        assert caught.value.sanitizer_error is sanitizer
+        assert caught.value.cleanup_error == "domain is busy"
+
+    def test_cleanup_executor_exception_preserves_both_failures(
+        self, clone: CloneVM
+    ):
+        sanitizer = CloneSanitizerError("inspection failed")
+        cleanup = ConfigError("runtime container missing")
+        with patch.object(clone.virsh, "execute", side_effect=cleanup):
+            with pytest.raises(CloneCleanupError) as caught:
+                clone.discard_unsafe_clone(sanitizer)
+        assert "inspection failed" in str(caught.value)
+        assert "runtime container missing" in str(caught.value)
+        assert caught.value.sanitizer_error is sanitizer
+        assert caught.value.cleanup_error is cleanup
+        assert caught.value.__cause__ is cleanup
 
 
 class TestRemoveNetworkInterfaces:
@@ -244,3 +515,42 @@ class TestCloneVmIsoBootDispatch:
                 info=info,
                 workdir=str(tmp_path),
             )
+
+
+class TestCloneVmMachineIdentityFailureChain:
+
+    def test_session_propagates_real_clone_sanitizer_failure(self, tmp_path):
+        session = LibVirtSession.__new__(LibVirtSession)
+        session.provider_config = {
+            "uri": "qemu:///system",
+            "use_sudo": False,
+        }
+
+        with patch(
+            "boxman.providers.libvirt.clone_vm.VirtCloneCommand.execute",
+            return_value=_result(),
+        ) as virt_clone, patch(
+            "boxman.providers.libvirt.clone_vm.VirtSysprepCommand.execute",
+            return_value=_result(
+                ok=False,
+                stderr="inspection failed",
+                return_code=1,
+            ),
+        ) as virt_sysprep, patch(
+            "boxman.providers.libvirt.clone_vm.VirshCommand.execute",
+            return_value=_result(),
+        ) as virsh:
+            with pytest.raises(CloneSanitizerError, match="inspection failed"):
+                session.clone_vm(
+                    new_vm_name="vm01",
+                    src_vm_name="template-base",
+                    info={"clone_machine_id": "required"},
+                    workdir=str(tmp_path),
+                )
+
+        virt_clone.assert_called_once()
+        virt_sysprep.assert_called_once_with(
+            domain="vm01", operations="machine-id", keys_from_stdin=True,
+            warn=True, execution_timeout=300, timeout=315)
+        virsh.assert_called_once_with(
+            "undefine", "vm01", "--remove-all-storage", warn=True)

--- a/tests/test_libvirt_clone_vm.py
+++ b/tests/test_libvirt_clone_vm.py
@@ -16,7 +16,7 @@ import pytest
 from boxman.exceptions import (
     CloneCleanupError,
     CloneSanitizerError,
-    CloneSanitizerUnavailable,
+    CloneSanitizerUnavailableError,
     ConfigError,
 )
 from boxman.providers.libvirt.clone_vm import CloneVM
@@ -257,7 +257,7 @@ class TestResetMachineIdentity:
                 return_code=127,
             ),
         ):
-            with pytest.raises(CloneSanitizerUnavailable) as caught:
+            with pytest.raises(CloneSanitizerUnavailableError) as caught:
                 clone.reset_machine_identity()
         assert "virt-sysprep" in str(caught.value)
         assert "guestfs-tools" in str(caught.value)
@@ -276,7 +276,7 @@ class TestResetMachineIdentity:
         ):
             with pytest.raises(CloneSanitizerError) as caught:
                 clone.reset_machine_identity()
-        assert not isinstance(caught.value, CloneSanitizerUnavailable)
+        assert not isinstance(caught.value, CloneSanitizerUnavailableError)
         assert "domain 'vm01' not found" in str(caught.value)
 
     def test_sudo_missing_tool_signature_is_classified_exactly(
@@ -291,7 +291,10 @@ class TestResetMachineIdentity:
                 return_code=1,
             ),
         ):
-            with pytest.raises(CloneSanitizerUnavailable, match="not installed"):
+            with pytest.raises(
+                CloneSanitizerUnavailableError,
+                match="not installed",
+            ):
                 clone.reset_machine_identity()
 
     def test_noninteractive_sudo_denial_is_a_permanent_prerequisite_failure(
@@ -309,7 +312,7 @@ class TestResetMachineIdentity:
                 return_code=1,
             ),
         ):
-            with pytest.raises(CloneSanitizerUnavailable) as caught:
+            with pytest.raises(CloneSanitizerUnavailableError) as caught:
                 clone.reset_machine_identity()
         assert "passwordless sudo" in str(caught.value)
         assert "use_sudo" in str(caught.value)

--- a/tests/test_libvirt_clone_vm.py
+++ b/tests/test_libvirt_clone_vm.py
@@ -327,11 +327,14 @@ class TestResetMachineIdentity:
         assert execute.call_args.kwargs["execution_timeout"] == 300
         assert execute.call_args.kwargs["timeout"] == 315
 
-    def test_inner_timeout_exit_is_typed(self, clone: CloneVM):
+    @pytest.mark.parametrize("return_code", [124, 137])
+    def test_inner_timeout_exit_is_typed(
+        self, clone: CloneVM, return_code: int
+    ):
         with patch.object(
             clone.virt_sysprep,
             "execute",
-            return_value=_result(ok=False, return_code=124),
+            return_value=_result(ok=False, return_code=return_code),
         ):
             with pytest.raises(CloneSanitizerError, match="timed out after 300s"):
                 clone.reset_machine_identity()

--- a/tests/test_libvirt_commands.py
+++ b/tests/test_libvirt_commands.py
@@ -19,6 +19,7 @@ from boxman.providers.libvirt.commands import (
     VirshCommand,
     VirtCloneCommand,
     VirtInstallCommand,
+    VirtSysprepCommand,
 )
 
 SHELL_RUN = "boxman.providers.libvirt.commands._shell_run"
@@ -89,6 +90,32 @@ class TestBuildCommandQuoting:
         assert "--original=src vm" in tokens
         assert "--name=new vm" in tokens
 
+    def test_virt_sysprep_uses_configured_uri_and_only_machine_id(self):
+        v = VirtSysprepCommand(provider_config={
+            "uri": "qemu+ssh://user@host/system",
+            "virt_sysprep_cmd": "/usr/local/bin/virt-sysprep",
+        })
+        cmd = v.build_command(domain="clone vm", operations="machine-id")
+        assert shlex.split(cmd) == [
+            "/usr/local/bin/virt-sysprep",
+            "--domain=clone vm",
+            "--operations=machine-id",
+            "--connect=qemu+ssh://user@host/system",
+        ]
+
+    def test_virt_sysprep_follows_sudo_convention(self):
+        v = VirtSysprepCommand(provider_config={"use_sudo": True})
+        assert v.build_command(domain="vm01").startswith("sudo virt-sysprep ")
+
+    def test_virt_sysprep_timeout_runs_inside_runtime_and_under_sudo(self):
+        v = VirtSysprepCommand(provider_config={"use_sudo": True})
+        tokens = shlex.split(v.build_command(
+            domain="vm01", execution_timeout=300))
+        assert tokens[:7] == [
+            "timeout", "--signal=TERM", "--kill-after=10s", "300s",
+            "sudo", "-n", "virt-sysprep",
+        ]
+
 
 class TestExecutePassesQuotedCommandToShell:
 
@@ -102,6 +129,21 @@ class TestExecutePassesQuotedCommandToShell:
         assert "vm01" in tokens
         assert "hd c" in tokens
         assert "/iso/a b.iso" in tokens
+
+    def test_timeout_is_runner_control_not_command_option(self):
+        v = VirtSysprepCommand()
+        with patch(SHELL_RUN, return_value=_result()) as run:
+            v.execute(
+                domain="vm01", operations="machine-id",
+                execution_timeout=300, timeout=315)
+        command = run.call_args.args[0]
+        tokens = shlex.split(command)
+        assert tokens[:5] == [
+            "timeout", "--signal=TERM", "--kill-after=10s", "300s",
+            "virt-sysprep",
+        ]
+        assert "--execution-timeout=300" not in tokens
+        assert run.call_args.kwargs["timeout"] == 315
 
 
 class TestCallSiteAudit:
@@ -215,3 +257,15 @@ class TestSharedDockerExecWrap:
     def test_local_runtime_needs_no_container(self):
         v = VirshCommand(provider_config={"runtime": "local"})
         assert v._wrap_for_runtime("virsh list") == "virsh list"
+
+    def test_virt_sysprep_uses_the_shared_docker_wrapper(self):
+        v = VirtSysprepCommand(provider_config={
+            "runtime": "docker-compose",
+            "runtime_container": "boxman-libvirt-demo",
+        })
+        wrapped = v._wrap_for_runtime(
+            v.build_command(domain="vm01", operations="machine-id"))
+        assert wrapped.startswith(
+            "docker exec --user root boxman-libvirt-demo bash -c '")
+        assert "virt-sysprep" in wrapped
+        assert "--operations=machine-id" in wrapped

--- a/tests/test_libvirt_commands.py
+++ b/tests/test_libvirt_commands.py
@@ -103,9 +103,10 @@ class TestBuildCommandQuoting:
             "--connect=qemu+ssh://user@host/system",
         ]
 
-    def test_virt_sysprep_follows_sudo_convention(self):
+    def test_virt_sysprep_is_noninteractive_without_timeout(self):
         v = VirtSysprepCommand(provider_config={"use_sudo": True})
-        assert v.build_command(domain="vm01").startswith("sudo virt-sysprep ")
+        assert v.build_command(domain="vm01").startswith(
+            "sudo -n virt-sysprep ")
 
     def test_virt_sysprep_timeout_runs_inside_runtime_and_under_sudo(self):
         v = VirtSysprepCommand(provider_config={"use_sudo": True})

--- a/tests/test_libvirt_net.py
+++ b/tests/test_libvirt_net.py
@@ -248,9 +248,13 @@ class TestBridgeModeDefinition:
 
     def test_existing_bridge_defines_without_firewall_setup(self, tmp_path):
         net = self._net(tmp_path)
-        net.virsh.execute_shell = MagicMock(return_value=_result())
+        net.virsh.execute_shell = MagicMock(side_effect=[
+            _result(),
+            _result(stdout="0x1003\n"),  # IFF_UP; operstate may still be unknown
+        ])
         net.virsh.execute = MagicMock(return_value=_result())
         net._get_libvirt_bridges = MagicMock(return_value={"br-migrate"})
+        net._log_bridge_mode_managed_owner = MagicMock()
         net.check_network_exists = MagicMock()
         net.update_network_cache = MagicMock()
         net.apply_route_iptables_rule = MagicMock()
@@ -258,9 +262,44 @@ class TestBridgeModeDefinition:
         assert net.define_network(str(tmp_path / "bridge.xml")) is True
         commands = [call.args[0] for call in net.virsh.execute.call_args_list]
         assert commands == ["net-define", "net-start", "net-autostart"]
+        net._log_bridge_mode_managed_owner.assert_called_once_with()
         net.apply_route_iptables_rule.assert_not_called()
 
-    def test_remote_uri_does_not_probe_the_client_namespace(self, tmp_path):
+    def test_administratively_down_bridge_is_rejected(self, tmp_path):
+        net = self._net(tmp_path)
+        net.virsh.execute_shell = MagicMock(side_effect=[
+            _result(),
+            _result(stdout="0x1002\n"),  # IFF_UP is clear
+        ])
+        net.virsh.execute = MagicMock()
+
+        with pytest.raises(ConfigError, match="administratively down"):
+            net.define_network(str(tmp_path / "down-bridge.xml"))
+
+        net.virsh.execute.assert_not_called()
+        commands = [call.args[0] for call in net.virsh.execute_shell.call_args_list]
+        assert commands == [
+            "test -d /sys/class/net/br-migrate/bridge",
+            "cat /sys/class/net/br-migrate/flags",
+        ]
+
+    def test_unreadable_bridge_admin_state_is_rejected(self, tmp_path):
+        net = self._net(tmp_path)
+        net.virsh.execute_shell = MagicMock(side_effect=[
+            _result(),
+            _result(ok=False, stderr="permission denied"),
+        ])
+
+        with pytest.raises(ConfigError, match="could not read administrative state"):
+            net.define_network(str(tmp_path / "unknown-bridge.xml"))
+
+    @pytest.mark.parametrize("uri", [
+        "qemu+ssh://hypervisor.example/system",
+        "qemu://localhost/system",
+    ])
+    def test_authority_uri_does_not_probe_the_client_namespace(
+        self, tmp_path, uri
+    ):
         manager = MagicMock()
         manager.config = {"project": "p1"}
         manager._runtime_name = "local"
@@ -270,7 +309,7 @@ class TestBridgeModeDefinition:
             {"mode": "bridge", "bridge": {"name": "br-migrate"}},
             provider_config={
                 "use_sudo": False,
-                "uri": "qemu+ssh://hypervisor.example/system",
+                "uri": uri,
             },
             manager=manager,
         )
@@ -282,6 +321,9 @@ class TestBridgeModeDefinition:
 
         assert net.define_network(str(tmp_path / "remote-bridge.xml")) is True
         net.virsh.execute_shell.assert_not_called()
+        assert [call.args[0] for call in net.virsh.execute.call_args_list] == [
+            "net-define", "net-start", "net-autostart",
+        ]
 
     def test_remote_start_failure_rolls_back_without_cache_entry(self, tmp_path):
         manager = MagicMock()
@@ -316,6 +358,51 @@ class TestBridgeModeDefinition:
         net.virsh.execute_shell.assert_not_called()
         net.update_network_cache.assert_not_called()
 
+    def test_cache_oserror_rolls_back_network_and_cache(self, tmp_path):
+        manager = MagicMock()
+        manager.config = {"project": "p1"}
+        manager._runtime_name = "local"
+        manager.cache.projects = {"p1": {"runtime": "local"}}
+        manager.cache.write_projects_cache.side_effect = OSError(
+            "projects.json is read-only")
+        with patch.object(Network, "find_available_bridge_name",
+                          return_value="virbr9"):
+            net = Network(
+                "managed-net", {"mode": "route"},
+                provider_config={"use_sudo": False}, manager=manager)
+        calls = []
+        net.virsh.execute = MagicMock(
+            side_effect=lambda command, *a, **k: calls.append(command) or _result())
+        net._get_libvirt_bridges = MagicMock(return_value=set())
+        net.check_network_exists = MagicMock()
+        net.apply_route_iptables_rule = MagicMock(return_value=True)
+        net.remove_route_iptables_rule = MagicMock(return_value=True)
+
+        assert net.define_network(str(tmp_path / "managed.xml")) is False
+        assert calls == [
+            "net-define", "net-start", "net-autostart",
+            "net-destroy", "net-undefine",
+        ]
+        net.apply_route_iptables_rule.assert_called_once_with()
+        net.remove_route_iptables_rule.assert_called_once_with()
+        assert manager.cache.projects == {"p1": {"runtime": "local"}}
+
+    def test_baseexception_is_not_swallowed(self, tmp_path):
+        manager = MagicMock()
+        manager.config = {"project": "p1"}
+        with patch.object(Network, "find_available_bridge_name",
+                          return_value="virbr9"):
+            net = Network(
+                "managed-net", {"mode": "nat"},
+                provider_config={"use_sudo": False}, manager=manager)
+        net.virsh.execute = MagicMock(return_value=_result())
+        net._get_libvirt_bridges = MagicMock(return_value=set())
+        net.check_network_exists = MagicMock()
+        net.update_network_cache = MagicMock(side_effect=KeyboardInterrupt)
+
+        with pytest.raises(KeyboardInterrupt):
+            net.define_network(str(tmp_path / "managed.xml"))
+
     def test_removal_needs_no_firewall_cleanup(self, tmp_path):
         net = self._net(tmp_path)
         net.destroy_network = MagicMock(return_value=True)
@@ -323,6 +410,50 @@ class TestBridgeModeDefinition:
         net.remove_route_iptables_rule = MagicMock()
         assert net.remove_network() is True
         net.remove_route_iptables_rule.assert_not_called()
+
+
+class TestBridgeModeManagedOwnerDiagnostic:
+
+    @staticmethod
+    def _net() -> Network:
+        return Network(
+            "migration-net",
+            {"mode": "bridge", "bridge": {"name": "br-migrate"}},
+            provider_config={"use_sudo": False},
+        )
+
+    def test_logs_managed_owner_and_lifecycle_risk_at_debug(self):
+        net = self._net()
+        net.logger = MagicMock()
+        net.logger.isEnabledFor.return_value = True
+        net._listed_networks = MagicMock(return_value=["nat-owner", "peer"])
+        xml = {
+            "nat-owner": (
+                "<network><forward mode='nat'/>"
+                "<bridge name='br-migrate'/></network>"),
+            "peer": (
+                "<network><forward mode='bridge'/>"
+                "<bridge name='br-migrate'/></network>"),
+        }
+        net.virsh.execute = MagicMock(
+            side_effect=lambda _cmd, name, **_kwargs: _result(stdout=xml[name]))
+
+        net._log_bridge_mode_managed_owner()
+
+        message = net.logger.debug.call_args.args[0]
+        assert "nat-owner (nat)" in message
+        assert "destroying an owner removes" in message
+        assert "peer" not in message
+
+    def test_diagnostic_does_no_virsh_work_when_debug_is_disabled(self):
+        net = self._net()
+        net.logger = MagicMock()
+        net.logger.isEnabledFor.return_value = False
+        net._listed_networks = MagicMock()
+
+        net._log_bridge_mode_managed_owner()
+
+        net._listed_networks.assert_not_called()
 
 
 class TestDhcpReservations:

--- a/tests/test_libvirt_net.py
+++ b/tests/test_libvirt_net.py
@@ -387,6 +387,35 @@ class TestBridgeModeDefinition:
         net.remove_route_iptables_rule.assert_called_once_with()
         assert manager.cache.projects == {"p1": {"runtime": "local"}}
 
+    def test_route_rule_failure_rolls_back_without_cache_entry(self, tmp_path):
+        manager = MagicMock()
+        manager.config = {"project": "p1"}
+        manager._runtime_name = "local"
+        manager.cache.projects = {"p1": {"runtime": "local"}}
+        with patch.object(Network, "find_available_bridge_name",
+                          return_value="virbr9"):
+            net = Network(
+                "managed-net", {"mode": "route"},
+                provider_config={"use_sudo": False}, manager=manager)
+        calls = []
+        net.virsh.execute = MagicMock(
+            side_effect=lambda command, *a, **k: calls.append(command) or _result())
+        net._get_libvirt_bridges = MagicMock(return_value=set())
+        net.check_network_exists = MagicMock()
+        net.apply_route_iptables_rule = MagicMock(return_value=False)
+        net.remove_route_iptables_rule = MagicMock(return_value=True)
+        net.update_network_cache = MagicMock()
+
+        assert net.define_network(str(tmp_path / "managed.xml")) is False
+        assert calls == [
+            "net-define", "net-start", "net-autostart",
+            "net-destroy", "net-undefine",
+        ]
+        net.apply_route_iptables_rule.assert_called_once_with()
+        net.remove_route_iptables_rule.assert_called_once_with()
+        net.update_network_cache.assert_not_called()
+        assert manager.cache.projects == {"p1": {"runtime": "local"}}
+
     def test_baseexception_is_not_swallowed(self, tmp_path):
         manager = MagicMock()
         manager.config = {"project": "p1"}

--- a/tests/test_libvirt_net.py
+++ b/tests/test_libvirt_net.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from boxman.exceptions import ConfigError
 from boxman.providers.libvirt.net import Network, NetworkInterface
 
 pytestmark = pytest.mark.unit
@@ -114,6 +115,214 @@ class TestGenerateXml:
         assert dhcp_range is not None
         assert dhcp_range.get("start") == "192.168.150.10"
         assert dhcp_range.get("end") == "192.168.150.100"
+
+    def test_bridge_mode_renders_only_forward_and_existing_bridge(self):
+        net = Network(
+            name="migration-net",
+            info={"mode": "bridge", "bridge": {"name": "br-migrate"}},
+            assign_new_bridge=True,
+            provider_config={"use_sudo": False},
+        )
+        root = ET.fromstring(net.generate_xml())
+        assert root.find("forward").get("mode") == "bridge"
+        assert root.find("bridge").attrib == {"name": "br-migrate"}
+        assert root.find("mac") is None
+        assert root.find("ip") is None
+
+
+class TestBridgeModeValidation:
+
+    @staticmethod
+    def _assert_rejected_before_define(tmp_path, info, message):
+        net = Network(
+            "migration-net", info, assign_new_bridge=True,
+            provider_config={"use_sudo": False})
+        net.virsh.execute = MagicMock()
+        xml_path = tmp_path / "invalid.xml"
+        with pytest.raises(ConfigError, match=message):
+            net.define_network(str(xml_path))
+        net.virsh.execute.assert_not_called()
+        assert not xml_path.exists()
+
+    def test_requires_an_explicit_bridge_name(self, tmp_path):
+        self._assert_rejected_before_define(
+            tmp_path, {"mode": "bridge"}, "requires.*bridge.name")
+
+    def test_bridge_block_must_be_a_mapping(self, tmp_path):
+        self._assert_rejected_before_define(
+            tmp_path, {"mode": "bridge", "bridge": ["br0"]},
+            "bridge must be a mapping")
+
+    def test_rejects_unsafe_or_overlong_bridge_name(self, tmp_path):
+        self._assert_rejected_before_define(
+            tmp_path,
+            {"mode": "bridge", "bridge": {"name": "br0;touch /tmp/x"}},
+            "invalid bridge name")
+
+    def test_rejects_non_string_bridge_name(self, tmp_path):
+        self._assert_rejected_before_define(
+            tmp_path,
+            {"mode": "bridge", "bridge": {"name": 123}},
+            "invalid bridge name")
+
+    @pytest.mark.parametrize("extra,field", [
+        ({"ip": {"address": "10.0.0.1"}}, "ip"),
+        ({"mac": "52:54:00:00:00:01"}, "mac"),
+        ({"bridge": {"name": "br0", "stp": "on"}}, "bridge.stp"),
+        ({"bridge": {"name": "br0", "delay": 0}}, "bridge.delay"),
+    ])
+    def test_rejects_fields_owned_by_the_host_bridge(
+        self, tmp_path, extra, field
+    ):
+        info = {"mode": "bridge", "bridge": {"name": "br0"}}
+        info.update(extra)
+        self._assert_rejected_before_define(
+            tmp_path, info, field.replace('.', r'\.'))
+
+    def test_rejects_unknown_modes_before_libvirt(self, tmp_path):
+        self._assert_rejected_before_define(
+            tmp_path,
+            {"mode": "hostdev", "bridge": {"name": "br-old"}},
+            "unsupported forward mode")
+
+    def test_legacy_unsupported_network_can_still_be_removed(self):
+        net = Network(
+            "old-open-net",
+            {"mode": "open", "bridge": {"name": "br-old"}},
+            assign_new_bridge=True,
+            provider_config={"use_sudo": False})
+        net.destroy_network = MagicMock(return_value=True)
+        net.undefine_network = MagicMock(return_value=True)
+        net.remove_route_iptables_rule = MagicMock()
+
+        assert net.remove_network() is True
+        net.destroy_network.assert_called_once_with()
+        net.undefine_network.assert_called_once_with()
+        net.remove_route_iptables_rule.assert_not_called()
+
+    def test_bridge_mode_may_reuse_an_existing_bridge_from_cache(self):
+        net = Network(
+            "migration-net",
+            {"mode": "bridge", "bridge": {"name": "br-migrate"}},
+            provider_config={"use_sudo": False},
+            manager=MagicMock(),
+        )
+        net.manager.config = {"project": "current"}
+        net.manager._runtime_name = "local"
+        net.manager.cache.projects = {
+            "other": {
+                "runtime": "local",
+                "networks": {
+                    "other-name": {"bridge_name": "br-migrate"}
+                },
+            }
+        }
+
+        net.check_network_exists()
+
+
+class TestBridgeModeDefinition:
+
+    @staticmethod
+    def _net(tmp_path):
+        manager = MagicMock()
+        manager.config = {"project": "p1"}
+        manager._runtime_name = "local"
+        manager.cache.projects = {"p1": {"runtime": "local"}}
+        return Network(
+            "migration-net",
+            {"mode": "bridge", "bridge": {"name": "br-migrate"}},
+            provider_config={"use_sudo": False}, manager=manager,
+        )
+
+    def test_missing_host_bridge_fails_before_net_define(self, tmp_path):
+        net = self._net(tmp_path)
+        net.virsh.execute_shell = MagicMock(return_value=_result(ok=False))
+        net.virsh.execute = MagicMock()
+
+        with pytest.raises(ConfigError, match="does not exist"):
+            net.define_network(str(tmp_path / "bridge.xml"))
+
+        net.virsh.execute.assert_not_called()
+        assert not (tmp_path / "bridge.xml").exists()
+
+    def test_existing_bridge_defines_without_firewall_setup(self, tmp_path):
+        net = self._net(tmp_path)
+        net.virsh.execute_shell = MagicMock(return_value=_result())
+        net.virsh.execute = MagicMock(return_value=_result())
+        net._get_libvirt_bridges = MagicMock(return_value={"br-migrate"})
+        net.check_network_exists = MagicMock()
+        net.update_network_cache = MagicMock()
+        net.apply_route_iptables_rule = MagicMock()
+
+        assert net.define_network(str(tmp_path / "bridge.xml")) is True
+        commands = [call.args[0] for call in net.virsh.execute.call_args_list]
+        assert commands == ["net-define", "net-start", "net-autostart"]
+        net.apply_route_iptables_rule.assert_not_called()
+
+    def test_remote_uri_does_not_probe_the_client_namespace(self, tmp_path):
+        manager = MagicMock()
+        manager.config = {"project": "p1"}
+        manager._runtime_name = "local"
+        manager.cache.projects = {"p1": {"runtime": "local"}}
+        net = Network(
+            "migration-net",
+            {"mode": "bridge", "bridge": {"name": "br-migrate"}},
+            provider_config={
+                "use_sudo": False,
+                "uri": "qemu+ssh://hypervisor.example/system",
+            },
+            manager=manager,
+        )
+        net.virsh.execute_shell = MagicMock()
+        net.virsh.execute = MagicMock(return_value=_result())
+        net._get_libvirt_bridges = MagicMock(return_value=set())
+        net.check_network_exists = MagicMock()
+        net.update_network_cache = MagicMock()
+
+        assert net.define_network(str(tmp_path / "remote-bridge.xml")) is True
+        net.virsh.execute_shell.assert_not_called()
+
+    def test_remote_start_failure_rolls_back_without_cache_entry(self, tmp_path):
+        manager = MagicMock()
+        manager.config = {"project": "p1"}
+        manager._runtime_name = "local"
+        manager.cache.projects = {"p1": {"runtime": "local"}}
+        net = Network(
+            "migration-net",
+            {"mode": "bridge", "bridge": {"name": "br-migrate"}},
+            provider_config={
+                "use_sudo": False,
+                "uri": "qemu+ssh://hypervisor.example/system",
+            },
+            manager=manager,
+        )
+        net.virsh.execute_shell = MagicMock()
+        calls = []
+
+        def execute(command, *args, **kwargs):
+            calls.append(command)
+            if command == "net-start":
+                raise RuntimeError("remote bridge is missing")
+            return _result()
+
+        net.virsh.execute = MagicMock(side_effect=execute)
+        net._get_libvirt_bridges = MagicMock(return_value=set())
+        net.check_network_exists = MagicMock()
+        net.update_network_cache = MagicMock()
+
+        assert net.define_network(str(tmp_path / "remote-bridge.xml")) is False
+        assert calls == ["net-define", "net-start", "net-undefine"]
+        net.virsh.execute_shell.assert_not_called()
+        net.update_network_cache.assert_not_called()
+
+    def test_removal_needs_no_firewall_cleanup(self, tmp_path):
+        net = self._net(tmp_path)
+        net.destroy_network = MagicMock(return_value=True)
+        net.undefine_network = MagicMock(return_value=True)
+        net.remove_route_iptables_rule = MagicMock()
+        assert net.remove_network() is True
+        net.remove_route_iptables_rule.assert_not_called()
 
 
 class TestDhcpReservations:

--- a/tests/test_libvirt_session.py
+++ b/tests/test_libvirt_session.py
@@ -24,6 +24,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from boxman.exceptions import ConfigError
+from boxman.providers.libvirt.net import Network
 from boxman.providers.libvirt.session import LibVirtSession
 
 pytestmark = pytest.mark.unit
@@ -117,6 +119,77 @@ class TestUpdateProviderConfigWithRuntime:
         # Runtime was applied
         assert s.provider_config["runtime"] == "docker-compose"
         assert s.provider_config["use_sudo"] is True
+
+
+class TestBridgeTransitionPlanning:
+
+    NAT_XML = (
+        "<network><name>demo</name><forward mode='nat'/>"
+        "<bridge name='virbr0' stp='on' delay='0'/>"
+        "<mac address='52:54:00:0a:0b:0c'/>"
+        "<ip address='10.5.3.1' netmask='255.255.255.0'/></network>"
+    )
+    BRIDGE_XML = (
+        "<network><name>demo</name><forward mode='bridge'/>"
+        "<bridge name='virbr0'/></network>"
+    )
+
+    @staticmethod
+    def _session() -> LibVirtSession:
+        session = _session({
+            "uri": "qemu+ssh://hypervisor.example/system",
+            "use_sudo": False,
+        })
+        session.manager = MagicMock()
+        return session
+
+    @staticmethod
+    def _network_state(xml: str):
+        return (
+            patch.object(Network, "exists", return_value=True),
+            patch.object(Network, "dump_xml", return_value=xml),
+            patch.object(Network, "attached_domains", return_value=[]),
+            patch.object(Network, "is_active", return_value=True),
+        )
+
+    def test_nat_to_bridge_same_name_is_rejected_during_planning(self):
+        session = self._session()
+        patches = self._network_state(self.NAT_XML)
+        with patches[0], patches[1], patches[2], patches[3]:
+            with pytest.raises(ConfigError, match="would delete.*managed bridge"):
+                session.plan_network(
+                    name="demo",
+                    info={"mode": "bridge", "bridge": {"name": "virbr0"}},
+                )
+
+    def test_bridge_to_nat_same_pinned_name_is_rejected_during_planning(self):
+        session = self._session()
+        patches = self._network_state(self.BRIDGE_XML)
+        with (
+            patches[0], patches[1], patches[2], patches[3],
+            patch.object(Network, "get_bridge_from_network",
+                         return_value="virbr0"),
+        ):
+            with pytest.raises(ConfigError, match="cannot claim its name"):
+                session.plan_network(
+                    name="demo",
+                    info={"mode": "nat", "bridge": {"name": "virbr0"}},
+                )
+
+    def test_bridge_to_auto_nat_reserves_name_before_removal(self):
+        session = self._session()
+        patches = self._network_state(self.BRIDGE_XML)
+        with (
+            patches[0], patches[1], patches[2], patches[3],
+            patch.object(Network, "get_bridge_from_network",
+                         return_value="virbr0"),
+            patch.object(Network, "find_available_bridge_name",
+                         return_value="virbr1"),
+        ):
+            plan = session.plan_network(name="demo", info={"mode": "nat"})
+
+        assert plan["action"] == "recreate"
+        assert plan["replacement_bridge_name"] == "virbr1"
 
 
 class TestDestroyDisks:

--- a/tests/test_libvirt_virsh_edit.py
+++ b/tests/test_libvirt_virsh_edit.py
@@ -103,6 +103,30 @@ class TestApplyMemballoonToXml:
             {"free_page_reporting": False})
         assert self._memballoon(xml).get("freePageReporting") == "off"
 
+    def test_autodeflate_true(self):
+        xml = VirshEdit.apply_memballoon_to_xml(
+            _domain_xml(), {"autodeflate": True})
+        mb = self._memballoon(xml)
+        assert mb.get("model") == "virtio"
+        assert mb.get("autodeflate") == "on"
+
+    def test_autodeflate_false(self):
+        xml = VirshEdit.apply_memballoon_to_xml(
+            _domain_xml("<memballoon model='virtio' autodeflate='on'/>"),
+            {"autodeflate": False})
+        assert self._memballoon(xml).get("autodeflate") == "off"
+
+    def test_autodeflate_preserves_other_balloon_settings(self):
+        xml = VirshEdit.apply_memballoon_to_xml(
+            _domain_xml(
+                "<memballoon model='virtio' freePageReporting='on'>"
+                "<stats period='5'/></memballoon>"),
+            {"autodeflate": True})
+        mb = self._memballoon(xml)
+        assert mb.get("freePageReporting") == "on"
+        assert mb.get("autodeflate") == "on"
+        assert mb.find("stats").get("period") == "5"
+
     def test_stats_period(self):
         xml = VirshEdit.apply_memballoon_to_xml(
             _domain_xml(), {"stats_period": 10})
@@ -115,6 +139,13 @@ class TestApplyMemballoonToXml:
         assert mb.get("model") == "virtio"
         assert mb.get("freePageReporting") is None
         assert mb.find("stats") is None
+
+    def test_absent_autodeflate_key_preserves_existing_attribute(self):
+        xml = VirshEdit.apply_memballoon_to_xml(
+            _domain_xml(
+                "<memballoon model='virtio' autodeflate='on'/>"),
+            {"free_page_reporting": True})
+        assert self._memballoon(xml).get("autodeflate") == "on"
 
 
 class TestConfigureMemballoon:
@@ -156,6 +187,12 @@ class TestMemballoonValidation:
         with pytest.raises(ConfigError):
             VirshEdit.apply_memballoon_to_xml(
                 _domain_xml(), {"free_page_reporting": "false"})
+
+    @pytest.mark.parametrize("value", ["false", 0, 1, None])
+    def test_autodeflate_non_bool_rejected(self, value):
+        with pytest.raises(ConfigError, match="memballoon.autodeflate"):
+            VirshEdit.apply_memballoon_to_xml(
+                _domain_xml(), {"autodeflate": value})
 
     def test_stats_period_bool_rejected(self):
         with pytest.raises(ConfigError):

--- a/tests/test_libvirt_vm_differ.py
+++ b/tests/test_libvirt_vm_differ.py
@@ -170,7 +170,7 @@ class TestMemballoonDiff:
     def _diff(self, differ: VMStateDiffer, desired, actual, *, live=None,
               vm_state="running") -> dict:
         states = [actual]
-        if vm_state == "running":
+        if vm_state in VMStateDiffer._LIVE_DOMAIN_STATES:
             states.append(actual if live is None else live)
         with patch.object(differ, "get_vm_state", return_value=vm_state), \
              patch.object(differ, "get_actual_cpu",
@@ -210,6 +210,23 @@ class TestMemballoonDiff:
                   "stats_period": None})
 
         assert diff["memballoon_changed"] is False
+        assert diff["memballoon_restart_pending"] is True
+        assert diff["live_memballoon"]["autodeflate"] is False
+
+    @pytest.mark.parametrize(
+        "vm_state",
+        ["paused", "blocked", "in shutdown", "pmsuspended"],
+    )
+    def test_other_active_states_with_live_mismatch_need_restart(
+            self, differ, vm_state):
+        desired = {"free_page_reporting": False, "autodeflate": True,
+                   "stats_period": None}
+
+        diff = self._diff(
+            differ, desired, desired, vm_state=vm_state,
+            live={"free_page_reporting": False, "autodeflate": False,
+                  "stats_period": None})
+
         assert diff["memballoon_restart_pending"] is True
         assert diff["live_memballoon"]["autodeflate"] is False
 

--- a/tests/test_libvirt_vm_differ.py
+++ b/tests/test_libvirt_vm_differ.py
@@ -215,7 +215,7 @@ class TestMemballoonDiff:
 
     @pytest.mark.parametrize(
         "vm_state",
-        ["paused", "blocked", "in shutdown", "pmsuspended"],
+        ["paused", "blocked", "in shutdown", "pmsuspended", "crashed"],
     )
     def test_other_active_states_with_live_mismatch_need_restart(
             self, differ, vm_state):

--- a/tests/test_libvirt_vm_differ.py
+++ b/tests/test_libvirt_vm_differ.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 
 import pytest
 
+from boxman.exceptions import ConfigError
 from boxman.providers.libvirt.vm_differ import VMStateDiffer
 
 pytestmark = pytest.mark.unit
@@ -26,6 +27,7 @@ def _default_memballoon_state():
     helper doesn't need another patch in every test."""
     with patch.object(VMStateDiffer, 'get_actual_memballoon',
                       return_value={'free_page_reporting': False,
+                                    'autodeflate': False,
                                     'stats_period': None}):
         yield
 
@@ -121,33 +123,56 @@ class TestMemballoonState:
         with patch.object(differ.virsh_edit, "get_domain_xml",
                           return_value=_balloon_xml()):
             assert differ.get_actual_memballoon("vm01") == {
-                "free_page_reporting": False, "stats_period": None}
+                "free_page_reporting": False, "autodeflate": False,
+                "stats_period": None}
 
-    def test_fpr_on_and_stats(self, differ: VMStateDiffer):
+    def test_fpr_autodeflate_on_and_stats(self, differ: VMStateDiffer):
         xml = _balloon_xml(
-            "<memballoon model='virtio' freePageReporting='on'>"
+            "<memballoon model='virtio' freePageReporting='on' "
+            "autodeflate='on'>"
             "<stats period='5'/></memballoon>")
         with patch.object(differ.virsh_edit, "get_domain_xml",
                           return_value=xml):
             assert differ.get_actual_memballoon("vm01") == {
-                "free_page_reporting": True, "stats_period": 5}
+                "free_page_reporting": True, "autodeflate": True,
+                "stats_period": 5}
+
+    @pytest.mark.parametrize(
+        "memballoon",
+        ["<memballoon model='virtio'/>",
+         "<memballoon model='virtio' autodeflate='off'/>"])
+    def test_autodeflate_missing_or_off_is_false(
+            self, differ: VMStateDiffer, memballoon: str):
+        with patch.object(differ.virsh_edit, "get_domain_xml",
+                          return_value=_balloon_xml(memballoon)):
+            assert differ.get_actual_memballoon("vm01")["autodeflate"] is False
 
     def test_normalize_none_is_defaults(self):
         assert VMStateDiffer.normalize_memballoon_config(None) == {
-            "free_page_reporting": False, "stats_period": None}
+            "free_page_reporting": False, "autodeflate": False,
+            "stats_period": None}
 
     def test_normalize_partial_block(self):
         assert VMStateDiffer.normalize_memballoon_config(
-            {"free_page_reporting": True}) == {
-            "free_page_reporting": True, "stats_period": None}
+            {"autodeflate": True}) == {
+            "free_page_reporting": False, "autodeflate": True,
+            "stats_period": None}
+
+    def test_normalize_rejects_non_bool_autodeflate(self):
+        with pytest.raises(ConfigError, match="memballoon.autodeflate"):
+            VMStateDiffer.normalize_memballoon_config({"autodeflate": "false"})
 
 
 class TestMemballoonDiff:
     """diff_vm must flag balloon changes only when the actual inactive
     state differs from the desired one, in both directions."""
 
-    def _diff(self, differ: VMStateDiffer, desired, actual) -> dict:
-        with patch.object(differ, "get_vm_state", return_value="running"), \
+    def _diff(self, differ: VMStateDiffer, desired, actual, *, live=None,
+              vm_state="running") -> dict:
+        states = [actual]
+        if vm_state == "running":
+            states.append(actual if live is None else live)
+        with patch.object(differ, "get_vm_state", return_value=vm_state), \
              patch.object(differ, "get_actual_cpu",
                           return_value={"sockets": 1, "cores": 1, "threads": 1,
                                         "total_vcpus": 1, "current_vcpus": 1}), \
@@ -157,7 +182,8 @@ class TestMemballoonDiff:
              patch.object(differ, "get_actual_disks", return_value=[]), \
              patch.object(differ, "get_actual_cdroms", return_value=[]), \
              patch.object(differ, "get_actual_shared_folders", return_value=[]), \
-             patch.object(differ, "get_actual_memballoon", return_value=actual):
+             patch.object(differ, "get_actual_memballoon",
+                          side_effect=states):
             return differ.diff_vm(
                 domain_name="vm01",
                 desired_cpus=None,
@@ -170,33 +196,65 @@ class TestMemballoonDiff:
 
     def test_no_block_and_default_actual_is_no_change(self, differ):
         diff = self._diff(differ, None,
-                          {"free_page_reporting": False, "stats_period": None})
+                          {"free_page_reporting": False, "autodeflate": False,
+                           "stats_period": None})
         assert diff["memballoon_changed"] is False
+        assert diff["memballoon_restart_pending"] is False
+
+    def test_persistent_match_but_live_mismatch_needs_restart(self, differ):
+        desired = {"free_page_reporting": False, "autodeflate": True,
+                   "stats_period": None}
+        diff = self._diff(
+            differ, desired, desired,
+            live={"free_page_reporting": False, "autodeflate": False,
+                  "stats_period": None})
+
+        assert diff["memballoon_changed"] is False
+        assert diff["memballoon_restart_pending"] is True
+        assert diff["live_memballoon"]["autodeflate"] is False
 
     def test_new_block_is_a_change(self, differ):
         diff = self._diff(differ, {"free_page_reporting": True},
-                          {"free_page_reporting": False, "stats_period": None})
+                          {"free_page_reporting": False, "autodeflate": False,
+                           "stats_period": None})
         assert diff["memballoon_changed"] is True
+        assert diff["memballoon_restart_pending"] is True
         assert diff["desired_memballoon"] == {
-            "free_page_reporting": True, "stats_period": None}
+            "free_page_reporting": True, "autodeflate": False,
+            "stats_period": None}
 
     def test_removed_block_reconciles_to_defaults(self, differ):
         """Removing the memballoon block after enabling it must show up as
         a change back to the libvirt defaults (review P2)."""
         diff = self._diff(differ, None,
-                          {"free_page_reporting": True, "stats_period": 5})
+                          {"free_page_reporting": False, "autodeflate": True,
+                           "stats_period": None})
         assert diff["memballoon_changed"] is True
         assert diff["desired_memballoon"] == {
-            "free_page_reporting": False, "stats_period": None}
+            "free_page_reporting": False, "autodeflate": False,
+            "stats_period": None}
 
     def test_matching_state_is_no_change(self, differ):
         diff = self._diff(differ,
-                          {"free_page_reporting": True, "stats_period": 5},
-                          {"free_page_reporting": True, "stats_period": 5})
+                          {"free_page_reporting": True, "autodeflate": True,
+                           "stats_period": 5},
+                          {"free_page_reporting": True, "autodeflate": True,
+                           "stats_period": 5})
         assert diff["memballoon_changed"] is False
 
     def test_stats_period_mismatch_is_a_change(self, differ):
         diff = self._diff(differ,
                           {"free_page_reporting": True, "stats_period": 10},
-                          {"free_page_reporting": True, "stats_period": 5})
+                          {"free_page_reporting": True, "autodeflate": False,
+                           "stats_period": 5})
         assert diff["memballoon_changed"] is True
+
+    @pytest.mark.parametrize("desired,actual", [(True, False), (False, True)])
+    def test_autodeflate_mismatch_is_a_change(self, differ, desired, actual):
+        diff = self._diff(
+            differ,
+            {"autodeflate": desired},
+            {"free_page_reporting": False, "autodeflate": actual,
+             "stats_period": None})
+        assert diff["memballoon_changed"] is True
+        assert diff["desired_memballoon"]["autodeflate"] is desired

--- a/tests/test_manager_core.py
+++ b/tests/test_manager_core.py
@@ -416,7 +416,8 @@ class TestCloneVmsExitCodeGuard:
     def test_required_clone_sanitizer_failure_is_not_retried(
         self, tmp_path: Path
     ):
-        from unittest.mock import MagicMock, patch as _patch
+        from unittest.mock import MagicMock
+        from unittest.mock import patch as _patch
 
         from boxman.exceptions import CloneSanitizerError
         from boxman.manager_parts.vms import _clone_with_retry
@@ -466,7 +467,8 @@ class TestCloneVmsExitCodeGuard:
         assert "virt-sysprep unavailable" in notices[0]
 
     def test_failed_unsafe_clone_cleanup_is_not_retried(self, tmp_path: Path):
-        from unittest.mock import MagicMock, patch as _patch
+        from unittest.mock import MagicMock
+        from unittest.mock import patch as _patch
 
         from boxman.exceptions import CloneCleanupError
         from boxman.manager_parts.vms import _clone_with_retry
@@ -491,7 +493,8 @@ class TestCloneVmsExitCodeGuard:
         configure/start phase, so the cloned guest can never boot with the
         inherited identity."""
         from types import SimpleNamespace
-        from unittest.mock import MagicMock, patch as _patch
+        from unittest.mock import MagicMock
+        from unittest.mock import patch as _patch
 
         m = self._mgr_with_one_vm(tmp_path)
         m.cache.projects = {}

--- a/tests/test_manager_core.py
+++ b/tests/test_manager_core.py
@@ -413,6 +413,80 @@ class TestCloneVmsExitCodeGuard:
             # No exception, no return value either.
             m.clone_vms()
 
+    def test_required_clone_sanitizer_failure_is_not_retried(
+        self, tmp_path: Path
+    ):
+        from unittest.mock import MagicMock, patch as _patch
+
+        from boxman.exceptions import CloneSanitizerError
+        from boxman.manager_parts.vms import _clone_with_retry
+
+        provider = MagicMock()
+        provider.clone_vm.side_effect = CloneSanitizerError(
+            "virt-sysprep is not installed"
+        )
+        cluster = {"base_image": "tpl", "workdir": str(tmp_path)}
+
+        with _patch("boxman.manager_parts.vms.time.sleep") as sleep:
+            with pytest.raises(CloneSanitizerError, match="virt-sysprep"):
+                _clone_with_retry(provider, cluster, {}, "vm01")
+
+        provider.clone_vm.assert_called_once()
+        sleep.assert_not_called()
+
+    def test_failed_unsafe_clone_cleanup_is_not_retried(self, tmp_path: Path):
+        from unittest.mock import MagicMock, patch as _patch
+
+        from boxman.exceptions import CloneCleanupError
+        from boxman.manager_parts.vms import _clone_with_retry
+
+        provider = MagicMock()
+        provider.clone_vm.side_effect = CloneCleanupError(
+            "inspection failed; cleanup also failed; manual cleanup required"
+        )
+        cluster = {"base_image": "tpl", "workdir": str(tmp_path)}
+
+        with _patch("boxman.manager_parts.vms.time.sleep") as sleep:
+            with pytest.raises(CloneCleanupError, match="cleanup also failed"):
+                _clone_with_retry(provider, cluster, {}, "vm01")
+
+        provider.clone_vm.assert_called_once()
+        sleep.assert_not_called()
+
+    def test_provision_never_configures_or_starts_after_clone_failure(
+        self, tmp_path: Path
+    ):
+        """A failed offline sanitizer exits through clone_vms before the
+        configure/start phase, so the cloned guest can never boot with the
+        inherited identity."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch as _patch
+
+        m = self._mgr_with_one_vm(tmp_path)
+        m.cache.projects = {}
+        cli_args = SimpleNamespace(force=False, rebuild_templates=False)
+
+        with _patch.object(m, '_update_sessions_with_runtime'), \
+             _patch.object(m, '_find_existing_project_vms', return_value=[]), \
+             _patch.object(m.cache, 'read_projects_cache'), \
+             _patch.object(m, 'register_project_in_cache'), \
+             _patch.object(m, '_expand_oci_base_images'), \
+             _patch.object(m, 'ensure_templates_exist', return_value=True), \
+             _patch.object(m, 'validate_base_images'), \
+             _patch.object(m, 'provision_files'), \
+             _patch.object(m, 'ensure_shared_bridges'), \
+             _patch.object(m, 'define_networks'), \
+             _patch.object(
+                 m, 'clone_vms', side_effect=RuntimeError('sysprep failed')
+             ), \
+             _patch.object(
+                 m, 'configure_and_start_vms', new=MagicMock()
+             ) as configure_and_start:
+            with pytest.raises(RuntimeError, match='sysprep failed'):
+                m.provision(cli_args)
+
+        configure_and_start.assert_not_called()
+
 
 class TestCloneAndConfigureNewVmsExitCodeGuard:
     """

--- a/tests/test_manager_core.py
+++ b/tests/test_manager_core.py
@@ -434,6 +434,37 @@ class TestCloneVmsExitCodeGuard:
         provider.clone_vm.assert_called_once()
         sleep.assert_not_called()
 
+    def test_auto_sanitizer_warning_survives_real_retry_wrapper(
+        self, tmp_path: Path, captured_logs
+    ):
+        """The successful first attempt is suppressed, then its one safety
+        notice is re-emitted outside that context instead of disappearing."""
+        from unittest.mock import patch as _patch
+
+        from boxman.manager_parts.vms import _clone_with_retry
+        from boxman.providers.libvirt.session import LibVirtSession
+
+        provider = LibVirtSession(config={
+            "provider": {"libvirt": {"use_sudo": False}},
+        })
+        cluster = {"base_image": "tpl", "workdir": str(tmp_path)}
+
+        with _patch(
+            "boxman.providers.libvirt.clone_vm.VirtCloneCommand.execute",
+            return_value=object(),
+        ), _patch(
+            "boxman.providers.libvirt.clone_vm.VirtSysprepCommand.execute",
+            side_effect=OSError("virt-sysprep unavailable"),
+        ):
+            _clone_with_retry(provider, cluster, {}, "vm01")
+
+        notices = [
+            record.message for record in captured_logs.records
+            if "clone_machine_id=auto" in record.message
+        ]
+        assert len(notices) == 1
+        assert "virt-sysprep unavailable" in notices[0]
+
     def test_failed_unsafe_clone_cleanup_is_not_retried(self, tmp_path: Path):
         from unittest.mock import MagicMock, patch as _patch
 

--- a/tests/test_net_reconcile.py
+++ b/tests/test_net_reconcile.py
@@ -127,6 +127,56 @@ class TestDesiredState:
         assert plan["action"] == "none"
         assert plan["structural"] == []
 
+    def test_bridge_mode_round_trip_has_no_phantom_ip_mac_or_stp_drift(self):
+        net = Network(
+            name="demo",
+            info={"mode": "bridge", "bridge": {"name": "br-migrate"}},
+            assign_new_bridge=True,
+            provider_config={"use_sudo": False},
+        )
+        xml = ("<network><name>demo</name><forward mode='bridge'/>"
+               "<bridge name='br-migrate'/></network>")
+        state = nr.desired_state(net)
+        assert state == {
+            "mode": "bridge", "bridge_name": "br-migrate",
+            "bridge_stp": None, "bridge_delay": None, "mac": None,
+            "ip_address": None, "netmask": None, "dhcp_range": None,
+            "dhcp_hosts": [],
+        }
+        assert nr.diff_network(
+            state, nr.parse_network_xml(xml))["action"] == "none"
+
+
+class TestBridgeOwnershipTransitions:
+
+    @pytest.mark.parametrize("old_mode", ["nat", "route"])
+    def test_managed_to_bridge_rejects_the_managed_bridge_name(self, old_mode):
+        message = nr.bridge_ownership_conflict(
+            {"mode": "bridge", "bridge_name": "virbr9"},
+            {"mode": old_mode, "bridge_name": "virbr9"},
+        )
+        assert "would delete that managed bridge" in message
+
+    @pytest.mark.parametrize("new_mode", ["nat", "route"])
+    def test_bridge_to_managed_rejects_the_host_bridge_name(self, new_mode):
+        message = nr.bridge_ownership_conflict(
+            {"mode": new_mode, "bridge_name": "br-migrate"},
+            {"mode": "bridge", "bridge_name": "br-migrate"},
+        )
+        assert "cannot claim its name" in message
+
+    def test_different_bridge_names_are_safe_to_recreate(self):
+        assert nr.bridge_ownership_conflict(
+            {"mode": "bridge", "bridge_name": "br-external"},
+            {"mode": "nat", "bridge_name": "virbr9"},
+        ) is None
+
+    def test_auto_managed_bridge_has_no_premature_name_conflict(self):
+        assert nr.bridge_ownership_conflict(
+            {"mode": "nat", "bridge_name": None},
+            {"mode": "bridge", "bridge_name": "virbr0"},
+        ) is None
+
 
 class TestDiffDhcpHosts:
 
@@ -381,6 +431,14 @@ class TestTeardownInfo:
         network_info = {'mode': 'nat'}
         assert self._teardown({}, network_info) is network_info
 
+    def test_bridge_mode_teardown_has_no_synthetic_ip_block(self):
+        info = self._teardown(
+            {'mode': 'bridge', 'bridge_name': 'br-migrate',
+             'ip_address': None, 'netmask': None},
+            {'mode': 'nat', 'ip': {'address': '10.9.9.1'}})
+        assert info == {
+            'mode': 'bridge', 'bridge': {'name': 'br-migrate'}}
+
 
 class TestRecreateSequence:
     """
@@ -464,6 +522,26 @@ class TestRecreateSequence:
         self._recreate(mgr)
         info = mgr.provider.remove_network.call_args.kwargs['info']
         assert info['mode'] == 'nat'          # what is there, not the new 'route'
+
+    def test_reserved_replacement_bridge_is_used_for_the_redefine(self):
+        mgr, _ = self._manager()
+        plan = {
+            'structural': ["forward mode 'bridge' -> 'nat'"],
+            'attached_vms': [],
+            'actual': {'mode': 'bridge', 'bridge_name': 'virbr0'},
+            'replacement_bridge_name': 'virbr1',
+        }
+        outcome = mgr._recreate_network(
+            cluster={'workdir': '/tmp/wd'},
+            network_name='cluster_1/mgmt',
+            full_name='full-net',
+            network_info={'mode': 'nat'},
+            plan=plan,
+            dry_run=False, allow_recreate=True, auto_accept=True)
+
+        assert outcome == 'recreated'
+        assert mgr.provider.define_network.call_args.kwargs['info'] == {
+            'mode': 'nat', 'bridge': {'name': 'virbr1'}}
 
     def test_nothing_is_touched_without_the_flag(self):
         mgr, calls = self._manager()

--- a/tests/test_net_reconcile.py
+++ b/tests/test_net_reconcile.py
@@ -173,8 +173,9 @@ class TestBridgeOwnershipTransitions:
 
     def test_auto_managed_bridge_has_no_premature_name_conflict(self):
         assert nr.bridge_ownership_conflict(
-            {"mode": "nat", "bridge_name": None},
+            {"mode": "nat", "bridge_name": "virbr0"},
             {"mode": "bridge", "bridge_name": "virbr0"},
+            desired_bridge_is_pinned=False,
         ) is None
 
 
@@ -294,26 +295,27 @@ class TestPinnedBridgeAndStp:
     """Fields whose configured form differs from what libvirt echoes back."""
 
     def test_pinned_bridge_name_reaches_the_diff(self, ):
-        # the plan builds its Network with assign_new_bridge=False, which reads
-        # the bridge from libvirt; the *configured* name has to survive that or
-        # the pinned-name drift check can never fire
+        # A configured bridge is the effective desired name. Live state is
+        # parsed separately from net-dumpxml, so construction must not replace
+        # the pin with the bridge currently in use.
         info = {"mode": "nat", "bridge": {"name": "virbr42"},
                 "ip": {"address": "10.5.3.1", "netmask": "255.255.255.0"}}
-        with patch.object(Network, "get_bridge_from_network",
-                          return_value="virbr9"):
+        with patch.object(Network, "get_bridge_from_network") as lookup:
             net = Network(name="demo", info=info, assign_new_bridge=False,
                           provider_config={"use_sudo": False})
-        assert net.bridge_name == "virbr9"          # what is in use
-        assert nr.desired_state(net)["bridge_name"] == "virbr42"   # what was asked for
+        assert net.bridge_name == "virbr42"
+        assert nr.desired_state(net)["bridge_name"] == "virbr42"
+        lookup.assert_not_called()
 
-    def test_unpinned_bridge_name_is_not_reported_as_desired(self):
+    def test_unpinned_existing_bridge_is_the_effective_desired_name(self):
         info = {"mode": "nat",
                 "ip": {"address": "10.5.3.1", "netmask": "255.255.255.0"}}
         with patch.object(Network, "get_bridge_from_network",
                           return_value="virbr9"):
             net = Network(name="demo", info=info, assign_new_bridge=False,
                           provider_config={"use_sudo": False})
-        assert nr.desired_state(net)["bridge_name"] is None
+        assert net.pinned_bridge_name is None
+        assert nr.desired_state(net)["bridge_name"] == "virbr9"
 
     def test_a_short_network_mac_does_not_read_as_drift(self):
         # libvirt zero-pads the network's own mac when it stores it, so a

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -18,9 +18,8 @@ pytestmark = pytest.mark.unit
 @pytest.fixture(autouse=True)
 def _default_memballoon_state():
     """diff_vm probes the balloon device via virsh; default it to the
-    libvirt defaults (no freePageReporting, no autodeflate, no stats) for
-    every test so
-    the existing decorator stacks don't each need another patch."""
+    libvirt defaults (no freePageReporting, no autodeflate, no stats) for every
+    test so the existing decorator stacks don't each need another patch."""
     with patch.object(VMStateDiffer, 'get_actual_memballoon',
                       return_value={'free_page_reporting': False,
                                     'autodeflate': False,
@@ -876,7 +875,8 @@ class TestMemballoonUpdateResult:
             'removed_shared_folders': [],
             'changed_shared_folders': [],
             'memballoon_changed': True,
-            'memballoon_restart_pending': vm_state == 'running',
+            'memballoon_restart_pending': (
+                vm_state in VMStateDiffer._LIVE_DOMAIN_STATES),
             'actual_memballoon': {
                 'free_page_reporting': False,
                 'autodeflate': False,
@@ -917,6 +917,16 @@ class TestMemballoonUpdateResult:
 
         assert result['status'] == 'needs_restart'
         assert 'restart required to apply memballoon changes' in result['details']
+        mgr.provider.shutdown_and_wait.assert_not_called()
+        mgr.provider.start_vm.assert_not_called()
+
+    def test_paused_vm_reports_restart_required(self):
+        mgr, result = self._run_update('paused')
+
+        assert result['status'] == 'needs_restart'
+        assert (
+            'restart required to apply memballoon changes'
+            in result['details'])
         mgr.provider.shutdown_and_wait.assert_not_called()
         mgr.provider.start_vm.assert_not_called()
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -875,8 +875,10 @@ class TestMemballoonUpdateResult:
             'removed_shared_folders': [],
             'changed_shared_folders': [],
             'memballoon_changed': True,
+            # Keep this manager fixture independent of VMStateDiffer's state
+            # classification; differ-level tests own that contract.
             'memballoon_restart_pending': (
-                vm_state in VMStateDiffer._LIVE_DOMAIN_STATES),
+                vm_state in ('running', 'paused', 'crashed')),
             'actual_memballoon': {
                 'free_page_reporting': False,
                 'autodeflate': False,
@@ -922,6 +924,16 @@ class TestMemballoonUpdateResult:
 
     def test_paused_vm_reports_restart_required(self):
         mgr, result = self._run_update('paused')
+
+        assert result['status'] == 'needs_restart'
+        assert (
+            'restart required to apply memballoon changes'
+            in result['details'])
+        mgr.provider.shutdown_and_wait.assert_not_called()
+        mgr.provider.start_vm.assert_not_called()
+
+    def test_crash_preserved_vm_reports_restart_required(self):
+        mgr, result = self._run_update('crashed')
 
         assert result['status'] == 'needs_restart'
         assert (

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -18,10 +18,12 @@ pytestmark = pytest.mark.unit
 @pytest.fixture(autouse=True)
 def _default_memballoon_state():
     """diff_vm probes the balloon device via virsh; default it to the
-    libvirt defaults (no freePageReporting, no stats) for every test so
+    libvirt defaults (no freePageReporting, no autodeflate, no stats) for
+    every test so
     the existing decorator stacks don't each need another patch."""
     with patch.object(VMStateDiffer, 'get_actual_memballoon',
                       return_value={'free_page_reporting': False,
+                                    'autodeflate': False,
                                     'stats_period': None}):
         yield
 
@@ -851,3 +853,92 @@ class TestDestroyRemovedVm:
         # first destroy_vm is the graceful one, second is force=True
         assert parent.mock_calls[1] == call.destroy_vm('test-vm')
         assert parent.mock_calls[2] == call.destroy_vm('test-vm', force=True)
+
+
+# ---------------------------------------------------------------------------
+# Persistent memballoon updates
+# ---------------------------------------------------------------------------
+class TestMemballoonUpdateResult:
+
+    @staticmethod
+    def _balloon_only_diff(vm_state):
+        return {
+            'cpu_changed': False,
+            'memory_changed': False,
+            'max_vcpus_changed': False,
+            'max_memory_changed': False,
+            'new_disks': [],
+            'resize_disks': [],
+            'new_cdroms': [],
+            'removed_cdroms': [],
+            'changed_cdroms': [],
+            'new_shared_folders': [],
+            'removed_shared_folders': [],
+            'changed_shared_folders': [],
+            'memballoon_changed': True,
+            'memballoon_restart_pending': vm_state == 'running',
+            'actual_memballoon': {
+                'free_page_reporting': False,
+                'autodeflate': False,
+                'stats_period': None,
+            },
+            'desired_memballoon': {
+                'free_page_reporting': False,
+                'autodeflate': True,
+                'stats_period': None,
+            },
+            'live_memballoon': {
+                'free_page_reporting': False,
+                'autodeflate': False,
+                'stats_period': None,
+            },
+            'vm_state': vm_state,
+        }
+
+    def _run_update(self, vm_state):
+        mgr = make_bare_manager({'project': 'demo'})
+        mgr.provider = MagicMock()
+        mgr.provider.provider_config = {'uri': 'qemu:///system'}
+        mgr.provider.configure_vm_memballoon.return_value = True
+        result_queue = MagicMock()
+
+        with patch.object(
+                VMStateDiffer, 'diff_vm',
+                return_value=self._balloon_only_diff(vm_state)):
+            mgr._update_single_vm(
+                'cluster1', {'workdir': '/tmp'}, 'node01',
+                {'memballoon': {'autodeflate': True}}, result_queue)
+
+        result_queue.put.assert_called_once()
+        return mgr, result_queue.put.call_args.args[0][1]
+
+    def test_running_vm_reports_restart_required(self):
+        mgr, result = self._run_update('running')
+
+        assert result['status'] == 'needs_restart'
+        assert 'restart required to apply memballoon changes' in result['details']
+        mgr.provider.shutdown_and_wait.assert_not_called()
+        mgr.provider.start_vm.assert_not_called()
+
+    def test_stopped_vm_reports_updated(self):
+        _mgr, result = self._run_update('shut off')
+
+        assert result['status'] == 'updated'
+        assert 'restart required' not in result['details']
+
+    def test_persistent_match_still_reports_live_restart_pending(self):
+        diff = self._balloon_only_diff('running')
+        diff['memballoon_changed'] = False
+        mgr = make_bare_manager({'project': 'demo'})
+        mgr.provider = MagicMock()
+        mgr.provider.provider_config = {'uri': 'qemu:///system'}
+        result_queue = MagicMock()
+
+        with patch.object(VMStateDiffer, 'diff_vm', return_value=diff):
+            mgr._update_single_vm(
+                'cluster1', {'workdir': '/tmp'}, 'node01',
+                {'memballoon': {'autodeflate': True}}, result_queue)
+
+        result = result_queue.put.call_args.args[0][1]
+        assert result['status'] == 'needs_restart'
+        mgr.provider.configure_vm_memballoon.assert_not_called()

--- a/tests/test_virtualbox_provider.py
+++ b/tests/test_virtualbox_provider.py
@@ -18,6 +18,7 @@ All external calls are mocked — no VBoxManage is invoked on any host.
 
 from __future__ import annotations
 
+import shlex
 import subprocess
 from unittest.mock import patch
 
@@ -149,6 +150,27 @@ class TestVBoxManageCommand:
         # --name dst present, --register bare, uuid/live skipped
         assert built == "VBoxManage clonevm src --name dst --register"
 
+    def test_build_command_quotes_all_data_tokens_once(self):
+        binary = "/opt/VirtualBox Tools/VBoxManage"
+        subcommand = "clone vm"
+        source = 'src "blue"; $(touch /tmp/nope) | true'
+        destination = "/tmp/VirtualBox VMs/node 'one'"
+        cmd = VBoxManageCommand(provider_config={"vboxmanage_cmd": binary})
+
+        built = cmd.build_command(
+            subcommand, source, name=destination, register=True)
+
+        assert shlex.split(built) == [
+            binary,
+            subcommand,
+            source,
+            "--name",
+            destination,
+            "--register",
+        ]
+        assert shlex.quote(source) in built
+        assert shlex.quote(shlex.quote(source)) not in built
+
     def test_override_use_sudo(self):
         cmd = VBoxManageCommand(provider_config={"use_sudo": True}, override_use_sudo=False)
         assert cmd.build_command("list", "vms") == "VBoxManage list vms"
@@ -171,6 +193,22 @@ class TestVBoxManageCommand:
         # command was split into argv
         args, _ = mock_run.call_args
         assert args[0] == ["VBoxManage", "list", "vms"]
+
+    def test_run_preserves_quoted_command_path_and_values_as_argv(self):
+        binary = "/opt/VirtualBox Tools/VBoxManage"
+        cmd = VBoxManageCommand(provider_config={"vboxmanage_cmd": binary})
+        with patch(
+                "boxman.providers.virtualbox.commands.subprocess.run",
+                return_value=_completed()) as mock_run:
+            cmd.run("showvminfo", "node 01; echo nope", machinereadable=True)
+
+        args, _ = mock_run.call_args
+        assert args[0] == [
+            binary,
+            "showvminfo",
+            "node 01; echo nope",
+            "--machinereadable",
+        ]
 
     def test_run_check_raises_on_nonzero(self):
         cmd = VBoxManageCommand(provider_config={})
@@ -356,6 +394,12 @@ class TestCommandBuilders:
     def test_modifyvm_natpf_builder(self):
         from boxman.providers.virtualbox.modifyvm import ModifyVm
         built = ModifyVm(provider_config={}).build_natpf_command(
-            "node01", host_port=2222, guest_port=22)
-        assert '--natpf1' in built
-        assert '"guestssh,tcp,,2222,,22"' in built
+            "node 01", host_port=2222, guest_port=22,
+            rule_name="guest ssh; echo nope")
+        assert shlex.split(built) == [
+            "VBoxManage",
+            "modifyvm",
+            "node 01",
+            "--natpf1",
+            "guest ssh; echo nope,tcp,,2222,,22",
+        ]


### PR DESCRIPTION
## Summary

This PR collects six independently reviewable Boxman fixes and follow-ups that
were developed on isolated branches, adversarially reviewed, remediated, and
validated together. The commits are intentionally preserved rather than
squashed so each change can receive focused review comments.

## Commit-by-commit review map

1. `f7558c6` — reset cloned Linux machine identity (#145)
   - Runs a bounded, noninteractive `virt-sysprep --operations machine-id`
     before interface changes or first boot.
   - Adds per-VM `clone_machine_id: auto|required|off` policy.
   - Preserves sanitizer and cleanup causes and avoids misleading retries.

2. `ffa7121` — expose virtio-balloon autodeflate (#144)
   - Adds strict per-VM `memballoon.autodeflate` configuration.
   - Reconciles persistent XML and compares live state.
   - Continues reporting `needs_restart` until a running guest boots with the
     new balloon configuration.

3. `2f39534` — quote VirtualBox command arguments centrally (#83)
   - Quotes executable, subcommand, positional arguments, and values exactly
     once.
   - Removes pre-quoted NATPF input and adds argv round-trip coverage.
   - Completes the VirtualBox half after the libvirt work in PR #109.

4. `12735df` — fix Docker-runtime SSH/PAM on Ubuntu 24.04 (#84)
   - Uses `/etc/shadow` mode `0400 root:root` so confined `unix_chkpwd` can
     pass ordinary DAC checks.
   - Adds build-time invariants and removes the host AppArmor capability
     workaround from the test runner.

5. `6179d87` — support existing Linux bridges in libvirt networks (#76)
   - Emits valid bridge-mode XML and validates bridge-owned fields early.
   - Handles local versus remote libvirt URI validation correctly.
   - Makes definition transactional and rejects unsafe bridge-ownership
     transitions before destructive recreation.

6. `d56429a` — add KSM operator guidance (#146)
   - Documents bounded evaluation, measurement, restoration, CPU/capacity
     costs, NUMA/COW behavior, and trust-boundary risks.
   - Records the sanitized six-VM result and deliberately avoids automatic
     host policy enablement.

## Validation

- Combined disposable test-runner gate: **2016 passed, 142 deselected**.
- Final real-libvirt bridge round trip: **1 passed**, with temporary bridge and
  network cleanup verified.
- Real clone check: two same-template guests regenerated distinct machine IDs
  and obtained distinct DHCP addresses.
- Docker SSH/PAM integration passed without the host AppArmor capability
  override; the built image retained `root:root:400` shadow permissions.
- All six final patches were compared with their isolated source commits, and
  the final `polish` tree is byte-for-byte identical to the combined candidate
  used for validation.

Closes #145
Closes #144
Closes #83
Closes #84
Closes #76
Closes #146
