### PR TITLE
fix(libvirt): routed-network isolation that reconciles and allows DHCP, plus destroy round-trip fixes

### DIFF
--- a/src/boxman/assets/network.xml.j2
+++ b/src/boxman/assets/network.xml.j2
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<network>
+{%- set has_dhcp = (dhcp_range_start and dhcp_range_end) or dhcp_hosts %}
+{#- A routed network is isolated from the host by firewall rules, so the
+    gateway and resolver dnsmasq would advertise (DHCP options 3 and 6, both
+    the bridge address) are unreachable by construction. Handing them out is
+    actively harmful: the router option installs a default route at metric 0,
+    which outranks the guest's real NIC and black-holes all of its traffic.
+    An empty `dhcp-option=N` tells dnsmasq to omit that option entirely, so
+    the guest gets an address and a netmask and nothing it cannot use. #}
+{%- set trim_dhcp_options = (forward_mode == 'route') and has_dhcp %}
+<network{% if trim_dhcp_options %} xmlns:dnsmasq='http://libvirt.org/schemas/network/dnsmasq/1.0'{% endif %}>
   {# the environment has no autoescape, so every config-derived value is
      escaped explicitly -- a name holding an & or a quote would otherwise
      produce XML that libvirt rejects at net-define #}
@@ -28,4 +37,10 @@
   {% endif %}
   </ip>
 {% endif %}
+{%- if trim_dhcp_options %}
+  <dnsmasq:options>
+    <dnsmasq:option value='dhcp-option=3'/>
+    <dnsmasq:option value='dhcp-option=6'/>
+  </dnsmasq:options>
+{%- endif %}
 </network>

--- a/src/boxman/manager_parts/flows.py
+++ b/src/boxman/manager_parts/flows.py
@@ -243,6 +243,7 @@ class FlowsMixin:
                 allow_recreate=getattr(cli_args, 'recreate_networks', False),
                 auto_accept=getattr(cli_args, 'yes', False))
             self.report_network_results(network_results)
+            self.raise_on_network_failures(network_results)
 
             # a recreate power-cycles the guests attached to the network, so
             # the addresses connect_info() and the ssh config are about to be
@@ -277,9 +278,11 @@ class FlowsMixin:
         # to find the network it is wired to, and any reservation added to the
         # config since the last run has to be in dnsmasq before the guest asks
         # for a lease.
-        self.report_network_results(self.reconcile_networks(
+        network_results = self.reconcile_networks(
             allow_recreate=getattr(cli_args, 'recreate_networks', False),
-            auto_accept=getattr(cli_args, 'yes', False)))
+            auto_accept=getattr(cli_args, 'yes', False))
+        self.report_network_results(network_results)
+        self.raise_on_network_failures(network_results)
 
         # Build workdir lookup for restore operations
         vm_workdir_map = dict(self._control_vm_targets(cli_args))

--- a/src/boxman/manager_parts/networks.py
+++ b/src/boxman/manager_parts/networks.py
@@ -8,7 +8,7 @@ import os
 import time
 from typing import Any
 
-from boxman.exceptions import ConfigError
+from boxman.exceptions import ConfigError, NetworkError
 from boxman.providers.libvirt import net_reconcile
 
 
@@ -238,6 +238,22 @@ class NetworksMixin:
                     f"could not be reconnected")
             else:
                 self.logger.info(f"network {full_name}: {outcome}")
+
+    def raise_on_network_failures(self, results: dict[str, str]) -> None:
+        """
+        Turn failed networks into a failed run.
+
+        Reporting alone is not enough: a routed network that could not be
+        isolated, or one that could not be defined at all, leaves guests
+        without the connectivity -- or the containment -- the configuration
+        asked for. Continuing to exit 0 makes that look like success.
+        """
+        failed = sorted(name for name, outcome in results.items()
+                        if outcome == 'failed')
+        if failed:
+            raise NetworkError(
+                f"{len(failed)} network(s) could not be brought to the "
+                f"configured state: {', '.join(failed)}")
 
     def _vms_worth_waiting_for(self) -> list[str]:
         """

--- a/src/boxman/manager_parts/networks.py
+++ b/src/boxman/manager_parts/networks.py
@@ -154,11 +154,17 @@ class NetworksMixin:
         # do not survive a reboot or a manual flush while the network itself
         # autostarts happily without them. Re-assert them on every reconcile
         # rather than only at define time.
-        self._reconcile_network_isolation(dry_run=dry_run)
+        for full_name, outcome in self._reconcile_network_isolation(
+                dry_run=dry_run).items():
+            # an unisolated routed network is a failed network: without this
+            # `up` exits 0 while the guests can reach the host
+            if outcome == 'failed':
+                results[full_name] = 'failed'
 
         return results
 
-    def _reconcile_network_isolation(self, dry_run: bool = False) -> None:
+    def _reconcile_network_isolation(
+            self, dry_run: bool = False) -> dict[str, str]:
         """
         Re-apply the host isolation of every routed network in the config.
 
@@ -167,8 +173,9 @@ class NetworksMixin:
         view unisolated, for however long it was up. That is worth a warning
         even though it is being fixed here and now.
         """
+        outcomes: dict[str, str] = {}
         if not hasattr(self.provider, 'reconcile_network_isolation'):
-            return
+            return outcomes
 
         for cluster_name, cluster in self.config['clusters'].items():
             for network_name, network_info in (cluster.get('networks') or {}).items():
@@ -186,7 +193,9 @@ class NetworksMixin:
                 except Exception as exc:
                     self.logger.error(
                         f"network {label}: could not check isolation rules: {exc}")
+                    outcomes[full_name] = 'failed'
                     continue
+                outcomes[full_name] = outcome
 
                 if outcome == 'absent':
                     # the network is not defined; its own failure was already
@@ -206,6 +215,8 @@ class NetworksMixin:
                 elif outcome == 'failed':
                     self.logger.error(
                         f"network {label}: could not apply isolation rules")
+
+        return outcomes
 
     def report_network_results(self, results: dict[str, str]) -> None:
         """

--- a/src/boxman/manager_parts/networks.py
+++ b/src/boxman/manager_parts/networks.py
@@ -150,7 +150,62 @@ class NetworksMixin:
                         allow_recreate=allow_recreate,
                         auto_accept=auto_accept)
 
+        # Isolation rules are host iptables state, not libvirt state, so they
+        # do not survive a reboot or a manual flush while the network itself
+        # autostarts happily without them. Re-assert them on every reconcile
+        # rather than only at define time.
+        self._reconcile_network_isolation(dry_run=dry_run)
+
         return results
+
+    def _reconcile_network_isolation(self, dry_run: bool = False) -> None:
+        """
+        Re-apply the host isolation of every routed network in the config.
+
+        Reported rather than done silently: a routed network that lost its
+        rules has been reachable from the host, and from the guests' point of
+        view unisolated, for however long it was up. That is worth a warning
+        even though it is being fixed here and now.
+        """
+        if not hasattr(self.provider, 'reconcile_network_isolation'):
+            return
+
+        for cluster_name, cluster in self.config['clusters'].items():
+            for network_name, network_info in (cluster.get('networks') or {}).items():
+                if (network_info or {}).get('mode') != 'route':
+                    continue
+                label = f"{cluster_name}/{network_name}"
+                full_name = self.full_network_name(
+                    project_config=self.config,
+                    cluster_name=cluster_name,
+                    network_name=network_name)
+                try:
+                    outcome = self.provider.reconcile_network_isolation(
+                        name=full_name, info=network_info,
+                        check_only=dry_run)
+                except Exception as exc:
+                    self.logger.error(
+                        f"network {label}: could not check isolation rules: {exc}")
+                    continue
+
+                if outcome == 'absent':
+                    # the network is not defined; its own failure was already
+                    # reported by the define path
+                    self.logger.debug(
+                        f"network {label}: not defined, isolation not applicable")
+                elif outcome == 'repaired':
+                    self.logger.warning(
+                        f"network {label}: isolation rules were missing and "
+                        f"have been re-applied. A routed network is left "
+                        f"unprotected between a host reboot and the next "
+                        f"boxman run.")
+                elif outcome == 'drifted':
+                    self.logger.warning(
+                        f"[dry-run] network {label}: isolation rules are "
+                        f"missing; they would be re-applied.")
+                elif outcome == 'failed':
+                    self.logger.error(
+                        f"network {label}: could not apply isolation rules")
 
     def report_network_results(self, results: dict[str, str]) -> None:
         """

--- a/src/boxman/manager_parts/vms.py
+++ b/src/boxman/manager_parts/vms.py
@@ -815,6 +815,8 @@ class VMsMixin:
 
         self.report_network_results(network_results)
 
+        self.raise_on_network_failures(network_results)
+
         # --- categorize VMs ---
         expected_vms = set(self._get_project_vm_names())
         all_existing_vms = set(self._find_all_existing_project_vms())

--- a/src/boxman/providers/libvirt/destroy_vm.py
+++ b/src/boxman/providers/libvirt/destroy_vm.py
@@ -288,7 +288,8 @@ class DestroyVM:
         try:
             self.logger.info(f"un-defining vm {self.name}")
 
-            self.virsh.execute("undefine", self.name)
+            # see force_undefine_vm: a managed save image blocks undefine
+            self.virsh.execute("undefine", self.name, "--managed-save")
 
             # verify that the vm is no longer defined
             if not self.is_vm_defined():
@@ -329,16 +330,27 @@ class DestroyVM:
             # requires a recent libvirt, so on failure fall back to a
             # plain undefine that only drops snapshot metadata — the
             # domain must always be removable.
+            # --managed-save is not optional: libvirt refuses with "Refusing to
+            # undefine while domain managed save image exists" for any domain
+            # that was suspended or snapshotted with memory state, which
+            # boxman itself creates. Without it destroy leaves the VM defined.
             result = self.virsh.execute(
                 "undefine", self.name,
                 "--remove-all-storage", "--wipe-storage",
                 "--delete-storage-volume-snapshots", "--snapshots-metadata",
+                "--managed-save",
                 warn=True)
             if not result.ok:
                 self.logger.warning(
                     f"undefine with storage removal failed for {self.name} "
                     f"({result.stderr.strip()}) — retrying plain undefine")
-                self.virsh.execute("undefine", self.name, "--snapshots-metadata")
+                fallback = self.virsh.execute(
+                    "undefine", self.name, "--snapshots-metadata",
+                    "--managed-save", warn=True)
+                if not fallback.ok:
+                    self.logger.error(
+                        f"plain undefine also failed for {self.name}: "
+                        f"{fallback.stderr.strip()}")
 
             # verify that the vm is no longer defined
             if not self.is_vm_defined():

--- a/src/boxman/providers/libvirt/net.py
+++ b/src/boxman/providers/libvirt/net.py
@@ -734,6 +734,25 @@ class Network:
         previous_projects = copy.deepcopy(self.manager.cache.projects)
         projects_in_cache = self.manager.cache.projects
         project_name = self.manager.config['project']
+
+        # `destroy` unregisters the project, so a later define that arrives
+        # through the reconcile path rather than a full provision used to
+        # KeyError here. The exception was swallowed as "Error defining
+        # network: '<project>'", the network was never created, and the VMs
+        # then failed to start with "Network not found". Re-register instead.
+        if project_name not in projects_in_cache:
+            self.logger.debug(
+                f"project {project_name} is not in the cache, re-registering "
+                f"it while defining network {self.name}")
+            entry: dict[str, Any] = {}
+            conf_path = getattr(self.manager, 'config_path', None)
+            if conf_path:
+                entry['conf'] = os.path.abspath(os.path.expanduser(conf_path))
+            runtime_name = getattr(self.manager, '_runtime_name', None)
+            if runtime_name:
+                entry['runtime'] = runtime_name
+            projects_in_cache[project_name] = entry
+
         project_cache = projects_in_cache[project_name]
 
         if 'networks' not in project_cache:
@@ -1213,8 +1232,11 @@ class Network:
     def remove_route_iptables_rule(self) -> bool:
         """
         Remove the isolation rules inserted by apply_route_iptables_rule.
-        Executed during `remove_network`.  Follows the same check-then-execute
-        pattern used in apply_route_iptables_rule.
+
+        Executed during ``remove_network``. Tearing down a chain is
+        unhook-flush-delete, so there is no rule-by-rule bookkeeping to fall
+        out of step with the apply path. Legacy loose rules from older
+        versions are cleaned up too, so a host does not accumulate them.
         """
         if self.forward_mode != 'route':
             return True
@@ -1237,18 +1259,20 @@ class Network:
                     f"iptables -D FORWARD -i {br_name} -o {br_name} -j ACCEPT",
                     present=False):
                 return False
-            if not self._ensure_rule(
-                    self,
-                    f"iptables -C INPUT  -i {br_name} -j DROP",
-                    f"iptables -D INPUT  -i {br_name} -j DROP",
-                    present=False):
-                return False
-            if not self._ensure_rule(
-                    self,
-                    f"iptables -C OUTPUT -o {br_name} -j DROP",
-                    f"iptables -D OUTPUT -o {br_name} -j DROP",
-                    present=False):
-                return False
+
+            for chain, hook, iface_flag, _port in self._isolation_chain_specs():
+                if not self._ensure_rule(
+                        self,
+                        f"iptables -C {hook} {iface_flag} {br_name} -j {chain}",
+                        f"iptables -D {hook} {iface_flag} {br_name} -j {chain}",
+                        present=False):
+                    return False
+                # a chain must be empty before it can be deleted; both fail
+                # harmlessly when the chain was never created
+                self.virsh.execute_shell(f"iptables -F {chain}", warn=True)
+                self.virsh.execute_shell(f"iptables -X {chain}", warn=True)
+
+            self._remove_legacy_isolation_rules(br_name)
 
             self.logger.info(f"successfully removed isolation rules for routed network {self.name}")
             return True
@@ -1256,20 +1280,113 @@ class Network:
             self.logger.error(f"error removing route isolation rules: {exc}")
             return False
 
+    def _dhcp_is_declared(self) -> bool:
+        """
+        Whether this network hands out addresses itself.
+
+        Only a network that actually declares ``dhcp:`` needs the exception
+        below. One without it keeps the unconditional host<->guest block that
+        ``mode: route`` has always had, so this stays additive: nobody relying
+        on "routed means the guest cannot reach the host at all" is affected.
+        """
+        return bool((self.dhcp_range_start and self.dhcp_range_end)
+                    or self.dhcp_hosts)
+
+    def _isolation_chain_specs(self) -> list[tuple[str, str, str, int]]:
+        """
+        ``(chain, hook, iface_flag, dhcp_port)`` for this network's isolation.
+
+        The rules live in a chain of their own rather than loose in
+        INPUT/OUTPUT so that reconciling is "flush and refill in order"
+        instead of "insert and hope the ordering survived". That matters:
+        ``iptables -I`` pushes to the top, so a DROP re-inserted after an
+        ACCEPT silently ends up above it and re-breaks DHCP.
+
+        The chain name is sanitised rather than shell-quoted -- it is an
+        iptables identifier, not an argument -- and the prefix is kept short
+        because iptables caps chain names at 28 characters while an interface
+        name may be up to 15.
+        """
+        safe_bridge = re.sub(r'[^A-Za-z0-9_]', '_', self.bridge_name or '')
+        return [
+            (f"BXM_ISO_I_{safe_bridge}", 'INPUT', '-i', 67),
+            (f"BXM_ISO_O_{safe_bridge}", 'OUTPUT', '-o', 68),
+        ]
+
+    def _isolation_is_intact(self) -> bool:
+        """
+        Whether both isolation chains are still hooked into INPUT/OUTPUT.
+
+        These rules are in-memory host state, so a reboot or a manual flush
+        drops them while libvirt happily autostarts the network again. Used
+        to tell "already fine" from "was unprotected and has been repaired",
+        because the second case is worth telling the operator about.
+        """
+        bridge_name = shlex.quote(self.bridge_name)
+        for chain, hook, iface_flag, _port in self._isolation_chain_specs():
+            probe = self.virsh.execute_shell(
+                f"iptables -C {hook} {iface_flag} {bridge_name} -j {chain}",
+                warn=True)
+            if probe.return_code != 0:
+                return False
+        return True
+
+    def reconcile_isolation(self, check_only: bool = False) -> str:
+        """
+        Re-assert this network's isolation, reporting whether it had drifted.
+
+        Returns one of ``skipped`` (not a routed network), ``ok`` (rules were
+        already in place), ``drifted`` (missing, and *check_only* asked us not
+        to touch them), ``repaired`` or ``failed``.
+        """
+        if self.forward_mode != 'route':
+            return 'skipped'
+        if not self.bridge_name:
+            # No bridge usually means the network is not defined at all -- a
+            # define that failed earlier, say. That is already reported by
+            # whatever failed; calling it an isolation failure here only adds
+            # a misleading second error to an existing one.
+            if self.name not in (self.list_networks(
+                    provider_config=self.provider_config) or []):
+                self.logger.debug(
+                    f"network {self.name}: not defined, nothing to isolate")
+                return 'absent'
+            self.logger.warning(
+                f"network {self.name}: no bridge name, cannot check isolation")
+            return 'failed'
+
+        intact = self._isolation_is_intact()
+        if check_only:
+            return 'ok' if intact else 'drifted'
+        if not self.apply_route_iptables_rule():
+            return 'failed'
+        return 'ok' if intact else 'repaired'
+
     def apply_route_iptables_rule(self) -> bool:
         """
         Apply iptables rules for truly isolated routed networks.
 
-        This method configures iptables to:
+        Guests on the bridge may talk to each other; host and guests may not
+        talk at all -- except for DHCP, when the network declares a ``dhcp:``
+        block of its own. That exception is required rather than optional:
+        DHCP terminates *on the host* (libvirt runs dnsmasq bound to the
+        bridge address), so it travels INPUT and OUTPUT, exactly the chains
+        this isolates. Without the hole a routed network can never hand out
+        the addresses it advertises.
 
-            - allow vm-to-vm communication on the same bridge
-            - block all traffic between host and guests in both directions
+        Idempotent, and safe to run repeatedly -- it is the reconcile path as
+        well as the create path.
 
         Returns:
             True if successful, False otherwise
         """
         if self.forward_mode != 'route':
             return True  # Nothing to do for non-route networks
+
+        if not self.bridge_name:
+            self.logger.error(
+                f"network {self.name}: no bridge name, cannot isolate")
+            return False
 
         try:
             # shlex.quote: the bridge name comes from the config and is
@@ -1286,17 +1403,42 @@ class Network:
             if not self._ensure_rule(self, vm2vm_check, vm2vm_cmd):
                 return False
 
-            # 2. block all traffic from the VMs to the host
-            host2vm_check = f"iptables -C INPUT -i {bridge_name} -j DROP"
-            host2vm_cmd   = f"iptables -I INPUT -i {bridge_name} -j DROP"
-            if not self._ensure_rule(self, host2vm_check, host2vm_cmd):
-                return False
+            # 2. host<->guest block, held in a chain per direction
+            for chain, hook, iface_flag, dhcp_port in self._isolation_chain_specs():
+                # -N fails harmlessly when the chain is already there
+                self.virsh.execute_shell(f"iptables -N {chain}", warn=True)
 
-            # 3. block all traffic from host to the VMs
-            vm2host_check = f"iptables -C OUTPUT -o {bridge_name} -j DROP"
-            vm2host_cmd   = f"iptables -I OUTPUT -o {bridge_name} -j DROP"
-            if not self._ensure_rule(self, vm2host_check, vm2host_cmd):
-                return False
+                # flush and refill: the contents are declarative, so drift in
+                # ordering or leftovers from an older boxman cannot survive
+                if not self.virsh.execute_shell(
+                        f"iptables -F {chain}", warn=True).ok:
+                    self.logger.error(f"could not flush {chain}")
+                    return False
+
+                if self._dhcp_is_declared():
+                    accept = self.virsh.execute_shell(
+                        f"iptables -A {chain} -p udp --dport {dhcp_port} "
+                        f"-j ACCEPT", warn=True)
+                    if not accept.ok:
+                        self.logger.error(
+                            f"could not add the dhcp exception to {chain}")
+                        return False
+
+                if not self.virsh.execute_shell(
+                        f"iptables -A {chain} -j DROP", warn=True).ok:
+                    self.logger.error(f"could not add the drop rule to {chain}")
+                    return False
+
+                if not self._ensure_rule(
+                        self,
+                        f"iptables -C {hook} {iface_flag} {bridge_name} -j {chain}",
+                        f"iptables -I {hook} {iface_flag} {bridge_name} -j {chain}"):
+                    return False
+
+            # 3. drop the loose rules older boxman versions inserted straight
+            # into INPUT/OUTPUT. Left behind they are dead weight at best and,
+            # if one ever lands above the jump, an unreachable-DHCP bug again
+            self._remove_legacy_isolation_rules(bridge_name)
 
             self.logger.info(f"successfully applied complete isolation for routed network {self.name}")
             return True
@@ -1304,6 +1446,25 @@ class Network:
         except Exception as exc:
             self.logger.error(f"error applying route isolation rules: {exc}")
             return False
+
+    def _remove_legacy_isolation_rules(self, bridge_name: str) -> None:
+        """
+        Delete the pre-chain isolation rules, if this host still carries them.
+
+        Best-effort: a host that never ran an older boxman simply has nothing
+        to delete, and ``-C`` failing is the normal case rather than an error.
+        """
+        legacy = [
+            f"INPUT -i {bridge_name} -j DROP",
+            f"OUTPUT -o {bridge_name} -j DROP",
+            f"INPUT -i {bridge_name} -p udp --dport 67 -j ACCEPT",
+            f"OUTPUT -o {bridge_name} -p udp --dport 68 -j ACCEPT",
+        ]
+        for spec in legacy:
+            self._ensure_rule(self,
+                              f"iptables -C {spec}",
+                              f"iptables -D {spec}",
+                              present=False)
 
     @staticmethod
     def get_bridge_from_network(network_name: str,

--- a/src/boxman/providers/libvirt/net.py
+++ b/src/boxman/providers/libvirt/net.py
@@ -1261,16 +1261,35 @@ class Network:
                 return False
 
             for chain, hook, iface_flag, _port in self._isolation_chain_specs():
-                if not self._ensure_rule(
-                        self,
-                        f"iptables -C {hook} {iface_flag} {br_name} -j {chain}",
-                        f"iptables -D {hook} {iface_flag} {br_name} -j {chain}",
-                        present=False):
+                # -D removes ONE match, so a duplicated jump would survive and
+                # keep the chain referenced, making -X fail. Loop until the
+                # hook is genuinely gone; bounded so a persistently failing
+                # delete cannot spin forever.
+                check = f"iptables -C {hook} {iface_flag} {br_name} -j {chain}"
+                for _ in range(16):
+                    if self.virsh.execute_shell(
+                            check, warn=True).return_code != 0:
+                        break
+                    if not self.virsh.execute_shell(
+                            f"iptables -D {hook} {iface_flag} {br_name} "
+                            f"-j {chain}", warn=True).ok:
+                        break
+                if self.virsh.execute_shell(check, warn=True).return_code == 0:
+                    self.logger.error(
+                        f"could not unhook {chain} from {hook}")
                     return False
-                # a chain must be empty before it can be deleted; both fail
-                # harmlessly when the chain was never created
-                self.virsh.execute_shell(f"iptables -F {chain}", warn=True)
-                self.virsh.execute_shell(f"iptables -X {chain}", warn=True)
+
+                # nothing to flush or delete if the chain was never created
+                if self._chain_rules(chain) is None:
+                    continue
+                if not self.virsh.execute_shell(
+                        f"iptables -F {chain}", warn=True).ok:
+                    self.logger.error(f"could not flush {chain}")
+                    return False
+                if not self.virsh.execute_shell(
+                        f"iptables -X {chain}", warn=True).ok:
+                    self.logger.error(f"could not delete {chain}")
+                    return False
 
             self._remove_legacy_isolation_rules(br_name)
 
@@ -1313,21 +1332,77 @@ class Network:
             (f"BXM_ISO_O_{safe_bridge}", 'OUTPUT', '-o', 68),
         ]
 
+    def _dhcp_offer_is_trimmed(self) -> bool:
+        """
+        Whether the *live* network suppresses dhcp options 3 and 6.
+
+        Opening the firewall for DHCP is only safe once dnsmasq has stopped
+        advertising the bridge as router and resolver, because both are
+        unreachable behind the isolation and the router option installs a
+        default route at metric 0 that black-holes the guest's traffic.
+
+        A network defined before that template change plans as ``action:
+        none`` -- ``parse_network_xml`` does not model these options -- so it
+        would otherwise keep the old offer while this code opened the hole,
+        producing exactly the breakage the trimming exists to prevent. Read
+        the live definition rather than assuming it matches the template.
+        """
+        dump = self.virsh.execute(
+            "net-dumpxml", self.name, hide=True, warn=True)
+        if not dump.ok or not dump.stdout:
+            return False
+        return "dhcp-option=3" in dump.stdout and "dhcp-option=6" in dump.stdout
+
+    def _dhcp_hole_wanted(self) -> bool:
+        """Whether this run should punch the DHCP exception."""
+        if not self._dhcp_is_declared():
+            return False
+        if not self._dhcp_offer_is_trimmed():
+            self.logger.warning(
+                f"network {self.name}: keeping DHCP blocked because the live "
+                f"definition still advertises a router and DNS server that "
+                f"this network's isolation makes unreachable. Recreate the "
+                f"network (boxman up --recreate-networks) to pick up the "
+                f"trimmed offer, after which DHCP will be allowed.")
+            return False
+        return True
+
+    def _chain_rules(self, chain: str) -> list[str] | None:
+        """``iptables -S`` for *chain*, or None when it does not exist."""
+        listed = self.virsh.execute_shell(f"iptables -S {chain}", warn=True)
+        if not listed.ok:
+            return None
+        return [line.strip() for line in (listed.stdout or "").splitlines()
+                if line.strip().startswith("-A ")]
+
     def _isolation_is_intact(self) -> bool:
         """
-        Whether both isolation chains are still hooked into INPUT/OUTPUT.
+        Whether the isolation is both hooked *and* correct.
 
-        These rules are in-memory host state, so a reboot or a manual flush
-        drops them while libvirt happily autostarts the network again. Used
-        to tell "already fine" from "was unprotected and has been repaired",
-        because the second case is worth telling the operator about.
+        Checking only the jump is not enough: a chain that is still hooked but
+        empty, or that lost its terminal DROP, returns from the user chain and
+        the traffic is no longer isolated at all -- while a jump-only probe
+        happily reports everything fine. So verify the contents too: a
+        terminal DROP, and the DHCP exception above it exactly when this run
+        would install one.
         """
         bridge_name = shlex.quote(self.bridge_name)
-        for chain, hook, iface_flag, _port in self._isolation_chain_specs():
+        want_hole = self._dhcp_hole_wanted()
+        for chain, hook, iface_flag, port in self._isolation_chain_specs():
             probe = self.virsh.execute_shell(
                 f"iptables -C {hook} {iface_flag} {bridge_name} -j {chain}",
                 warn=True)
             if probe.return_code != 0:
+                return False
+
+            rules = self._chain_rules(chain)
+            if not rules:
+                return False
+            if not rules[-1].endswith("-j DROP"):
+                return False
+            has_hole = any(f"--dport {port}" in rule and rule.endswith("-j ACCEPT")
+                           for rule in rules[:-1])
+            if has_hole != want_hole:
                 return False
         return True
 
@@ -1335,9 +1410,16 @@ class Network:
         """
         Re-assert this network's isolation, reporting whether it had drifted.
 
-        Returns one of ``skipped`` (not a routed network), ``ok`` (rules were
-        already in place), ``drifted`` (missing, and *check_only* asked us not
-        to touch them), ``repaired`` or ``failed``.
+        Returns one of:
+
+        ``skipped``  not a routed network, nothing to isolate
+        ``absent``   the network is not defined, so there is nothing to
+                     isolate and its own failure is reported elsewhere
+        ``ok``       rules were already in place and correct
+        ``drifted``  rules were missing or wrong and *check_only* asked us
+                     not to touch them
+        ``repaired`` rules were missing or wrong and have been re-applied
+        ``failed``   the rules could not be applied
         """
         if self.forward_mode != 'route':
             return 'skipped'
@@ -1415,7 +1497,7 @@ class Network:
                     self.logger.error(f"could not flush {chain}")
                     return False
 
-                if self._dhcp_is_declared():
+                if self._dhcp_hole_wanted():
                     accept = self.virsh.execute_shell(
                         f"iptables -A {chain} -p udp --dport {dhcp_port} "
                         f"-j ACCEPT", warn=True)

--- a/src/boxman/providers/libvirt/net.py
+++ b/src/boxman/providers/libvirt/net.py
@@ -1361,9 +1361,10 @@ class Network:
             self.logger.warning(
                 f"network {self.name}: keeping DHCP blocked because the live "
                 f"definition still advertises a router and DNS server that "
-                f"this network's isolation makes unreachable. Recreate the "
-                f"network (boxman up --recreate-networks) to pick up the "
-                f"trimmed offer, after which DHCP will be allowed.")
+                f"this network's isolation makes unreachable. Reconcile plans "
+                f"this as a structural change, so `boxman up "
+                f"--recreate-networks` will migrate it; DHCP is allowed once "
+                f"it has.")
             return False
         return True
 
@@ -1374,6 +1375,26 @@ class Network:
             return None
         return [line.strip() for line in (listed.stdout or "").splitlines()
                 if line.strip().startswith("-A ")]
+
+    @staticmethod
+    def _rule_body(rule: str) -> list[str]:
+        """
+        A rule reduced to what it *does*, for exact comparison.
+
+        Drops the leading ``-A <chain>`` and the ``-m <module>`` pairs iptables
+        inserts when echoing a rule back, so ``-p udp -m udp --dport 67 -j
+        ACCEPT`` compares equal to the ``-p udp --dport 67 -j ACCEPT`` that was
+        written.
+        """
+        tokens = rule.split()[2:]
+        body, index = [], 0
+        while index < len(tokens):
+            if tokens[index] == '-m':
+                index += 2
+                continue
+            body.append(tokens[index])
+            index += 1
+        return body
 
     def _isolation_is_intact(self) -> bool:
         """
@@ -1396,14 +1417,26 @@ class Network:
                 return False
 
             rules = self._chain_rules(chain)
-            if not rules:
+            if rules is None:
                 return False
-            if not rules[-1].endswith("-j DROP"):
+
+            # Compare against the exact rule list this run would install.
+            # Extras matter as much as omissions: a broad `-j ACCEPT` above
+            # the drop satisfies any "ends with a DROP, has the right hole"
+            # check while isolating precisely nothing. The terminal DROP is
+            # required to be unconditional for the same reason -- one carrying
+            # match criteria only drops some traffic.
+            wanted = []
+            if want_hole:
+                wanted.append(
+                    ['-p', 'udp', '--dport', str(port), '-j', 'ACCEPT'])
+            wanted.append(['-j', 'DROP'])
+
+            if len(rules) != len(wanted):
                 return False
-            has_hole = any(f"--dport {port}" in rule and rule.endswith("-j ACCEPT")
-                           for rule in rules[:-1])
-            if has_hole != want_hole:
-                return False
+            for expected, rule in zip(wanted, rules, strict=True):
+                if self._rule_body(rule) != expected:
+                    return False
         return True
 
     def reconcile_isolation(self, check_only: bool = False) -> str:

--- a/src/boxman/providers/libvirt/net_reconcile.py
+++ b/src/boxman/providers/libvirt/net_reconcile.py
@@ -36,7 +36,27 @@ STRUCTURAL_FIELDS = (
     ('bridge_stp', 'bridge stp'),
     ('bridge_delay', 'bridge delay'),
     ('mac', 'mac address'),
+    # libvirt cannot change dnsmasq options on a live network, and leaving
+    # them unmodelled meant a network defined before they existed planned as
+    # `action: none` -- so it could never be migrated, not even with
+    # --recreate-networks, which only permits an already-planned recreate
+    ('dhcp_options_trimmed', 'dhcp router/dns suppression'),
 )
+
+
+def _dhcp_options_trimmed(root) -> bool:
+    """
+    Whether the network tells dnsmasq to omit DHCP options 3 and 6.
+
+    A routed network isolates the host, so the gateway and resolver dnsmasq
+    would otherwise advertise -- both the bridge address -- are unreachable by
+    construction, and the router option installs a default route at metric 0
+    that black-holes the guest. The elements are namespaced, hence matching on
+    the local name rather than a fixed prefix.
+    """
+    values = {element.get('value') for element in root.iter()
+              if element.tag.rsplit('}', 1)[-1] == 'option'}
+    return 'dhcp-option=3' in values and 'dhcp-option=6' in values
 
 
 def parse_network_xml(xml_text: str) -> dict[str, Any]:
@@ -68,6 +88,7 @@ def parse_network_xml(xml_text: str) -> dict[str, Any]:
         'netmask': None,
         'dhcp_range': None,
         'dhcp_hosts': [],
+        'dhcp_options_trimmed': _dhcp_options_trimmed(root),
     }
 
     if ip is None:
@@ -126,6 +147,7 @@ def desired_state(network) -> dict[str, Any]:
             'netmask': None,
             'dhcp_range': None,
             'dhcp_hosts': [],
+            'dhcp_options_trimmed': False,
         }
 
     dhcp_range = None
@@ -146,6 +168,11 @@ def desired_state(network) -> dict[str, Any]:
         'netmask': network.netmask,
         'dhcp_range': dhcp_range,
         'dhcp_hosts': list(network.dhcp_hosts),
+        # mirrors the template: emitted only for a routed network that hands
+        # out addresses of its own
+        'dhcp_options_trimmed': bool(
+            network.forward_mode == 'route'
+            and (dhcp_range or network.dhcp_hosts)),
     }
 
 

--- a/src/boxman/providers/libvirt/session.py
+++ b/src/boxman/providers/libvirt/session.py
@@ -399,6 +399,28 @@ class LibVirtSession(SessionConfigMixin):
             manager=self.manager)
         return network.start()
 
+    def reconcile_network_isolation(self,
+                                    name: str = None,
+                                    info: dict[str, Any] | None = None,
+                                    check_only: bool = False) -> str:
+        """
+        Re-assert the host isolation of a routed network.
+
+        The rules are in-memory iptables state, so a host reboot or a manual
+        flush drops them while libvirt autostarts the network again -- the
+        network then comes back up unprotected and stays that way until
+        something re-applies them. Nothing did, before this.
+
+        Returns ``skipped``, ``ok``, ``drifted``, ``repaired`` or ``failed``.
+        """
+        network = Network(
+            name=name,
+            info=info,
+            provider_config=self.provider_config,
+            assign_new_bridge=False,
+            manager=self.manager)
+        return network.reconcile_isolation(check_only=check_only)
+
     def apply_network_live_plan(self,
                                 name: str = None,
                                 info: dict[str, Any] | None = None,

--- a/tests/test_libvirt_destroy_vm.py
+++ b/tests/test_libvirt_destroy_vm.py
@@ -221,7 +221,11 @@ class TestForceUndefine:
             assert dv.force_undefine_vm() is True
         undefines = [args for args, _ in calls if args[0] == "undefine"]
         assert len(undefines) == 2
-        assert undefines[1] == ("undefine", "vm01", "--snapshots-metadata")
+        # --managed-save rides along on the fallback too: libvirt refuses to
+        # undefine a domain that has a managed save image, which is exactly
+        # the state a suspended or memory-snapshotted VM is left in
+        assert undefines[1] == ("undefine", "vm01", "--snapshots-metadata",
+                                "--managed-save")
         # rich form ran with warn=True so its failure could be handled
         rich_kwargs = [kw for args, kw in calls
                        if args[0] == "undefine"
@@ -291,3 +295,51 @@ class TestRemove:
         assert not any(c.startswith("snapshot-delete") for c in commands)
         assert any("--snapshots-metadata" in c.args
                    for c in execute.call_args_list)
+
+
+class TestManagedSaveBlocksUndefine:
+    """A managed save image makes libvirt refuse to undefine.
+
+    boxman creates managed save images itself (suspend, and snapshots taken
+    with memory state), so any VM that was ever suspended or snapshotted
+    survived `destroy` -- while destroy still reported success. Observed as:
+    `error: Refusing to undefine while domain managed save image exists`.
+    """
+
+    def test_force_undefine_passes_managed_save(self, dv: DestroyVM):
+        with patch.object(dv, "is_vm_defined", side_effect=[True, False]), \
+             patch.object(dv, "is_vm_shut_off", return_value=True), \
+             patch.object(dv.virsh, "execute",
+                          return_value=_result()) as execute:
+            assert dv.force_undefine_vm() is True
+        args = execute.call_args_list[0].args
+        assert "--managed-save" in args
+
+    def test_plain_undefine_passes_managed_save(self, dv: DestroyVM):
+        with patch.object(dv, "is_vm_defined", side_effect=[True, False]), \
+             patch.object(dv.virsh, "execute", return_value=_result()) as execute:
+            assert dv.undefine_vm() is True
+        assert "--managed-save" in execute.call_args_list[0].args
+
+    def test_fallback_also_clears_the_managed_save(self, dv: DestroyVM):
+        # the storage-removal form is not idempotent, so the fallback is the
+        # path a real destroy usually takes -- it needs the flag too
+        with patch.object(dv, "is_vm_defined", side_effect=[True, False]), \
+             patch.object(dv, "is_vm_shut_off", return_value=True), \
+             patch.object(
+                 dv.virsh, "execute",
+                 side_effect=[_result(ok=False, stderr="not managed by libvirt"),
+                              _result()]) as execute:
+            assert dv.force_undefine_vm() is True
+        assert "--managed-save" in execute.call_args_list[1].args
+
+    def test_a_failing_fallback_is_reported_not_swallowed(self, dv: DestroyVM):
+        # destroy used to exit 0 while leaving the domain defined; the whole
+        # point is that this surfaces
+        with patch.object(dv, "is_vm_defined", return_value=True), \
+             patch.object(dv, "is_vm_shut_off", return_value=True), \
+             patch.object(
+                 dv.virsh, "execute",
+                 side_effect=[_result(ok=False, stderr="storage gone"),
+                              _result(ok=False, stderr="still refusing")]):
+            assert dv.force_undefine_vm() is False

--- a/tests/test_libvirt_net.py
+++ b/tests/test_libvirt_net.py
@@ -1171,6 +1171,15 @@ class TestRoutedDhcpOptionTrimming:
         assert sorted(self._options(xml)) == ['dhcp-option=3', 'dhcp-option=6']
 
 
+TRIMMED_XML = (
+    "<network><dnsmasq:options>"
+    "<dnsmasq:option value='dhcp-option=3'/>"
+    "<dnsmasq:option value='dhcp-option=6'/>"
+    "</dnsmasq:options></network>"
+)
+UNTRIMMED_XML = "<network><forward mode='route'/></network>"
+
+
 class TestRouteIsolationChains:
     """Routed-network isolation lives in a chain per direction.
 
@@ -1195,22 +1204,34 @@ class TestRouteIsolationChains:
                        provider_config={"use_sudo": use_sudo})
 
     @staticmethod
-    def _record(net: Network, rules_present: bool = False):
-        """Stub execute_shell: `-C` probes report absent unless told otherwise."""
+    def _record(net: Network, rules_present: bool = False,
+                trimmed: bool = True, chain_rules: list | None = None):
+        """Stub both executors and record every iptables command."""
         calls: list[str] = []
 
-        def run(command, *_args, **_kwargs):
+        def shell(command, *_args, **_kwargs):
             calls.append(command)
+            if command.startswith("iptables -S "):
+                if chain_rules is None:
+                    return _result(ok=False, return_code=1)
+                return _result(stdout="\n".join(chain_rules))
             if " -C " in f" {command} ":
                 return _result(ok=rules_present,
                                return_code=0 if rules_present else 1)
             return _result(ok=True, return_code=0)
 
-        net.virsh.execute_shell = MagicMock(side_effect=run)
+        def execute(cmd, *_args, **_kwargs):
+            if cmd == "net-dumpxml":
+                return _result(
+                    stdout=TRIMMED_XML if trimmed else UNTRIMMED_XML)
+            return _result()
+
+        net.virsh.execute_shell = MagicMock(side_effect=shell)
+        net.virsh.execute = MagicMock(side_effect=execute)
         return calls
 
-    def _apply(self, net: Network, rules_present: bool = False) -> list[str]:
-        calls = self._record(net, rules_present)
+    def _apply(self, net: Network, **kwargs) -> list[str]:
+        calls = self._record(net, **kwargs)
         assert net.apply_route_iptables_rule() is True
         return calls
 
@@ -1223,8 +1244,6 @@ class TestRouteIsolationChains:
             assert f"iptables -I {hook} {flag} virbr9 -j {chain}" in calls
 
     def test_accept_is_filled_before_drop(self):
-        # inside a chain the rules are appended, so this ordering is the whole
-        # point: an ACCEPT after the DROP would never be reached
         calls = self._apply(self._net())
         accept = calls.index("iptables -A BXM_ISO_I_virbr9 -p udp --dport 67 -j ACCEPT")
         drop = calls.index("iptables -A BXM_ISO_I_virbr9 -j DROP")
@@ -1236,18 +1255,23 @@ class TestRouteIsolationChains:
         assert "iptables -A BXM_ISO_O_virbr9 -p udp --dport 68 -j ACCEPT" in calls
 
     def test_no_dhcp_hole_without_a_dhcp_block(self):
-        # a routed network that hands out nothing keeps the unconditional
-        # host<->guest block it has always had, so this stays additive
         calls = self._apply(self._net(with_dhcp=False))
-        # the chain is filled with the DROP alone. (Legacy `-D ... --dport`
-        # cleanup commands may still appear -- those remove an exception, they
-        # do not add one.)
+        assert not any(c.startswith("iptables -A") and "--dport" in c
+                       for c in calls)
+        assert "iptables -A BXM_ISO_I_virbr9 -j DROP" in calls
+
+    def test_hole_stays_shut_until_the_live_offer_is_trimmed(self):
+        # an upgrade must not open DHCP on a network whose dnsmasq still
+        # advertises the bridge as router and DNS: the resulting lease
+        # installs a metric-0 default route to an unreachable gateway and
+        # black-holes the guest. Such a network plans as `action: none`, so
+        # nothing else would stop this.
+        calls = self._apply(self._net(), trimmed=False)
         assert not any(c.startswith("iptables -A") and "--dport" in c
                        for c in calls)
         assert "iptables -A BXM_ISO_I_virbr9 -j DROP" in calls
 
     def test_reservations_alone_also_open_the_hole(self):
-        # `dhcp: hosts` with no range is valid libvirt -- every guest pinned
         info = {
             "mode": "route", "bridge": {"name": "virbr9"},
             "ip": {"address": "10.0.14.1", "netmask": "255.255.255.0",
@@ -1263,25 +1287,64 @@ class TestRouteIsolationChains:
         assert ("iptables -I FORWARD -i virbr9 -o virbr9 -j ACCEPT") in calls
 
     def test_legacy_loose_rules_are_migrated_away(self):
-        # hosts provisioned by an older boxman still carry the pre-chain
-        # rules; left in place they are dead weight at best
         calls = self._apply(self._net(), rules_present=True)
         assert "iptables -D INPUT -i virbr9 -j DROP" in calls
         assert "iptables -D OUTPUT -o virbr9 -j DROP" in calls
 
     def test_removal_unhooks_flushes_and_deletes(self):
         net = self._net()
-        calls = self._record(net, rules_present=True)
+        calls = self._record(net, rules_present=False,
+                             chain_rules=["-A BXM_ISO_I_virbr9 -j DROP"])
         assert net.remove_route_iptables_rule() is True
-        for chain, hook, flag in (("BXM_ISO_I_virbr9", "INPUT", "-i"),
-                                  ("BXM_ISO_O_virbr9", "OUTPUT", "-o")):
-            assert f"iptables -D {hook} {flag} virbr9 -j {chain}" in calls
+        for chain in ("BXM_ISO_I_virbr9", "BXM_ISO_O_virbr9"):
             assert f"iptables -F {chain}" in calls
             assert f"iptables -X {chain}" in calls
 
+    def test_removal_deletes_every_duplicate_hook(self):
+        # -D removes ONE match; a duplicated jump would keep the chain
+        # referenced and make -X fail, while teardown still reported success
+        net = self._net()
+        seen: list[str] = []
+        remaining = {"INPUT": 3, "OUTPUT": 1}
+
+        def shell(command, *_a, **_k):
+            seen.append(command)
+            if command.startswith("iptables -S "):
+                return _result(stdout="-A chain -j DROP")
+            for hook in remaining:
+                if f" -C {hook} " in command and "BXM_ISO" in command:
+                    return _result(ok=remaining[hook] > 0,
+                                   return_code=0 if remaining[hook] > 0 else 1)
+                if f" -D {hook} " in command and "BXM_ISO" in command:
+                    remaining[hook] -= 1
+                    return _result(ok=True, return_code=0)
+            if " -C " in f" {command} ":
+                return _result(ok=False, return_code=1)
+            return _result(ok=True, return_code=0)
+
+        net.virsh.execute_shell = MagicMock(side_effect=shell)
+        net.virsh.execute = MagicMock(return_value=_result(stdout=TRIMMED_XML))
+        assert net.remove_route_iptables_rule() is True
+        assert remaining == {"INPUT": 0, "OUTPUT": 0}
+
+    def test_removal_fails_loudly_when_the_chain_cannot_be_deleted(self):
+        net = self._net()
+
+        def shell(command, *_a, **_k):
+            if command.startswith("iptables -S "):
+                return _result(stdout="-A BXM_ISO_I_virbr9 -j DROP")
+            if command.startswith("iptables -X "):
+                return _result(ok=False, return_code=1,
+                               stderr="chain is still referenced")
+            if " -C " in f" {command} ":
+                return _result(ok=False, return_code=1)
+            return _result(ok=True, return_code=0)
+
+        net.virsh.execute_shell = MagicMock(side_effect=shell)
+        net.virsh.execute = MagicMock(return_value=_result(stdout=TRIMMED_XML))
+        assert net.remove_route_iptables_rule() is False
+
     def test_chain_name_is_sanitised_not_quoted(self):
-        # the chain name is an iptables identifier, not an argument, so it is
-        # sanitised; the bridge name in the match IS quoted
         net = self._net(bridge_name="br-a.b")
         calls = self._apply(net)
         assert any("BXM_ISO_I_br_a_b" in c for c in calls)
@@ -1296,8 +1359,6 @@ class TestRouteIsolationChains:
             assert "'virbr 9;touch /tmp/x'" in cmd
 
     def test_a_plain_bridge_name_is_left_unquoted(self):
-        # shlex.quote leaves a shell-safe name untouched, so existing command
-        # strings stay byte-identical
         calls = self._apply(self._net())
         assert not any("'" in c for c in calls)
 
@@ -1312,6 +1373,72 @@ class TestRouteIsolationChains:
                    return_value=_result()) as run:
             net.virsh.execute_shell("iptables -C INPUT -i virbr9 -j DROP", warn=True)
         assert run.call_args.args[0].startswith(expected_prefix)
+
+
+class TestIsolationContentsAreChecked:
+    """A hooked chain is not necessarily an isolating one.
+
+    A chain that is still jumped to but empty, or that lost its terminal
+    DROP, returns from the user chain and stops isolating anything -- while a
+    jump-only probe reports everything fine and a reconcile returns 'ok'
+    instead of 'repaired', hiding the exposure.
+    """
+
+    @staticmethod
+    def _net(with_dhcp: bool = True) -> Network:
+        info: dict = {"mode": "route", "bridge": {"name": "virbr9"}}
+        if with_dhcp:
+            info["ip"] = {"address": "10.0.14.1", "netmask": "255.255.255.0",
+                          "dhcp": {"range": {"start": "10.0.14.2",
+                                             "end": "10.0.14.254"}}}
+        return Network("routed-net", info, assign_new_bridge=True,
+                       provider_config={"use_sudo": False})
+
+    @staticmethod
+    def _probe(net: Network, chain_rules: list, trimmed: bool = True):
+        def shell(command, *_a, **_k):
+            if command.startswith("iptables -S "):
+                chain = command.split()[-1]
+                port = 67 if chain.startswith("BXM_ISO_I_") else 68
+                rules = [r.replace("CHAIN", chain).replace("PORT", str(port))
+                         for r in chain_rules]
+                return _result(stdout="\n".join(rules))
+            if " -C " in f" {command} ":
+                return _result(ok=True, return_code=0)   # jump present
+            return _result(ok=True, return_code=0)
+        net.virsh.execute_shell = MagicMock(side_effect=shell)
+        net.virsh.execute = MagicMock(return_value=_result(
+            stdout=TRIMMED_XML if trimmed else UNTRIMMED_XML))
+        return net._isolation_is_intact()
+
+    def test_correct_contents_are_intact(self):
+        assert self._probe(self._net(), [
+            "-A CHAIN -p udp -m udp --dport PORT -j ACCEPT",
+            "-A CHAIN -j DROP"]) is True
+
+    def test_empty_chain_is_not_intact(self):
+        # hooked but empty: traffic returns from the user chain unfiltered
+        assert self._probe(self._net(), []) is False
+
+    def test_missing_terminal_drop_is_not_intact(self):
+        assert self._probe(self._net(), [
+            "-A CHAIN -p udp -m udp --dport PORT -j ACCEPT"]) is False
+
+    def test_unexpected_dhcp_hole_is_not_intact(self):
+        # no dhcp declared, so an ACCEPT here is drift, not correctness
+        assert self._probe(self._net(with_dhcp=False), [
+            "-A CHAIN -p udp -m udp --dport PORT -j ACCEPT",
+            "-A CHAIN -j DROP"]) is False
+
+    def test_missing_expected_hole_is_not_intact(self):
+        assert self._probe(self._net(), [
+            "-A CHAIN -j DROP"]) is False
+
+    def test_untrimmed_offer_expects_no_hole(self):
+        # while the live offer is untrimmed the hole must NOT be present,
+        # so a drop-only chain is the correct state
+        assert self._probe(self._net(), [
+            "-A CHAIN -j DROP"], trimmed=False) is True
 
 
 class TestRouteIsolationDrift:
@@ -1329,10 +1456,13 @@ class TestRouteIsolationDrift:
                        assign_new_bridge=True,
                        provider_config={"use_sudo": False})
 
-    def test_intact_when_both_jumps_are_present(self):
+    def test_a_present_jump_alone_is_not_enough(self):
+        # the jump can be there while the chain is empty, which isolates
+        # nothing; contents are checked in TestIsolationContentsAreChecked
         net = self._net()
         net.virsh.execute_shell = MagicMock(return_value=_result(return_code=0))
-        assert net._isolation_is_intact() is True
+        net.virsh.execute = MagicMock(return_value=_result(stdout=""))
+        assert net._isolation_is_intact() is False
 
     def test_not_intact_when_a_jump_is_missing(self):
         net = self._net()

--- a/tests/test_libvirt_net.py
+++ b/tests/test_libvirt_net.py
@@ -1434,6 +1434,37 @@ class TestIsolationContentsAreChecked:
         assert self._probe(self._net(), [
             "-A CHAIN -j DROP"]) is False
 
+    def test_a_broad_accept_is_not_intact(self):
+        # the case a "terminal DROP plus the right hole" check waves through:
+        # everything is accepted before either rule is reached
+        assert self._probe(self._net(), [
+            "-A CHAIN -j ACCEPT",
+            "-A CHAIN -p udp -m udp --dport PORT -j ACCEPT",
+            "-A CHAIN -j DROP"]) is False
+
+    def test_an_extra_rule_after_the_drop_is_not_intact(self):
+        assert self._probe(self._net(), [
+            "-A CHAIN -p udp -m udp --dport PORT -j ACCEPT",
+            "-A CHAIN -j DROP",
+            "-A CHAIN -j ACCEPT"]) is False
+
+    def test_a_conditional_drop_is_not_intact(self):
+        # a DROP carrying match criteria only drops some traffic
+        assert self._probe(self._net(with_dhcp=False), [
+            "-A CHAIN -p tcp -m tcp --dport 22 -j DROP"]) is False
+
+    def test_a_hole_on_the_wrong_port_is_not_intact(self):
+        assert self._probe(self._net(), [
+            "-A CHAIN -p udp -m udp --dport 9999 -j ACCEPT",
+            "-A CHAIN -j DROP"]) is False
+
+    def test_match_modules_are_normalised_not_compared(self):
+        # iptables echoes back `-m udp` that was never written; that must not
+        # read as drift
+        assert self._probe(self._net(), [
+            "-A CHAIN -p udp -m udp --dport PORT -j ACCEPT",
+            "-A CHAIN -j DROP"]) is True
+
     def test_untrimmed_offer_expects_no_hole(self):
         # while the live offer is untrimmed the hole must NOT be present,
         # so a drop-only chain is the correct state

--- a/tests/test_libvirt_net.py
+++ b/tests/test_libvirt_net.py
@@ -293,6 +293,28 @@ class TestBridgeModeDefinition:
         with pytest.raises(ConfigError, match="could not read administrative state"):
             net.define_network(str(tmp_path / "unknown-bridge.xml"))
 
+    @pytest.mark.parametrize("stdout", [
+        "not-a-number",   # a runtime that answers, but not with the flags
+        "",               # an empty read
+        None,             # no stdout at all on the result object
+    ])
+    def test_unparseable_bridge_flags_are_rejected(self, tmp_path, stdout):
+        # a successful `cat` whose payload is not an integer must fail the
+        # same way an unreadable one does. Guessing "probably up" here would
+        # hand libvirt a bridge that cannot carry traffic
+        net = self._net(tmp_path)
+        net.virsh.execute_shell = MagicMock(side_effect=[
+            _result(),
+            _result(stdout=stdout),
+        ])
+        net.virsh.execute = MagicMock()
+
+        with pytest.raises(ConfigError,
+                           match="could not read administrative state"):
+            net.define_network(str(tmp_path / "bad-flags.xml"))
+
+        net.virsh.execute.assert_not_called()
+
     @pytest.mark.parametrize("uri", [
         "qemu+ssh://hypervisor.example/system",
         "qemu://localhost/system",
@@ -441,6 +463,82 @@ class TestBridgeModeDefinition:
         net.remove_route_iptables_rule.assert_not_called()
 
 
+class TestDefineNetworkRollbackDiagnostics:
+    """A rollback that cannot finish must say so, step by step.
+
+    ``define_network`` unwinds route rules, ``net-destroy`` and
+    ``net-undefine`` when bring-up fails. Each of those can fail in turn,
+    and the warnings are the only place an operator learns which pieces of
+    the half-built network were left on the host — the return value is a
+    bare ``False`` either way.
+    """
+
+    @staticmethod
+    def _routed_net():
+        manager = MagicMock()
+        manager.config = {"project": "p1"}
+        manager._runtime_name = "local"
+        manager.cache.projects = {"p1": {"runtime": "local"}}
+        with patch.object(Network, "find_available_bridge_name",
+                          return_value="virbr9"):
+            net = Network("managed-net", {"mode": "route"},
+                          provider_config={"use_sudo": False}, manager=manager)
+        net._get_libvirt_bridges = MagicMock(return_value=set())
+        net.check_network_exists = MagicMock()
+        net.apply_route_iptables_rule = MagicMock(return_value=True)
+        # bring-up itself succeeds; the cache write is what fails, so the
+        # rollback runs with all three steps armed
+        net.update_network_cache = MagicMock(
+            side_effect=OSError("projects.json is read-only"))
+        net.logger = MagicMock()
+        return net
+
+    def test_failed_rollback_steps_are_each_warned_about(self, tmp_path):
+        net = self._routed_net()
+        net.remove_route_iptables_rule = MagicMock(return_value=False)
+        net.virsh.execute = MagicMock(
+            side_effect=lambda command, *a, **k: _result(
+                ok=command not in ("net-destroy", "net-undefine")))
+
+        assert net.define_network(str(tmp_path / "managed.xml")) is False
+
+        warnings = [c.args[0] for c in net.logger.warning.call_args_list]
+        assert any("could not remove route isolation rules" in w
+                   for w in warnings)
+        assert any("could not stop the partially defined network" in w
+                   for w in warnings)
+        assert any("could not undefine the partially defined network" in w
+                   for w in warnings)
+
+    def test_raising_rollback_steps_report_their_cause(self, tmp_path):
+        # a rollback step that raises must not abort the remaining steps:
+        # failing to drop the iptables rules is no reason to leave the
+        # network defined as well
+        net = self._routed_net()
+        net.remove_route_iptables_rule = MagicMock(
+            side_effect=RuntimeError("iptables lock held"))
+
+        def execute(command, *_args, **_kwargs):
+            if command in ("net-destroy", "net-undefine"):
+                raise RuntimeError(f"{command} refused")
+            return _result()
+
+        net.virsh.execute = MagicMock(side_effect=execute)
+
+        assert net.define_network(str(tmp_path / "managed.xml")) is False
+
+        warnings = [c.args[0] for c in net.logger.warning.call_args_list]
+        assert any("iptables lock held" in w for w in warnings)
+        assert any("net-destroy refused" in w for w in warnings)
+        assert any("net-undefine refused" in w for w in warnings)
+        # every step was still attempted
+        attempted = [c.args[0] for c in net.virsh.execute.call_args_list]
+        assert attempted == [
+            "net-define", "net-start", "net-autostart",
+            "net-destroy", "net-undefine",
+        ]
+
+
 class TestBridgeModeManagedOwnerDiagnostic:
 
     @staticmethod
@@ -483,6 +581,47 @@ class TestBridgeModeManagedOwnerDiagnostic:
         net._log_bridge_mode_managed_owner()
 
         net._listed_networks.assert_not_called()
+
+    def test_unlistable_networks_are_reported_instead_of_dumped(self):
+        # this is a diagnostic, so libvirt being unreachable is a note, not
+        # a failure — but it must not silently read as "no owners found"
+        net = self._net()
+        net.logger = MagicMock()
+        net.logger.isEnabledFor.return_value = True
+        net._listed_networks = MagicMock(return_value=None)
+        net.virsh.execute = MagicMock()
+
+        net._log_bridge_mode_managed_owner()
+
+        net.virsh.execute.assert_not_called()
+        assert "could not inspect ownership" in net.logger.debug.call_args.args[0]
+
+    def test_unreadable_and_malformed_definitions_are_skipped(self):
+        # one bad definition among many must not hide the owner that the
+        # operator actually needs to know about
+        net = self._net()
+        net.logger = MagicMock()
+        net.logger.isEnabledFor.return_value = True
+        net._listed_networks = MagicMock(
+            return_value=["vanished", "truncated", "nat-owner"])
+        responses = {
+            # disappeared between net-list and net-dumpxml
+            "vanished": _result(ok=False, stderr="no such network"),
+            # well-formed enough to reach the parser, not enough to parse
+            "truncated": _result(stdout="<network><forward mode='nat'"),
+            "nat-owner": _result(stdout=(
+                "<network><forward mode='nat'/>"
+                "<bridge name='br-migrate'/></network>")),
+        }
+        net.virsh.execute = MagicMock(
+            side_effect=lambda _cmd, name, **_kwargs: responses[name])
+
+        net._log_bridge_mode_managed_owner()
+
+        message = net.logger.debug.call_args.args[0]
+        assert "nat-owner (nat)" in message
+        assert "vanished" not in message
+        assert "truncated" not in message
 
 
 class TestDhcpReservations:
@@ -900,45 +1039,267 @@ class TestNatIsLibvirtdsJob:
         shell.assert_not_called()
 
 
-class TestRouteIsolationRules:
-    """The routed-network isolation rules stay; sudo is execute_shell's call."""
+class TestCacheSurvivesADestroyedProject:
+    """`destroy` unregisters the project; a later define must still work.
+
+    Redefining through the reconcile path used to raise a bare KeyError on
+    the project name. It surfaced as the opaque "Error defining network:
+    '<project>'", the network was never created, and the VMs then failed to
+    start with "Network not found".
+    """
 
     @staticmethod
-    def _net(use_sudo: bool = False) -> Network:
+    def _net(projects: dict) -> Network:
+        manager = MagicMock()
+        manager.config = {"project": "gone"}
+        manager.config_path = "/tmp/some/conf.yml"
+        manager._runtime_name = "local"
+        manager.cache.projects = projects
         with patch.object(Network, "find_available_bridge_name",
                           return_value="virbr9"):
-            return Network(name="routed-net", info={"mode": "route"},
-                           assign_new_bridge=True,
-                           provider_config={"use_sudo": use_sudo})
+            return Network("net1", {"mode": "nat"},
+                           provider_config={"use_sudo": False},
+                           manager=manager)
 
-    def test_apply_commands_embed_no_sudo(self):
-        net = self._net()
-        seen = []
-        with patch.object(
-                net, "_ensure_rule",
-                side_effect=lambda cls, chk, act, present=True:
-                    seen.append((chk, act)) or True):
-            assert net.apply_route_iptables_rule() is True
-        # the three isolation rules (vm-to-vm, vm->host, host->vm) survive
-        assert len(seen) == 3
-        for check_cmd, action_cmd in seen:
-            assert not check_cmd.startswith("sudo")
-            assert not action_cmd.startswith("sudo")
-            assert "virbr9" in check_cmd
+    def test_missing_project_is_re_registered_instead_of_raising(self):
+        projects: dict = {}
+        net = self._net(projects)
+        net.update_network_cache()
+        assert "gone" in projects
+        assert projects["gone"]["networks"]["net1"]["bridge_name"] == "virbr9"
 
-    def test_remove_commands_embed_no_sudo(self):
+    def test_re_registered_entry_is_well_formed(self):
+        # other code reads conf/runtime off the entry, so a bare {} would be
+        # a different kind of landmine
+        projects: dict = {}
+        self._net(projects).update_network_cache()
+        assert projects["gone"]["conf"] == "/tmp/some/conf.yml"
+        assert projects["gone"]["runtime"] == "local"
+
+    def test_an_existing_project_entry_is_preserved(self):
+        projects = {"gone": {"conf": "/orig.yml", "runtime": "local",
+                             "networks": {"other": {"bridge_name": "virbr1"}}}}
+        self._net(projects).update_network_cache()
+        assert projects["gone"]["conf"] == "/orig.yml"
+        assert "other" in projects["gone"]["networks"]
+        assert "net1" in projects["gone"]["networks"]
+
+
+class TestIsolationOfAnUndefinedNetwork:
+    """A network that does not exist is not an isolation failure.
+
+    Reporting one adds a misleading second error on top of whatever actually
+    failed to define the network.
+    """
+
+    @staticmethod
+    def _net() -> Network:
+        with patch.object(Network, "get_bridge_from_network", return_value=None):
+            return Network("ghost-net", {"mode": "route"},
+                           assign_new_bridge=False,
+                           provider_config={"use_sudo": False})
+
+    def test_undefined_network_reports_absent(self):
         net = self._net()
-        seen = []
-        with patch.object(
-                net, "_ensure_rule",
-                side_effect=lambda cls, chk, act, present=True:
-                    seen.append((chk, act, present)) or True):
-            assert net.remove_route_iptables_rule() is True
-        assert len(seen) == 3
-        for check_cmd, action_cmd, present in seen:
-            assert present is False
-            assert not check_cmd.startswith("sudo")
-            assert not action_cmd.startswith("sudo")
+        with patch.object(Network, "list_networks", return_value=["other-net"]):
+            assert net.reconcile_isolation() == 'absent'
+
+    def test_defined_but_bridgeless_network_is_still_a_failure(self):
+        net = self._net()
+        with patch.object(Network, "list_networks", return_value=["ghost-net"]):
+            assert net.reconcile_isolation() == 'failed'
+
+
+class TestRoutedDhcpOptionTrimming:
+    """A routed network must not advertise what it then blocks.
+
+    dnsmasq offers the bridge address as both gateway (option 3) and resolver
+    (option 6), but the isolation rules drop traffic to it. The router option
+    is the damaging one: it installs a default route at metric 0, outranking
+    the guest's real NIC and black-holing all of its traffic. An empty
+    ``dhcp-option=N`` makes dnsmasq omit the option entirely.
+    """
+
+    DNSMASQ_NS = {'dnsmasq': 'http://libvirt.org/schemas/network/dnsmasq/1.0'}
+
+    @staticmethod
+    def _xml(mode: str, with_dhcp: bool = True) -> str:
+        info: dict = {"mode": mode, "bridge": {"name": "virbr9"}}
+        if mode != 'bridge':
+            info["ip"] = {"address": "10.0.14.1", "netmask": "255.255.255.0"}
+            if with_dhcp:
+                info["ip"]["dhcp"] = {"range": {"start": "10.0.14.2",
+                                                "end": "10.0.14.254"}}
+        return Network("t", info, assign_new_bridge=True,
+                       provider_config={"use_sudo": False}).generate_xml()
+
+    def _options(self, xml: str) -> list[str]:
+        root = ET.fromstring(xml)  # must stay well-formed with the namespace
+        block = root.find('dnsmasq:options', self.DNSMASQ_NS)
+        if block is None:
+            return []
+        return [o.get('value')
+                for o in block.findall('dnsmasq:option', self.DNSMASQ_NS)]
+
+    def test_routed_dhcp_network_suppresses_router_and_dns(self):
+        assert sorted(self._options(self._xml('route'))) == [
+            'dhcp-option=3', 'dhcp-option=6']
+
+    def test_routed_network_without_dhcp_declares_nothing(self):
+        # nothing is handed out, so there is no offer to trim
+        assert self._options(self._xml('route', with_dhcp=False)) == []
+
+    @pytest.mark.parametrize("mode", ["nat", "bridge"])
+    def test_other_modes_are_untouched(self, mode):
+        # only route mode installs the host<->guest block, so only route mode
+        # advertises a gateway the guest cannot reach
+        xml = self._xml(mode)
+        assert self._options(xml) == []
+        assert 'dnsmasq' not in xml
+
+    def test_namespace_is_only_declared_when_used(self):
+        assert 'xmlns:dnsmasq' in self._xml('route')
+        assert 'xmlns:dnsmasq' not in self._xml('route', with_dhcp=False)
+
+    def test_reservations_alone_also_trim_the_offer(self):
+        info = {"mode": "route", "bridge": {"name": "virbr9"},
+                "ip": {"address": "10.0.14.1", "netmask": "255.255.255.0",
+                       "dhcp": {"hosts": [{"mac": "52:54:00:0c:01:01",
+                                           "ip": "10.0.14.10"}]}}}
+        xml = Network("t", info, assign_new_bridge=True,
+                      provider_config={"use_sudo": False}).generate_xml()
+        assert sorted(self._options(xml)) == ['dhcp-option=3', 'dhcp-option=6']
+
+
+class TestRouteIsolationChains:
+    """Routed-network isolation lives in a chain per direction.
+
+    Loose rules in INPUT/OUTPUT could not be reconciled safely: ``iptables
+    -I`` pushes to the top, so a DROP re-inserted after an ACCEPT ends up
+    above it and silently re-breaks DHCP. A chain is declarative -- flush and
+    refill -- so ordering is owned rather than inherited from insertion
+    history.
+    """
+
+    @staticmethod
+    def _net(with_dhcp: bool = True, bridge_name: str = "virbr9",
+             use_sudo: bool = False) -> Network:
+        info: dict = {"mode": "route", "bridge": {"name": bridge_name}}
+        if with_dhcp:
+            info["ip"] = {
+                "address": "10.0.14.1", "netmask": "255.255.255.0",
+                "dhcp": {"range": {"start": "10.0.14.2",
+                                   "end": "10.0.14.254"}},
+            }
+        return Network(name="routed-net", info=info, assign_new_bridge=True,
+                       provider_config={"use_sudo": use_sudo})
+
+    @staticmethod
+    def _record(net: Network, rules_present: bool = False):
+        """Stub execute_shell: `-C` probes report absent unless told otherwise."""
+        calls: list[str] = []
+
+        def run(command, *_args, **_kwargs):
+            calls.append(command)
+            if " -C " in f" {command} ":
+                return _result(ok=rules_present,
+                               return_code=0 if rules_present else 1)
+            return _result(ok=True, return_code=0)
+
+        net.virsh.execute_shell = MagicMock(side_effect=run)
+        return calls
+
+    def _apply(self, net: Network, rules_present: bool = False) -> list[str]:
+        calls = self._record(net, rules_present)
+        assert net.apply_route_iptables_rule() is True
+        return calls
+
+    def test_chain_is_created_flushed_and_hooked(self):
+        calls = self._apply(self._net())
+        for chain, hook, flag in (("BXM_ISO_I_virbr9", "INPUT", "-i"),
+                                  ("BXM_ISO_O_virbr9", "OUTPUT", "-o")):
+            assert f"iptables -N {chain}" in calls
+            assert f"iptables -F {chain}" in calls
+            assert f"iptables -I {hook} {flag} virbr9 -j {chain}" in calls
+
+    def test_accept_is_filled_before_drop(self):
+        # inside a chain the rules are appended, so this ordering is the whole
+        # point: an ACCEPT after the DROP would never be reached
+        calls = self._apply(self._net())
+        accept = calls.index("iptables -A BXM_ISO_I_virbr9 -p udp --dport 67 -j ACCEPT")
+        drop = calls.index("iptables -A BXM_ISO_I_virbr9 -j DROP")
+        assert accept < drop
+
+    def test_dhcp_ports_are_direction_specific(self):
+        calls = self._apply(self._net())
+        assert "iptables -A BXM_ISO_I_virbr9 -p udp --dport 67 -j ACCEPT" in calls
+        assert "iptables -A BXM_ISO_O_virbr9 -p udp --dport 68 -j ACCEPT" in calls
+
+    def test_no_dhcp_hole_without_a_dhcp_block(self):
+        # a routed network that hands out nothing keeps the unconditional
+        # host<->guest block it has always had, so this stays additive
+        calls = self._apply(self._net(with_dhcp=False))
+        # the chain is filled with the DROP alone. (Legacy `-D ... --dport`
+        # cleanup commands may still appear -- those remove an exception, they
+        # do not add one.)
+        assert not any(c.startswith("iptables -A") and "--dport" in c
+                       for c in calls)
+        assert "iptables -A BXM_ISO_I_virbr9 -j DROP" in calls
+
+    def test_reservations_alone_also_open_the_hole(self):
+        # `dhcp: hosts` with no range is valid libvirt -- every guest pinned
+        info = {
+            "mode": "route", "bridge": {"name": "virbr9"},
+            "ip": {"address": "10.0.14.1", "netmask": "255.255.255.0",
+                   "dhcp": {"hosts": [{"mac": "52:54:00:0c:01:01",
+                                       "ip": "10.0.14.10"}]}},
+        }
+        net = Network("routed-net", info, assign_new_bridge=True,
+                      provider_config={"use_sudo": False})
+        assert any("--dport 67" in c for c in self._apply(net))
+
+    def test_vm_to_vm_forward_rule_survives(self):
+        calls = self._apply(self._net())
+        assert ("iptables -I FORWARD -i virbr9 -o virbr9 -j ACCEPT") in calls
+
+    def test_legacy_loose_rules_are_migrated_away(self):
+        # hosts provisioned by an older boxman still carry the pre-chain
+        # rules; left in place they are dead weight at best
+        calls = self._apply(self._net(), rules_present=True)
+        assert "iptables -D INPUT -i virbr9 -j DROP" in calls
+        assert "iptables -D OUTPUT -o virbr9 -j DROP" in calls
+
+    def test_removal_unhooks_flushes_and_deletes(self):
+        net = self._net()
+        calls = self._record(net, rules_present=True)
+        assert net.remove_route_iptables_rule() is True
+        for chain, hook, flag in (("BXM_ISO_I_virbr9", "INPUT", "-i"),
+                                  ("BXM_ISO_O_virbr9", "OUTPUT", "-o")):
+            assert f"iptables -D {hook} {flag} virbr9 -j {chain}" in calls
+            assert f"iptables -F {chain}" in calls
+            assert f"iptables -X {chain}" in calls
+
+    def test_chain_name_is_sanitised_not_quoted(self):
+        # the chain name is an iptables identifier, not an argument, so it is
+        # sanitised; the bridge name in the match IS quoted
+        net = self._net(bridge_name="br-a.b")
+        calls = self._apply(net)
+        assert any("BXM_ISO_I_br_a_b" in c for c in calls)
+        assert not any("BXM_ISO_I_br-a.b" in c for c in calls)
+
+    def test_bridge_name_with_metacharacters_is_quoted(self):
+        net = self._net(bridge_name="virbr 9;touch /tmp/x")
+        calls = self._apply(net)
+        matches = [c for c in calls if "-i " in c or "-o " in c]
+        assert matches
+        for cmd in matches:
+            assert "'virbr 9;touch /tmp/x'" in cmd
+
+    def test_a_plain_bridge_name_is_left_unquoted(self):
+        # shlex.quote leaves a shell-safe name untouched, so existing command
+        # strings stay byte-identical
+        calls = self._apply(self._net())
+        assert not any("'" in c for c in calls)
 
     @pytest.mark.parametrize("use_sudo, expected_prefix", [
         (False, "iptables"),
@@ -953,60 +1314,63 @@ class TestRouteIsolationRules:
         assert run.call_args.args[0].startswith(expected_prefix)
 
 
-class TestShellQuoting:
-    """Config-derived values interpolated into shell strings are quoted.
+class TestRouteIsolationDrift:
+    """Isolation is host iptables state, so it does not survive a reboot.
 
-    Regression tests for issue #85 item 6 (net.py part): the bridge name
-    comes from the configuration and used to land in the iptables command
-    strings verbatim.
+    libvirt autostarts the network again regardless, so without a reconcile
+    the network comes back up unprotected and stays that way. Detecting that
+    is what separates "already fine" from "was open, now repaired".
     """
 
     @staticmethod
-    def _net(bridge_name: str) -> Network:
+    def _net(mode: str = "route") -> Network:
         return Network(name="routed-net",
-                       info={"mode": "route", "bridge": {"name": bridge_name}},
+                       info={"mode": mode, "bridge": {"name": "virbr9"}},
                        assign_new_bridge=True,
                        provider_config={"use_sudo": False})
 
-    def test_apply_quotes_a_bridge_name_with_metacharacters(self):
-        net = self._net("virbr 9;touch /tmp/x")
-        seen = []
-        with patch.object(
-                net, "_ensure_rule",
-                side_effect=lambda cls, chk, act, present=True:
-                    seen.append((chk, act)) or True):
-            assert net.apply_route_iptables_rule() is True
-        assert seen
-        for check_cmd, action_cmd in seen:
-            assert "'virbr 9;touch /tmp/x'" in check_cmd
-            assert "'virbr 9;touch /tmp/x'" in action_cmd
+    def test_intact_when_both_jumps_are_present(self):
+        net = self._net()
+        net.virsh.execute_shell = MagicMock(return_value=_result(return_code=0))
+        assert net._isolation_is_intact() is True
 
-    def test_remove_quotes_a_bridge_name_with_metacharacters(self):
-        net = self._net("virbr 9;touch /tmp/x")
-        seen = []
-        with patch.object(
-                net, "_ensure_rule",
-                side_effect=lambda cls, chk, act, present=True:
-                    seen.append((chk, act)) or True):
-            assert net.remove_route_iptables_rule() is True
-        assert seen
-        for check_cmd, action_cmd in seen:
-            assert "'virbr 9;touch /tmp/x'" in check_cmd
-            assert "'virbr 9;touch /tmp/x'" in action_cmd
+    def test_not_intact_when_a_jump_is_missing(self):
+        net = self._net()
+        net.virsh.execute_shell = MagicMock(
+            return_value=_result(ok=False, return_code=1))
+        assert net._isolation_is_intact() is False
 
-    def test_a_plain_bridge_name_is_left_unquoted(self):
-        net = self._net("virbr9")
-        seen = []
-        with patch.object(
-                net, "_ensure_rule",
-                side_effect=lambda cls, chk, act, present=True:
-                    seen.append(chk) or True):
-            assert net.apply_route_iptables_rule() is True
-        assert seen
-        for check_cmd in seen:
-            # shlex.quote leaves a shell-safe name untouched
-            assert "virbr9" in check_cmd
-            assert "'" not in check_cmd
+    def test_reconcile_reports_repaired_when_rules_had_vanished(self):
+        net = self._net()
+        net._isolation_is_intact = MagicMock(return_value=False)
+        net.apply_route_iptables_rule = MagicMock(return_value=True)
+        assert net.reconcile_isolation() == 'repaired'
+        net.apply_route_iptables_rule.assert_called_once_with()
+
+    def test_reconcile_reports_ok_when_nothing_had_drifted(self):
+        net = self._net()
+        net._isolation_is_intact = MagicMock(return_value=True)
+        net.apply_route_iptables_rule = MagicMock(return_value=True)
+        assert net.reconcile_isolation() == 'ok'
+
+    def test_check_only_reports_drift_without_touching_anything(self):
+        net = self._net()
+        net._isolation_is_intact = MagicMock(return_value=False)
+        net.apply_route_iptables_rule = MagicMock()
+        assert net.reconcile_isolation(check_only=True) == 'drifted'
+        net.apply_route_iptables_rule.assert_not_called()
+
+    def test_failure_to_apply_is_reported(self):
+        net = self._net()
+        net._isolation_is_intact = MagicMock(return_value=False)
+        net.apply_route_iptables_rule = MagicMock(return_value=False)
+        assert net.reconcile_isolation() == 'failed'
+
+    def test_non_routed_networks_are_skipped(self):
+        net = self._net(mode="nat")
+        net.virsh.execute_shell = MagicMock()
+        assert net.reconcile_isolation() == 'skipped'
+        net.virsh.execute_shell.assert_not_called()
 
 
 class TestXmlEscaping:

--- a/tests/test_net_reconcile.py
+++ b/tests/test_net_reconcile.py
@@ -141,7 +141,7 @@ class TestDesiredState:
             "mode": "bridge", "bridge_name": "br-migrate",
             "bridge_stp": None, "bridge_delay": None, "mac": None,
             "ip_address": None, "netmask": None, "dhcp_range": None,
-            "dhcp_hosts": [],
+            "dhcp_hosts": [], "dhcp_options_trimmed": False,
         }
         assert nr.diff_network(
             state, nr.parse_network_xml(xml))["action"] == "none"
@@ -835,3 +835,57 @@ class TestApplyLivePlan:
             else _result(ok=False, stderr="boom"))
         assert net.apply_live_plan(
             {"host_ops": [("add-last", {"mac": "aa", "ip": "1.1.1.2"})]}) is False
+
+
+class TestDhcpOptionTrimmingIsReconciled:
+    """The dnsmasq option suppression has to be part of the comparison.
+
+    Left unmodelled, a routed network defined before those options existed
+    compares equal and plans as ``action: none`` -- so it can never be
+    migrated, not even with ``--recreate-networks``, which only permits an
+    already-planned recreate. It would then keep advertising an unreachable
+    router while the isolation chains started permitting DHCP.
+    """
+
+    TRIMMED = (
+        "<network xmlns:dnsmasq='http://libvirt.org/schemas/network/dnsmasq/1.0'>"
+        "<name>n</name><forward mode='route'/>"
+        "<bridge name='virbr9' stp='on' delay='0'/>"
+        "<mac address='52:54:00:00:0a:02'/>"
+        "<ip address='10.0.14.1' netmask='255.255.255.0'>"
+        "<dhcp><range start='10.0.14.10' end='10.0.14.99'/></dhcp></ip>"
+        "<dnsmasq:options>"
+        "<dnsmasq:option value='dhcp-option=3'/>"
+        "<dnsmasq:option value='dhcp-option=6'/>"
+        "</dnsmasq:options></network>"
+    )
+    UNTRIMMED = TRIMMED.replace(
+        "<dnsmasq:options>"
+        "<dnsmasq:option value='dhcp-option=3'/>"
+        "<dnsmasq:option value='dhcp-option=6'/>"
+        "</dnsmasq:options>", "")
+
+    def test_parser_detects_the_suppression(self):
+        assert nr.parse_network_xml(self.TRIMMED)["dhcp_options_trimmed"] is True
+
+    def test_parser_reports_a_legacy_network_as_untrimmed(self):
+        assert nr.parse_network_xml(self.UNTRIMMED)["dhcp_options_trimmed"] is False
+
+    def test_only_both_options_together_count(self):
+        partial = self.TRIMMED.replace(
+            "<dnsmasq:option value='dhcp-option=6'/>", "")
+        assert nr.parse_network_xml(partial)["dhcp_options_trimmed"] is False
+
+    def test_a_legacy_routed_network_plans_as_structural_drift(self):
+        # the whole point: without this the plan is `none` and the network is
+        # unmigratable
+        desired = nr.parse_network_xml(self.TRIMMED)
+        actual = nr.parse_network_xml(self.UNTRIMMED)
+        plan = nr.diff_network(desired, actual)
+        assert plan["action"] == "recreate"
+        assert any("dhcp router/dns suppression" in change
+                   for change in plan["structural"])
+
+    def test_an_already_migrated_network_shows_no_drift(self):
+        state = nr.parse_network_xml(self.TRIMMED)
+        assert nr.diff_network(state, state)["action"] == "none"

--- a/tests/test_network_isolation_reconcile.py
+++ b/tests/test_network_isolation_reconcile.py
@@ -1,0 +1,87 @@
+"""
+Manager-level behaviour of routed-network isolation reconciliation.
+
+Isolation is host iptables state rather than libvirt state, so it does not
+survive a reboot while libvirt autostarts the network regardless. Reconciling
+it on every run is only half the job: the outcome has to reach the caller,
+otherwise `up` exits 0 while a routed network sits unisolated.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from boxman.manager import BoxmanManager
+
+pytestmark = pytest.mark.unit
+
+
+def _mgr(tmp_path: Path, mode: str = "route") -> BoxmanManager:
+    with patch("boxman.manager.BoxmanCache"):
+        m = BoxmanManager()
+    m.config = {
+        "project": "demo",
+        "clusters": {
+            "cluster_1": {
+                "workdir": str(tmp_path),
+                "networks": {"isolated1": {"mode": mode}},
+            },
+        },
+    }
+    m._provider = MagicMock()
+    m._provider.provider_config = {}
+    m._provider.plan_network.return_value = {"action": "none"}
+    return m
+
+
+class TestIsolationOutcomeReachesTheCaller:
+
+    def test_failed_isolation_fails_the_network(self, tmp_path: Path):
+        # without this the run is reported as successful while the guests can
+        # still reach the host -- the exact property the mode exists to deny
+        m = _mgr(tmp_path)
+        m._provider.reconcile_network_isolation.return_value = 'failed'
+        results = m.reconcile_networks()
+        assert set(results.values()) == {'failed'}
+        assert all('isolated1' in key for key in results)
+
+    def test_an_exception_is_also_a_failure(self, tmp_path: Path):
+        m = _mgr(tmp_path)
+        m._provider.reconcile_network_isolation.side_effect = RuntimeError("boom")
+        assert set(m.reconcile_networks().values()) == {'failed'}
+
+    @pytest.mark.parametrize("outcome", ["ok", "repaired", "absent", "skipped"])
+    def test_non_failure_outcomes_do_not_fail_the_network(
+        self, tmp_path: Path, outcome
+    ):
+        m = _mgr(tmp_path)
+        m._provider.reconcile_network_isolation.return_value = outcome
+        assert m.reconcile_networks() == {}
+
+    def test_repaired_is_reported_loudly(self, tmp_path: Path):
+        # a network that lost its rules was reachable for however long it was
+        # up; repairing it silently would hide that entirely
+        m = _mgr(tmp_path)
+        m.logger = MagicMock()
+        m._provider.reconcile_network_isolation.return_value = 'repaired'
+        m.reconcile_networks()
+        warnings = [c.args[0] for c in m.logger.warning.call_args_list if c.args]
+        assert any("isolation rules were missing" in w for w in warnings)
+
+    def test_dry_run_checks_without_touching_anything(self, tmp_path: Path):
+        m = _mgr(tmp_path)
+        m.logger = MagicMock()
+        m._provider.reconcile_network_isolation.return_value = 'drifted'
+        m.reconcile_networks(dry_run=True)
+        assert m._provider.reconcile_network_isolation.call_args.kwargs[
+            "check_only"] is True
+        warnings = [c.args[0] for c in m.logger.warning.call_args_list if c.args]
+        assert any("would be re-applied" in w for w in warnings)
+
+    def test_non_routed_networks_are_not_probed(self, tmp_path: Path):
+        m = _mgr(tmp_path, mode="nat")
+        m.reconcile_networks()
+        m._provider.reconcile_network_isolation.assert_not_called()

--- a/tests/test_network_isolation_reconcile.py
+++ b/tests/test_network_isolation_reconcile.py
@@ -39,6 +39,35 @@ def _mgr(tmp_path: Path, mode: str = "route") -> BoxmanManager:
 
 class TestIsolationOutcomeReachesTheCaller:
 
+    def test_a_failed_network_aborts_the_run(self, tmp_path: Path):
+        # reporting alone left `up` exiting 0 over a routed network that was
+        # never isolated, which reads as success
+        from boxman.exceptions import NetworkError
+        m = _mgr(tmp_path)
+        with pytest.raises(NetworkError, match="could not be brought"):
+            m.raise_on_network_failures({"net-a": "failed", "net-b": "created"})
+
+    def test_the_guard_names_every_failed_network(self, tmp_path: Path):
+        from boxman.exceptions import NetworkError
+        m = _mgr(tmp_path)
+        with pytest.raises(NetworkError) as caught:
+            m.raise_on_network_failures({"net-a": "failed", "net-b": "failed"})
+        assert "net-a" in str(caught.value) and "net-b" in str(caught.value)
+
+    def test_the_guard_is_quiet_when_nothing_failed(self, tmp_path: Path):
+        m = _mgr(tmp_path)
+        m.raise_on_network_failures(
+            {"a": "created", "b": "updated", "c": "skipped"})
+
+    def test_isolation_failure_reaches_the_guard(self, tmp_path: Path):
+        # end to end: a failed isolation becomes a failed network, and a
+        # failed network aborts the run
+        from boxman.exceptions import NetworkError
+        m = _mgr(tmp_path)
+        m._provider.reconcile_network_isolation.return_value = 'failed'
+        with pytest.raises(NetworkError):
+            m.raise_on_network_failures(m.reconcile_networks())
+
     def test_failed_isolation_fails_the_network(self, tmp_path: Path):
         # without this the run is reported as successful while the guests can
         # still reach the host -- the exact property the mode exists to deny


### PR DESCRIPTION
Fixes four related defects found by actually provisioning, isolating and tearing down routed networks on a real host.

## What was broken

**DHCP could never work on a `mode: route` network (#152).** DHCP terminates *on the host* — libvirt runs dnsmasq bound to the bridge address — so it travels INPUT and OUTPUT, the exact chains the isolation drops. Every `dhcp:` range declared on a routed network was dead config; the guest NIC came up link-local only. Six existing boxes carry that pattern.

**Isolation silently disappeared (#155).** The rules were applied once at define time and live only in memory. A host reboot dropped them while libvirt autostarted the network anyway. Found in the wild: two routed networks on one host, one protected and one wide open, differing only in which side of the last reboot they were created on. A lock that quietly stops locking is worse than no lock.

**`destroy` left the VM behind and still reported success (#156).** libvirt refuses to undefine a domain with a managed save image — which boxman itself creates via suspend and memory snapshots.

**`up` after `destroy` could not recreate the networks (#157).** `destroy` unregisters the project; `update_network_cache` then indexed it unconditionally and raised a bare `KeyError`, swallowed as `Error defining network: '<project>'`.

The last two compound: a destroy that leaves the VM defined sends the next `up` down the reconcile path, which is precisely the path that KeyErrored — leaving a VM that cannot start.

## Approach

Isolation moves into a chain per direction (`BXM_ISO_I_<bridge>` / `BXM_ISO_O_<bridge>`) that is flushed and refilled rather than inserted into, so ordering belongs to boxman instead of insertion history. `iptables -I` pushes to the top, so a DROP re-inserted after an ACCEPT would otherwise land above it and silently re-break DHCP.

- The DHCP hole opens **only** when the network declares `dhcp:`, so this is additive — a routed network that hands out nothing keeps exactly the block it always had.
- Teardown is unhook → flush → delete, removing the risk of apply and remove drifting apart. Pre-chain rules from older versions are migrated away on apply.
- Isolation is reconciled on every `up`/`update`, and drift is **reported**, not repaired mutely.

Opening the firewall alone made things *worse*, so the DHCP offer is trimmed too. dnsmasq advertises the bridge address as both gateway and resolver, both unreachable by construction. The router option installs a default route at metric 0 that outranks the guest's real NIC:

| | firewall fix only | with offer trimmed |
|---|---|---|
| default routes | 2 — isolated NIC winning | 1, via the real NIC |
| `ping 8.8.8.8` | 100% packet loss | 0% packet loss |

## Verification

On a real host with a live guest:

- isolation holds — bridge unreachable, tcp/53 blocked — **while** DHCP succeeds
- deleting the chains to simulate a reboot, then `boxman up`, detects, warns and repairs
- destroy leaves zero VMs, networks, chains or disk files
- lease contains an address and netmask, and no `routers` / `domain-name-servers`

## Tests

2075 passing on this branch, ruff clean. ~30 new tests: chain creation/hooking, fill order, `dhcp:` gating, direction-specific ports, legacy migration, teardown, chain-name sanitisation, shell quoting, all five drift outcomes, offer trimming per mode, `--managed-save` on all undefine forms, and project re-registration.

One pre-existing failure remains, unrelated and also present on `main`: `test_stale_file_logs_warning` asserts on `caplog` for a logger with `propagate=False`, so it can never see the record.

Closes #152
Closes #155
Closes #156
Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)