### PR TITLE
feat(boxes): add Arch Linux, NixOS and Guix System examples

### DIFF
--- a/boxes/guix-1.5.0-iso-boot/README.md
+++ b/boxes/guix-1.5.0-iso-boot/README.md
@@ -35,9 +35,10 @@ oversight:
   declaration, and that declaration can include `openssh-service-type` with
   authorized keys baked in ahead of time.
 - boxman's `templates:` path **always** builds a NoCloud seed and then waits on
-  cloud-init plus the qemu guest agent
-  (`providers/libvirt/cloudinit.py`). Either Guix artifact pushed through it
-  would time out and never receive a key.
+  cloud-init plus the qemu guest agent (`providers/libvirt/cloudinit.py`).
+  Neither published Guix artifact consumes that seed, so either would time out
+  and never receive a key. A qcow2 built with keys already declared in it would
+  boot fine — it just would not be receiving them *from boxman*.
 
 So the real boxman gaps for Guix are narrower than "no cloud-init": **dynamic
 key injection** (boxman generates a keypair at provision time, which a

--- a/boxes/guix-1.5.0-iso-boot/README.md
+++ b/boxes/guix-1.5.0-iso-boot/README.md
@@ -1,0 +1,172 @@
+# guix-1.5.0-iso-boot
+
+Boots a single VM from the official **Guix System 1.5.0 installer ISO**, using
+the same ISO-boot path as
+[`ubuntu-24.04-live-iso-boot`](../ubuntu-24.04-live-iso-boot) and
+[`nixos-25.05-iso-boot`](../nixos-25.05-iso-boot) — no template, no clone, no
+cloud-init.
+
+Verified end to end on 2026-08-17: `boxman up` exits 0 in ~2 min including the
+download, the pinned checksum matches, and the guest reaches the Guix guided
+installer's locale screen and takes a DHCP lease (hostname `gnu`).
+
+## Read this first: what this box does *not* do
+
+It **boots** Guix System's installer. It does not **install or provision** it.
+There is no admin user and no injected SSH key, so `boxman ssh` will not reach
+the guest.
+
+(boxman *does* still generate an `ssh_config` and an `id_ed25519_boxman`
+keypair in the workspace, and `boxman up` prints an `ssh …` line for the VM.
+Ignore both: the `admin` user they name does not exist in the guest. `boxman
+up` also ends with `ERROR: failed to add ssh keys to some vms`, which is the
+correct outcome here, not a fault.)
+
+As with the NixOS box, that is the current limit of the tooling rather than an
+oversight:
+
+- Guix System has **no cloud image and no cloud-init**. GNU does publish a
+  bootable `guix-system-vm-image-1.5.0.x86_64-linux.qcow2`, but it is a GNOME
+  desktop *demo* image with a fixed user — there is nothing in it that consumes
+  an injected SSH key.
+- boxman's `templates:` path **always** builds a NoCloud seed and then waits on
+  cloud-init plus the qemu guest agent
+  (`providers/libvirt/cloudinit.py`). Either Guix artifact pushed through it
+  would time out and never receive a key.
+
+Getting to a usable, SSH-able Guix guest needs a declarative provisioning hook
+in boxman — push an `operating-system` declaration and run
+`guix system reconfigure` — which does not exist yet. Until then, finishing the
+install is done in the guest console.
+
+## About the checksum
+
+This is the one box here whose checksum did **not** come from upstream. GNU
+publishes only a detached OpenPGP signature for this ISO, no `.sha256`. The
+hash pinned in [`conf.yml`](conf.yml) was computed locally *after* verifying
+that signature, and you can reproduce the whole chain:
+
+```bash
+curl -O https://ftp.gnu.org/gnu/guix/guix-system-install-1.5.0.x86_64-linux.iso
+curl -O https://ftp.gnu.org/gnu/guix/guix-system-install-1.5.0.x86_64-linux.iso.sig
+gpg --recv-keys A28BF40C3E551372662D14F741AAE7DCCA3D8351
+gpg --verify guix-system-install-1.5.0.x86_64-linux.iso.sig
+sha256sum guix-system-install-1.5.0.x86_64-linux.iso
+# 107e0a8082f03a10b15c1fb9383d2d752c1cdeda41b8db575a15550e1c2d8b4a
+```
+
+The signature is from **Efraim Flashner**, a Guix maintainer, made 2026-01-22.
+The OpenPGP signature is the real authority here; the `sha256:` in `conf.yml`
+only pins what boxman downloads so a corrupted or swapped file fails loudly.
+
+## Prerequisites
+
+- libvirt/KVM working (`virsh -c qemu:///system list`), and `sudo` for
+  `qemu:///system` (the box uses `use_sudo: true`).
+- `wget` or `curl` on `PATH` (boxman uses them to fetch the ISO).
+- **~1.13 GB** of network + disk for the ISO, plus 30 GB for the VM disk.
+- The **local** runtime — ISO boot is rejected under docker-compose, because
+  the cached ISO is not visible inside the libvirt container.
+
+## Bring it up
+
+```bash
+cd boxes/guix-1.5.0-iso-boot
+boxman up
+```
+
+> The first run downloads ~1.13 GB and boots a VM. Re-runs reuse the cached,
+> checksum-verified ISO under `~/.cache/boxman/images`.
+
+## How to test / verify
+
+Let `V=bprj__boxman_dev_guix-1.5.0-iso-boot__bprj_guix_guix01` (the
+fully-qualified libvirt name; `virsh list` shows it).
+
+**1. ISO was downloaded and checksum-verified** — the file exists in your
+configured cache dir (default `~/.cache/boxman/images`):
+
+```bash
+ls -lh <cache_dir>/guix-system-install-1.5.0-*.iso
+```
+
+Note: at default verbosity boxman prints **no** `checksum ok` line — that
+message logs at `INFO` while the default level is `STATUS`. Verification does
+run (a mismatch raises `Checksum mismatch for ISO` and evicts the file). Given
+this box's hand-computed hash, checking it yourself is worthwhile:
+
+```bash
+sha256sum <the cached iso>
+# 107e0a8082f03a10b15c1fb9383d2d752c1cdeda41b8db575a15550e1c2d8b4a
+```
+
+**2. The VM is defined and running:**
+
+```bash
+virsh -c qemu:///system list --all | grep guix01
+```
+
+**3. The ISO is attached as a CDROM:**
+
+```bash
+virsh -c qemu:///system dumpxml "$V" | grep -A2 '<boot\|cdrom\|\.iso'
+# expect: <disk device='cdrom'> … <source file='…guix-system-install-….iso'/>
+#         <boot dev='cdrom'/> <boot dev='hd'/>
+```
+
+Note the boot order you actually get is **`cdrom` then `hd`**, even though
+`IsoBootVM` asks virt-install for `hd,cdrom`: passing `--cdrom=` puts
+virt-install into two-phase install mode, and boxman never reaches the
+post-install reconfigure. For this box it makes no difference — it boots the
+installer and never completes one — but do not rely on the `hd`-first ordering.
+
+**4. It actually booted the installer** — watch the console:
+
+```bash
+virt-viewer -c qemu:///system "$V"          # or: virsh console "$V"
+```
+
+You should reach the GNU Guix **guided installer** (a text-mode/ncurses
+wizard), starting at its language-selection screen. Switching to another tty
+(`Ctrl-Alt-F3` in virt-viewer) gets you a root shell in the live system
+instead.
+
+**5. (Automated signal) the installer requests DHCP** — it brings up networking
+and takes a lease from this box's NAT network:
+
+```bash
+virsh -c qemu:///system net-dhcp-leases \
+  bprj__boxman_dev_guix-1.5.0-iso-boot__bprj__clstr__guix__clstr__guix-net
+```
+
+A lease for the VM's MAC confirms it booted far enough to configure networking
+from the ISO. As with the NixOS box, this is the best non-interactive signal
+available — there is no guest agent and no SSH.
+
+## Going further: actually installing
+
+Run the guided installer on the console, or drop to a shell on another tty and
+write an `operating-system` declaration by hand and `guix system init` it onto
+the 30 G disk.
+
+Be aware the domain boots **cdrom first** (see above), so once you have
+installed something you must detach the CDROM — or change the boot order — or
+the VM will drop back into the installer on every reboot.
+
+If you install, remember Guix pulls a large number of substitutes on first
+build; the VM needs working outbound networking through `guix-net`.
+
+## Refreshing the ISO
+
+Newer releases appear at <https://ftp.gnu.org/gnu/guix/>. Because upstream
+still publishes no `.sha256`, refreshing means repeating the verify-then-hash
+procedure above and updating `uri` and `checksum` together.
+
+## Tearing down
+
+```bash
+boxman destroy
+```
+
+The cached ISO stays under `~/.cache/boxman/images`; delete it there to force a
+re-download.

--- a/boxes/guix-1.5.0-iso-boot/README.md
+++ b/boxes/guix-1.5.0-iso-boot/README.md
@@ -25,19 +25,31 @@ correct outcome here, not a fault.)
 As with the NixOS box, that is the current limit of the tooling rather than an
 oversight:
 
-- Guix System has **no cloud image and no cloud-init**. GNU does publish a
-  bootable `guix-system-vm-image-1.5.0.x86_64-linux.qcow2`, but it is a GNOME
-  desktop *demo* image with a fixed user — there is nothing in it that consumes
-  an injected SSH key.
+- Guix System has **no native cloud-init**, so boxman's NoCloud seed — the
+  mechanism it uses to inject a key at provision time — has nothing to
+  consume it. GNU does publish a bootable
+  `guix-system-vm-image-1.5.0.x86_64-linux.qcow2`, but it is a GNOME desktop
+  *demo* image with a fixed user.
+- That does **not** mean an SSH-able Guix image is impossible. `guix system
+  image --image-type=qcow2` builds one from an `operating-system`
+  declaration, and that declaration can include `openssh-service-type` with
+  authorized keys baked in ahead of time.
 - boxman's `templates:` path **always** builds a NoCloud seed and then waits on
   cloud-init plus the qemu guest agent
   (`providers/libvirt/cloudinit.py`). Either Guix artifact pushed through it
   would time out and never receive a key.
 
-Getting to a usable, SSH-able Guix guest needs a declarative provisioning hook
-in boxman — push an `operating-system` declaration and run
-`guix system reconfigure` — which does not exist yet. Until then, finishing the
-install is done in the guest console.
+So the real boxman gaps for Guix are narrower than "no cloud-init": **dynamic
+key injection** (boxman generates a keypair at provision time, which a
+prebuilt image cannot know in advance), **image build/import** (boxman has no
+way to build a `guix system image` or consume one as a template), and the
+**guest-agent assumptions** in the template verification phase. A
+declaratively prebuilt image with your own key already in it sidesteps the
+first of those, at the cost of the image no longer being a signed upstream
+artifact. See #149.
+
+Until this box ships such an image, finishing the install is done in the guest
+console.
 
 ## About the checksum
 

--- a/boxes/guix-1.5.0-iso-boot/conf.yml
+++ b/boxes/guix-1.5.0-iso-boot/conf.yml
@@ -13,9 +13,12 @@
 # boots you into Guix's guided installer. It does NOT install Guix, create a
 # user, or configure SSH — see README.md.
 #
-# Turning this into a box that yields a usable, SSH-able Guix guest needs a
-# declarative provisioning hook in boxman (push an operating-system
-# declaration, run `guix system reconfigure`). That is tracked separately.
+# Turning this into a box that yields a usable, SSH-able Guix guest does not
+# strictly need an in-guest reconfigure hook: `guix system image
+# --image-type=qcow2` can build a qcow2 from an operating-system declaration
+# that already includes openssh-service-type and authorized keys. The boxman
+# gaps are dynamic key injection, image build/import, and the guest-agent
+# assumptions in template verification. Tracked separately.
 #
 version: '1.0'
 project: boxman_dev_guix-1.5.0-iso-boot

--- a/boxes/guix-1.5.0-iso-boot/conf.yml
+++ b/boxes/guix-1.5.0-iso-boot/conf.yml
@@ -1,12 +1,17 @@
 # Example: boot a VM directly from the Guix System 1.5.0 installer ISO
 #
-# Why this is an ISO-boot box and not a cloud-init template box: Guix System
-# has no cloud image and no cloud-init. GNU does publish a bootable qcow2
-# (guix-system-vm-image-1.5.0.x86_64-linux.qcow2), but it is a GNOME desktop
-# demo image, not a cloud image — it has a fixed user and no way to take an
-# injected SSH key. boxman's `templates:` path always builds a NoCloud seed and
-# then waits for cloud-init plus the qemu guest agent, so either Guix artifact
-# put through it would time out and never receive a key.
+# Why this is an ISO-boot box and not a cloud-init template box: the artifact
+# pinned here is the *installer* ISO, which creates no user and consumes no
+# NoCloud seed, so boxman has nothing to inject a key into.
+#
+# Guix also has no native cloud-init, so boxman's dynamic key injection -- it
+# generates a keypair at provision time and expects the guest to pick it up
+# from the seed -- has no mechanism to work through. That is a narrower claim
+# than "Guix cannot be SSH-able": `guix system image --image-type=qcow2`
+# builds a qcow2 from an operating-system declaration that can include
+# openssh-service-type with authorized keys already in it. The boxman gaps are
+# dynamic key injection, image build/import, and the guest-agent assumptions
+# in template verification -- see #149.
 #
 # So this box uses the same shape as talos-iso-boot and
 # ubuntu-24.04-live-iso-boot: a bare VM with the installer ISO attached. It

--- a/boxes/guix-1.5.0-iso-boot/conf.yml
+++ b/boxes/guix-1.5.0-iso-boot/conf.yml
@@ -1,0 +1,87 @@
+# Example: boot a VM directly from the Guix System 1.5.0 installer ISO
+#
+# Why this is an ISO-boot box and not a cloud-init template box: Guix System
+# has no cloud image and no cloud-init. GNU does publish a bootable qcow2
+# (guix-system-vm-image-1.5.0.x86_64-linux.qcow2), but it is a GNOME desktop
+# demo image, not a cloud image — it has a fixed user and no way to take an
+# injected SSH key. boxman's `templates:` path always builds a NoCloud seed and
+# then waits for cloud-init plus the qemu guest agent, so either Guix artifact
+# put through it would time out and never receive a key.
+#
+# So this box uses the same shape as talos-iso-boot and
+# ubuntu-24.04-live-iso-boot: a bare VM with the installer ISO attached. It
+# boots you into Guix's guided installer. It does NOT install Guix, create a
+# user, or configure SSH — see README.md.
+#
+# Turning this into a box that yields a usable, SSH-able Guix guest needs a
+# declarative provisioning hook in boxman (push an operating-system
+# declaration, run `guix system reconfigure`). That is tracked separately.
+#
+version: '1.0'
+project: boxman_dev_guix-1.5.0-iso-boot
+
+provider:
+  libvirt:
+    uri: qemu:///system
+    use_sudo: true
+    virt_install_cmd: '/bin/python3 /usr/bin/virt-install'
+    virt_clone_cmd: '/bin/python3 /usr/bin/virt-clone'
+    virsh_cmd: '/usr/bin/virsh'
+
+isos:
+  guix-system-install-1.5.0:
+    # Guix System 1.5.0 installer (x86_64). ~1.13 GB.
+    #
+    # NOTE ON THE CHECKSUM: unlike every other box here, upstream publishes NO
+    # sha256 for this artifact — ftp.gnu.org ships only a detached OpenPGP
+    # signature (.sig). The hash below was therefore computed locally from the
+    # downloaded file *after* verifying that signature. Reproduce it with:
+    #
+    #   curl -O https://ftp.gnu.org/gnu/guix/guix-system-install-1.5.0.x86_64-linux.iso
+    #   curl -O https://ftp.gnu.org/gnu/guix/guix-system-install-1.5.0.x86_64-linux.iso.sig
+    #   gpg --recv-keys A28BF40C3E551372662D14F741AAE7DCCA3D8351
+    #   gpg --verify guix-system-install-1.5.0.x86_64-linux.iso.sig
+    #   sha256sum guix-system-install-1.5.0.x86_64-linux.iso
+    #
+    # Signed 2026-01-22 by A28BF40C 3E551372 662D14F7 41AAE7DC CA3D8351
+    # (Efraim Flashner), a Guix maintainer. Treat the OpenPGP signature as the
+    # authority; the sha256 here only pins what boxman downloads.
+    uri: https://ftp.gnu.org/gnu/guix/guix-system-install-1.5.0.x86_64-linux.iso
+    checksum: sha256:107e0a8082f03a10b15c1fb9383d2d752c1cdeda41b8db575a15550e1c2d8b4a
+
+workspace:
+  path: ~/workspaces/guix-1.5.0-iso-boot
+
+clusters:
+  guix:
+    workdir: ~/workspaces/guix-1.5.0-iso-boot
+    networks:
+      guix-net:
+        mode: nat
+        bridge:
+          stp: 'on'
+          delay: '0'
+        mac: '52:54:00:00:98:01'
+        ip:
+          address: '192.168.152.1'
+          netmask: '255.255.255.0'
+          dhcp:
+            range:
+              start: '192.168.152.2'
+              end: '192.168.152.254'
+        enable: True
+        autostart: True
+    vms:
+      guix01:
+        vcpus: 2
+        memory: 4096
+        boot_order: [cdrom, hd]
+        # Empty disk: the installer live-boots past it. It is only written to
+        # if you run the guided install inside the guest. Guix pulls a lot of
+        # substitutes during an install, so give it more room than the NixOS
+        # box gets.
+        disk_size: 30G
+        networks:
+          - name: guix-net
+        cdroms:
+          - name: guix-system-install-1.5.0

--- a/boxes/nixos-25.05-iso-boot/README.md
+++ b/boxes/nixos-25.05-iso-boot/README.md
@@ -35,9 +35,12 @@ That is not an oversight, it is the current limit of the tooling:
   could point `templates:` at — the installer ISO is the only artifact this
   box can pin without building one.
 - boxman's `templates:` path **always** builds a NoCloud seed and then waits on
-  cloud-init plus the qemu guest agent (`providers/libvirt/cloudinit.py`). A
-  NixOS image pushed through it would time out and never receive a key, so
-  using `templates:` here would produce a box that looks supported and isn't.
+  cloud-init plus the qemu guest agent (`providers/libvirt/cloudinit.py`).
+  Pushing *this installer ISO* through it would time out and never receive a
+  key, so using `templates:` here would produce a box that looks supported and
+  isn't. A cloud-init-enabled NixOS **disk image** would work through that path
+  normally — the gap is that this box has no such image to point at, not that
+  the path is unusable for NixOS.
 
 Getting from "boots" to "usable, SSH-able NixOS guest" does **not** require a
 `nixos-rebuild` hook in boxman. The straightforward route is a

--- a/boxes/nixos-25.05-iso-boot/README.md
+++ b/boxes/nixos-25.05-iso-boot/README.md
@@ -1,0 +1,158 @@
+# nixos-25.05-iso-boot
+
+Boots a single VM from the official, checksummed **NixOS 25.05 minimal
+installer ISO**, using the same ISO-boot path as
+[`ubuntu-24.04-live-iso-boot`](../ubuntu-24.04-live-iso-boot) — no template, no
+clone, no cloud-init.
+
+Verified end to end on 2026-08-17: `boxman up` exits 0 in ~70 s (after the
+download), and the guest reaches the installer's `[nixos@nixos:~]$` auto-login
+shell and takes a DHCP lease.
+
+## Read this first: what this box does *not* do
+
+It **boots** NixOS. It does not **install or provision** it. There is no admin
+user and no injected SSH key, so `boxman ssh` will not reach the guest.
+
+(boxman *does* still generate an `ssh_config` and an `id_ed25519_boxman`
+keypair in the workspace, and `boxman up` prints an `ssh …` line for the VM.
+Ignore both: the `admin` user they name does not exist in the guest. `boxman
+up` also ends with `ERROR: failed to add ssh keys to some vms`, which is the
+correct outcome here, not a fault.)
+
+That is not an oversight, it is the current limit of the tooling:
+
+- NixOS publishes **no generic cloud qcow2**, and no official NixOS image ships
+  with cloud-init enabled. The only pinned, public artifact is the installer
+  ISO used here.
+- boxman's `templates:` path **always** builds a NoCloud seed and then waits on
+  cloud-init plus the qemu guest agent (`providers/libvirt/cloudinit.py`). A
+  NixOS image pushed through it would time out and never receive a key, so
+  using `templates:` here would produce a box that looks supported and isn't.
+
+Getting from "boots" to "usable, SSH-able NixOS guest" needs a declarative
+provisioning hook in boxman — push a `configuration.nix` and run
+`nixos-rebuild switch` — which does not exist yet. Until then, the two honest
+ways to finish the job are both **outside** boxman:
+
+- interactively, in the guest console (`nixos-generate-config`, edit
+  `/etc/nixos/configuration.nix`, `nixos-install`), or
+- with [`nixos-anywhere`](https://github.com/nix-community/nixos-anywhere)
+  driving the booted installer from your workstation.
+
+## Prerequisites
+
+- libvirt/KVM working (`virsh -c qemu:///system list`), and `sudo` for
+  `qemu:///system` (the box uses `use_sudo: true`).
+- `wget` or `curl` on `PATH` (boxman uses them to fetch the ISO).
+- **~1.65 GB** of network + disk for the ISO, plus 20 GB for the VM disk.
+- The **local** runtime — ISO boot is rejected under docker-compose, because
+  the cached ISO is not visible inside the libvirt container.
+
+## Bring it up
+
+```bash
+cd boxes/nixos-25.05-iso-boot
+boxman up
+```
+
+> The first run downloads ~1.65 GB and boots a VM. Re-runs reuse the cached,
+> checksum-verified ISO under `~/.cache/boxman/images`.
+
+## How to test / verify
+
+Let `V=bprj__boxman_dev_nixos-25.05-iso-boot__bprj_nixos_nixos01` (the
+fully-qualified libvirt name; `virsh list` shows it).
+
+**1. ISO was downloaded and checksum-verified** — the file exists:
+
+```bash
+ls -lh "$(boxman conf 2>/dev/null | grep -i cache_dir | awk '{print $2}')"/nixos-minimal-25.05-*.iso
+# or just look in your configured cache dir, default ~/.cache/boxman/images
+```
+
+Note: at default verbosity boxman prints **no** `checksum ok` line — that
+message logs at `INFO` while the default level is `STATUS`. Verification does
+run (a mismatch raises `Checksum mismatch for ISO` and evicts the file), but if
+you want to see it, run with `-v`. To check independently:
+
+```bash
+sha256sum <the cached iso>
+# 38dee38fd5b5f2429c35aef7d9cc039a21cafbd93809adf061d29149e3583c94
+```
+
+**2. The VM is defined and running:**
+
+```bash
+virsh -c qemu:///system list --all | grep nixos01
+```
+
+**3. The ISO is attached as a CDROM:**
+
+```bash
+virsh -c qemu:///system dumpxml "$V" | grep -A2 '<boot\|cdrom\|\.iso'
+# expect: <disk device='cdrom'> … <source file='…nixos-minimal-25.05-….iso'/>
+#         <boot dev='cdrom'/> <boot dev='hd'/>
+```
+
+Note the boot order you actually get is **`cdrom` then `hd`**, even though
+`IsoBootVM` asks virt-install for `hd,cdrom`: passing `--cdrom=` puts
+virt-install into two-phase install mode, and boxman never reaches the
+post-install reconfigure. For this box it makes no difference — it live-boots
+and never installs — but do not rely on the `hd`-first ordering.
+
+**4. It actually booted the installer** — watch the console:
+
+```bash
+virsh -c qemu:///system console "$V"       # serial; or use the graphical one:
+virt-viewer -c qemu:///system "$V"
+```
+
+You should reach the NixOS installer's shell, auto-logged in as the `nixos`
+user with a `[nixos@nixos:~]$` prompt.
+
+**5. (Automated signal) the installer requests DHCP** — the ISO brings up
+networking on boot and takes a lease from this box's NAT network:
+
+```bash
+virsh -c qemu:///system net-dhcp-leases \
+  bprj__boxman_dev_nixos-25.05-iso-boot__bprj__clstr__nixos__clstr__nixos-net
+```
+
+A lease for the VM's MAC confirms it booted far enough to configure networking
+from the ISO. This is the best non-interactive signal available, precisely
+because there is no guest agent and no SSH.
+
+## Going further: actually installing
+
+Inside the guest console, the installer ISO is a normal NixOS live system:
+
+```bash
+sudo -i
+passwd nixos                 # needed before sshd will accept a remote login
+ip -brief addr               # note the address handed out above
+```
+
+From there either install by hand, or point `nixos-anywhere` at that address.
+Anything you install lands on the empty 20 G disk.
+
+Be aware the domain boots **cdrom first** (see above), so once you have
+installed something you must detach the CDROM — or change the boot order — or
+the VM will drop back into the installer on every reboot.
+
+## Refreshing the ISO
+
+The `uri` is deliberately the **release-pinned** `releases.nixos.org` path that
+`channels.nixos.org` redirects to, not the `latest-nixos-minimal-…` alias. The
+alias moves as the channel advances and would break the checksum. To move to a
+newer release, take both the URL and its hash from the sibling `.iso.sha256`
+file on `releases.nixos.org` and update them together.
+
+## Tearing down
+
+```bash
+boxman destroy
+```
+
+The cached ISO stays under `~/.cache/boxman/images`; delete it there to force a
+re-download.

--- a/boxes/nixos-25.05-iso-boot/README.md
+++ b/boxes/nixos-25.05-iso-boot/README.md
@@ -22,18 +22,34 @@ correct outcome here, not a fault.)
 
 That is not an oversight, it is the current limit of the tooling:
 
-- NixOS publishes **no generic cloud qcow2**, and no official NixOS image ships
-  with cloud-init enabled. The only pinned, public artifact is the installer
-  ISO used here.
+- This box boots the **minimal installer ISO**, which is a live installer: it
+  does not consume boxman's NoCloud seed and creates no user for boxman to
+  inject a key into. That, not any limitation of NixOS, is why it is not
+  SSH-able.
+- NixOS itself supports cloud-init perfectly well
+  ([`services.cloud-init.enable`](https://github.com/NixOS/nixpkgs/blob/nixos-25.05/nixos/modules/services/system/cloud-init.nix)),
+  and the official
+  [`proxmoxImage`](https://github.com/NixOS/nixpkgs/blob/nixos-25.05/nixos/release.nix)
+  job builds a disk image with cloud-init, sshd and the qemu guest agent
+  enabled. What is missing is a *generic* published cloud qcow2 that boxman
+  could point `templates:` at — the installer ISO is the only artifact this
+  box can pin without building one.
 - boxman's `templates:` path **always** builds a NoCloud seed and then waits on
   cloud-init plus the qemu guest agent (`providers/libvirt/cloudinit.py`). A
   NixOS image pushed through it would time out and never receive a key, so
   using `templates:` here would produce a box that looks supported and isn't.
 
-Getting from "boots" to "usable, SSH-able NixOS guest" needs a declarative
-provisioning hook in boxman — push a `configuration.nix` and run
-`nixos-rebuild switch` — which does not exist yet. Until then, the two honest
-ways to finish the job are both **outside** boxman:
+Getting from "boots" to "usable, SSH-able NixOS guest" does **not** require a
+`nixos-rebuild` hook in boxman. The straightforward route is a
+cloud-init-enabled NixOS disk image — built with
+[`nixos-generators`](https://github.com/nix-community/nixos-generators) or
+modelled on the upstream `proxmoxImage` job — used as an ordinary
+`templates:` image. The boxman gap is therefore about **obtaining, building
+or importing** such an image (and the guest-agent assumptions in the
+verification phase), not about NixOS lacking the mechanism. See #149.
+
+Until this box ships such an image, the two ways to finish the job by hand
+are both **outside** boxman:
 
 - interactively, in the guest console (`nixos-generate-config`, edit
   `/etc/nixos/configuration.nix`, `nixos-install`), or

--- a/boxes/nixos-25.05-iso-boot/conf.yml
+++ b/boxes/nixos-25.05-iso-boot/conf.yml
@@ -1,20 +1,25 @@
 # Example: boot a VM directly from the NixOS 25.05 minimal installer ISO
 #
-# Why this is an ISO-boot box and not a cloud-init template box: NixOS
-# publishes no generic cloud qcow2, and no official NixOS image ships with
-# cloud-init enabled. boxman's `templates:` path always builds a NoCloud seed
-# and then waits for cloud-init plus the qemu guest agent, so a NixOS image put
-# through it would simply time out and never receive an SSH key. The honest
-# shape for NixOS today is therefore the same one talos-iso-boot and
-# ubuntu-24.04-live-iso-boot use: a bare VM with the ISO attached.
+# Why this is an ISO-boot box and not a cloud-init template box: the artifact
+# pinned here is the minimal *installer* ISO, a live installer that does not
+# consume boxman's NoCloud seed and creates no user to inject a key into.
+#
+# That is a property of this artifact, not of NixOS. NixOS supports cloud-init
+# (services.cloud-init.enable) and its official proxmoxImage job builds a disk
+# image with cloud-init, sshd and the qemu guest agent enabled. What NixOS does
+# not publish is a *generic* cloud qcow2 that `templates:` could point at, so a
+# template box would first have to build or import one -- see #149. Until then
+# this takes the same shape as talos-iso-boot and ubuntu-24.04-live-iso-boot:
+# a bare VM with the ISO attached.
 #
 # What this box does NOT do: install NixOS, create a user, or configure SSH.
 # It boots you to the installer's console shell. Finishing the install is
 # manual (or driven from outside by nixos-anywhere) — see README.md.
 #
 # Turning this into a box that yields a usable, SSH-able NixOS guest needs a
-# declarative provisioning hook in boxman (push a configuration.nix, run
-# nixos-rebuild switch). That is tracked separately, not worked around here.
+# cloud-init-enabled NixOS image for `templates:` to clone -- built with
+# nixos-generators or modelled on upstream's proxmoxImage -- not necessarily
+# an in-guest rebuild hook. Tracked separately, not worked around here.
 #
 version: '1.0'
 project: boxman_dev_nixos-25.05-iso-boot

--- a/boxes/nixos-25.05-iso-boot/conf.yml
+++ b/boxes/nixos-25.05-iso-boot/conf.yml
@@ -1,0 +1,77 @@
+# Example: boot a VM directly from the NixOS 25.05 minimal installer ISO
+#
+# Why this is an ISO-boot box and not a cloud-init template box: NixOS
+# publishes no generic cloud qcow2, and no official NixOS image ships with
+# cloud-init enabled. boxman's `templates:` path always builds a NoCloud seed
+# and then waits for cloud-init plus the qemu guest agent, so a NixOS image put
+# through it would simply time out and never receive an SSH key. The honest
+# shape for NixOS today is therefore the same one talos-iso-boot and
+# ubuntu-24.04-live-iso-boot use: a bare VM with the ISO attached.
+#
+# What this box does NOT do: install NixOS, create a user, or configure SSH.
+# It boots you to the installer's console shell. Finishing the install is
+# manual (or driven from outside by nixos-anywhere) — see README.md.
+#
+# Turning this into a box that yields a usable, SSH-able NixOS guest needs a
+# declarative provisioning hook in boxman (push a configuration.nix, run
+# nixos-rebuild switch). That is tracked separately, not worked around here.
+#
+version: '1.0'
+project: boxman_dev_nixos-25.05-iso-boot
+
+provider:
+  libvirt:
+    uri: qemu:///system
+    use_sudo: true
+    virt_install_cmd: '/bin/python3 /usr/bin/virt-install'
+    virt_clone_cmd: '/bin/python3 /usr/bin/virt-clone'
+    virsh_cmd: '/usr/bin/virsh'
+
+isos:
+  nixos-minimal-25.05:
+    # NixOS 25.05 minimal installer (x86_64). ~1.65 GB.
+    #
+    # This is the release-pinned path that channels.nixos.org redirects to, so
+    # the URL and its checksum stay stable. Do NOT substitute
+    # https://channels.nixos.org/nixos-25.05/latest-nixos-minimal-x86_64-linux.iso
+    # here: that alias is republished as the channel advances and the checksum
+    # below would start failing. Refresh both together from
+    # https://nixos.org/download/ and the sibling .iso.sha256 file.
+    uri: https://releases.nixos.org/nixos/25.05/nixos-25.05.813814.ac62194c3917/nixos-minimal-25.05.813814.ac62194c3917-x86_64-linux.iso
+    checksum: sha256:38dee38fd5b5f2429c35aef7d9cc039a21cafbd93809adf061d29149e3583c94
+
+workspace:
+  path: ~/workspaces/nixos-25.05-iso-boot
+
+clusters:
+  nixos:
+    workdir: ~/workspaces/nixos-25.05-iso-boot
+    networks:
+      nixos-net:
+        mode: nat
+        bridge:
+          stp: 'on'
+          delay: '0'
+        mac: '52:54:00:00:97:01'
+        ip:
+          address: '192.168.151.1'
+          netmask: '255.255.255.0'
+          dhcp:
+            range:
+              start: '192.168.151.2'
+              end: '192.168.151.254'
+        enable: True
+        autostart: True
+    vms:
+      nixos01:
+        vcpus: 2
+        memory: 4096
+        boot_order: [cdrom, hd]
+        # Empty disk: the ISO live-boots past it. It is only used if you go on
+        # to run a real `nixos-install` inside the guest. 20G is enough for a
+        # minimal system with room for a couple of generations.
+        disk_size: 20G
+        networks:
+          - name: nixos-net
+        cdroms:
+          - name: nixos-minimal-25.05

--- a/boxes/tiny-libvirt-arch-cloudinit/conf.yml
+++ b/boxes/tiny-libvirt-arch-cloudinit/conf.yml
@@ -54,17 +54,16 @@ templates:
     # cloudinit_done_timeout. Keys here are therefore the real interface names;
     # the Arch cloud image boots with net.ifnames=0, so they are eth0/eth1.
     #
-    # eth1 is static on purpose. The second adapter of this box lands on the
-    # `isolated1` network, which is `mode: route` -- and boxman answers a routed
-    # network by installing "complete isolation" iptables rules for its bridge
-    # (Network.apply_route_iptables_rule): `INPUT -i <br> -j DROP` plus
-    # `OUTPUT -o <br> -j DROP`. libvirt's dnsmasq for that network runs *on the
-    # host*, so those two rules drop the DHCPDISCOVER on the way in and the
-    # DHCPOFFER on the way out: DHCP on an isolated network can never complete,
-    # no matter which distro is in the guest. Left on dhcp4, eth1 sits at
-    # "degraded (configuring)" forever with only a link-local address. The
-    # address below is inside isolated1's subnet and outside its (inert) DHCP
-    # range, so it also survives if the network is ever switched to nat.
+    # eth1 is static on purpose. The second adapter lands on `isolated1`,
+    # which is `mode: route`, and boxman answers a routed network by
+    # installing "complete isolation" iptables rules for its bridge. libvirt's
+    # dnsmasq for that network runs *on the host*, so those rules drop the
+    # DHCPDISCOVER on the way in and the DHCPOFFER on the way out -- DHCP on a
+    # routed network cannot complete for any guest OS. That is tracked as #152;
+    # a static address keeps this box working on any boxman version, before or
+    # after that fix. It sits inside isolated1's subnet and outside its DHCP
+    # pool, so nothing can lease it out from under the guest, and it survives
+    # if the network is ever switched to nat.
     cloudinit_network_config: |
       version: 2
       ethernets:
@@ -192,9 +191,13 @@ clusters:
           address: '10.0.14.1'
           netmask: '255.255.255.0'
           dhcp:
+            # deliberately stops well short of .101, the address the second
+            # adapter takes statically below. Once routed networks can lease
+            # addresses (see #152) an overlapping pool would let dnsmasq hand
+            # .101 to another guest and collide.
             range:
-              start: '10.0.14.2'
-              end: '10.0.14.254'
+              start: '10.0.14.10'
+              end: '10.0.14.99'
         enable: True
         autostart: True
 

--- a/boxes/tiny-libvirt-arch-cloudinit/conf.yml
+++ b/boxes/tiny-libvirt-arch-cloudinit/conf.yml
@@ -1,0 +1,222 @@
+---
+# Arch Linux (rolling) from the official cloud image.
+#
+# Unlike the Ubuntu/Rocky boxes, the upstream image here MOVES: Arch publishes a
+# new cloud image roughly every two weeks and prunes the dated directories after
+# a handful of releases. The uri below is the *dated* path rather than
+# images/latest/, so the checksum stays valid — but expect it to 404 eventually
+# and to need a refresh. Pick the newest entry from
+# https://geo.mirror.pkgbuild.com/images/ and take its .SHA256 file.
+#
+# The same rolling property is why this template does a full `pacman -Syu`
+# (package_upgrade) rather than only refreshing the database: Arch does not
+# support partial upgrades, so installing a package against a stale image
+# without upgrading first is the one thing guaranteed to break.
+version: '1.0'
+project: boxman_dev_tiny-arch
+provider:
+  libvirt:
+    uri: qemu:///system
+    use_sudo: True
+    virt_install_cmd: '/bin/python3 /usr/bin/virt-install'
+    virt_clone_cmd: '/bin/python3 /usr/bin/virt-clone'
+    virsh_cmd: '/usr/bin/virsh'
+    verbose: True
+
+templates:
+  template1:
+    name: arch-rolling-base-template-cloudinit
+    image:
+      uri: https://geo.mirror.pkgbuild.com/images/v20260815.573966/Arch-Linux-x86_64-cloudimg-20260815.573966.qcow2
+      checksum: sha256:5d8be8d28cfd290f051b0f67df0a6874596ad23de3f3f18b90c91aeb758eb878
+    disk_size: 20G
+    os_variant: archlinux
+    memory: 4096
+    vcpus: 2
+    cloudinit_done_marker: /var/log/hello-cloudinit.log
+    # A first-boot `pacman -Syu` on a rolling distro can pull a lot more than
+    # the package list below, so the done-marker poll needs more room than the
+    # 120s default. The other three are boxman's defaults, shown for reference.
+    cloudinit_done_timeout: 600
+    #cloudinit_agent_timeout: 300        # wait for the qemu guest agent
+    #cloudinit_guest_exec_timeout: 120   # wait for guest-exec to be usable
+    #cloudinit_fallback_timeout: 180     # blind wait when the guest can't be polled
+    #
+    # Why this box overrides the network config instead of taking boxman's
+    # default: Arch has no netplan, so cloud-init renders network config with
+    # its systemd-networkd renderer -- and that renderer writes the ethernet
+    # KEY into `[Match] Name=`, discarding any `match: {name: "en*"}` glob.
+    # boxman's built-in default (cloudinit_presets.DEFAULT_NETWORK_CONFIG) is
+    # keyed `all-en` / `all-eth`, so on Arch it emits `Name=all-en`, which
+    # matches no interface. The guest then never gets an address,
+    # systemd-networkd-wait-online times out, cloud-final never starts, and the
+    # done marker is never written -- template creation fails after the full
+    # cloudinit_done_timeout. Keys here are therefore the real interface names;
+    # the Arch cloud image boots with net.ifnames=0, so they are eth0/eth1.
+    #
+    # eth1 is static on purpose. The second adapter of this box lands on the
+    # `isolated1` network, which is `mode: route` -- and boxman answers a routed
+    # network by installing "complete isolation" iptables rules for its bridge
+    # (Network.apply_route_iptables_rule): `INPUT -i <br> -j DROP` plus
+    # `OUTPUT -o <br> -j DROP`. libvirt's dnsmasq for that network runs *on the
+    # host*, so those two rules drop the DHCPDISCOVER on the way in and the
+    # DHCPOFFER on the way out: DHCP on an isolated network can never complete,
+    # no matter which distro is in the guest. Left on dhcp4, eth1 sits at
+    # "degraded (configuring)" forever with only a link-local address. The
+    # address below is inside isolated1's subnet and outside its (inert) DHCP
+    # range, so it also survives if the network is ever switched to nat.
+    cloudinit_network_config: |
+      version: 2
+      ethernets:
+        eth0:
+          dhcp4: true
+        eth1:
+          dhcp4: false
+          addresses:
+            - 10.0.14.101/24
+    cloudinit: |
+      #cloud-config
+      hostname: hello-cloudinit
+      manage_etc_hosts: true
+
+      users:
+        - name: arch
+          plain_text_passwd: arch
+          lock_passwd: false
+          groups: [wheel]
+          sudo: ALL=(ALL) NOPASSWD:ALL
+          shell: /bin/bash
+        - name: admin
+          plain_text_passwd: {{ env("BOXMAN_ADMIN_PASS", default="boxman") }}
+          lock_passwd: false
+          groups: [wheel]
+          sudo: ALL=(ALL) NOPASSWD:ALL
+          shell: /bin/bash
+          homedir: /admin
+
+      ssh_pwauth: true
+
+      # -Sy alone would leave a partially-upgraded system; on Arch the full
+      # upgrade is the safe option, not the thorough one
+      package_update: true
+      package_upgrade: true
+      packages:
+        - qemu-guest-agent
+        - openssh
+        - sudo
+        - vim
+        - curl
+        # not cosmetic: boxman verifies a freshly key-authenticated VM by
+        # running plain `hostname` over ssh and treating empty stdout as a
+        # failed login (manager_parts/ssh.py::_verify_ssh_connection). The Arch
+        # cloud image ships no /usr/bin/hostname -- only hostnamectl -- so
+        # without inetutils every attempt fails with
+        # "bash: line 1: hostname: command not found" and provisioning gives up
+        # after 10 retries even though ssh itself works perfectly.
+        - inetutils
+
+      growpart:
+        mode: auto
+        devices: ['/']
+
+      resize_rootfs: true
+
+      write_files:
+        - path: /etc/hello-from-cloudinit
+          permissions: "0644"
+          content: |
+            hello world from cloud-init (Arch Linux, rolling)
+        # Supplying our own `cloudinit:` block means we lose the equivalent
+        # drop-in from boxman's DEFAULT_USER_DATA preset. Without it a single
+        # configured-but-absent interface makes wait-online block the whole
+        # boot, which is exactly how this box failed the first time.
+        - path: /etc/systemd/system/systemd-networkd-wait-online.service.d/override.conf
+          permissions: "0644"
+          content: |
+            [Service]
+            ExecStart=
+            ExecStart=/usr/lib/systemd/systemd-networkd-wait-online --any
+
+      runcmd:
+        - systemctl daemon-reload
+        # Arch names the ssh unit sshd.service, not ssh.service
+        - systemctl enable --now sshd
+        - systemctl enable --now qemu-guest-agent
+        - systemctl restart systemd-networkd || true
+        - [ sh, -c, "mkdir -p /admin/.ssh && chmod 700 /admin/.ssh && chown -R admin:admin /admin/.ssh" ]
+        - [ sh, -c, "echo ran at $(date -Is) >> /var/log/hello-cloudinit.log" ]
+
+workspace:
+  path: ~/workspaces/boxmandev/tiny-libvirt-arch-cloudinit
+
+clusters:
+  cluster_1:
+    base_image: arch-rolling-base-template-cloudinit
+    proxy_host: localhost
+    admin_user: admin
+    admin_pass: {{ env("BOXMAN_ADMIN_PASS", default="boxman") }}
+    admin_key_name: id_ed25519_boxman    # generated automatically at provisioning time
+    ssh_config: ssh_config               # generated automatically at provisioning time
+
+    networks:
+      # Subnet choice is not arbitrary: boxman refuses to define a network whose
+      # gateway address is already claimed by another project, and on a busy
+      # host the low 192.168.x/24 range fills up fast (192.168.10-15 are taken
+      # by other boxman projects, and docker hands itself 192.168.16.0/20,
+      # 32.0/20, 48.0/20, 64.0/20, 96.0/20 and 144.0/20). 192.168.214.0/24 sits
+      # clear of both. If you ever see
+      #   ERROR: ip address ... is already used by network ... in project ...
+      # then pick another free /24 here rather than deleting the other project.
+      nat1:
+        mode: nat
+        bridge:
+          stp: 'on'
+          delay: '0'
+        mac: '52:54:00:00:0a:01'
+        ip:
+          address: '192.168.214.1'
+          netmask: '255.255.255.0'
+          dhcp:
+            range:
+              start: '192.168.214.2'
+              end: '192.168.214.254'
+        enable: True
+        autostart: True
+      isolated1:
+        mode: route
+        bridge:
+          stp: 'on'
+          delay: '0'
+        mac: '52:54:00:00:0a:02'
+        ip:
+          address: '10.0.14.1'
+          netmask: '255.255.255.0'
+          dhcp:
+            range:
+              start: '10.0.14.2'
+              end: '10.0.14.254'
+        enable: True
+        autostart: True
+
+    vms:
+      boxman01:
+        hostname: boxman01
+        cpus:
+          sockets: 1
+          cores: 2
+          threads: 1
+        memory: 2048
+        disks:
+          - name: disk01
+            driver:
+              name: qemu
+              type: qcow2
+            target: vdb
+            size: 2048
+        network_adapters:
+          - name: adapter_1
+            link_state: 'up'
+            network_source: 'nat1'
+          - name: adapter_2
+            link_state: 'up'
+            network_source: 'isolated1'

--- a/tests/test_iso_boot_boxes.py
+++ b/tests/test_iso_boot_boxes.py
@@ -1,0 +1,123 @@
+"""
+Deterministic checks for the ISO-boot example boxes.
+
+These boxes are excluded from the provisioning integration job -- they have no
+`templates:` block and deliberately never create a login, so every assertion
+in that suite would fail on them by design. That exclusion would otherwise
+leave them untested entirely, and a pinned ISO whose URL or checksum has gone
+stale would sit in the repository looking healthy. Everything verifiable
+without downloading gigabytes is asserted here instead.
+
+The URL reachability check is opt-in (``integration``): it is the one part
+that needs the network.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+
+import pytest
+import yaml
+
+from boxman.utils.jinja_env import create_jinja_env
+
+pytestmark = pytest.mark.unit
+
+BOXES_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "boxes")
+
+ISO_BOXES = sorted(
+    os.path.dirname(p) for p in glob.glob(os.path.join(BOXES_DIR, "*/conf.yml"))
+    if os.path.basename(os.path.dirname(p)).endswith("-iso-boot")
+)
+
+# every box shipped as an ISO-boot example must be picked up here; a rename
+# that silently drops one from this list is the failure mode being guarded
+EXPECTED_AT_LEAST = {"nixos-25.05-iso-boot", "guix-1.5.0-iso-boot"}
+
+
+def _config(box_dir: str) -> dict:
+    env = create_jinja_env(box_dir)
+    os.environ.setdefault("BOXMAN_CONF_DIR", box_dir)
+    return yaml.safe_load(env.get_template("conf.yml").render())
+
+
+def test_the_iso_boxes_are_discovered():
+    names = {os.path.basename(d) for d in ISO_BOXES}
+    assert EXPECTED_AT_LEAST <= names, f"missing ISO-boot boxes: {names}"
+
+
+@pytest.mark.parametrize("box_dir", ISO_BOXES,
+                         ids=[os.path.basename(d) for d in ISO_BOXES])
+class TestIsoBoxConfig:
+
+    def test_renders_and_parses(self, box_dir):
+        assert _config(box_dir).get("project")
+
+    def test_every_iso_is_pinned_with_a_sha256(self, box_dir):
+        # an unpinned or unchecksummed ISO is how a box silently starts
+        # booting something other than what it claims
+        isos = _config(box_dir).get("isos") or {}
+        assert isos, "an iso-boot box must declare isos:"
+        for name, spec in isos.items():
+            assert spec.get("uri", "").startswith("https://"), name
+            checksum = spec.get("checksum", "")
+            assert re.fullmatch(r"sha256:[0-9a-f]{64}", checksum), (
+                f"{name} needs a full sha256 checksum, got {checksum!r}")
+
+    def test_uri_is_a_release_pinned_path(self, box_dir):
+        # "latest" style aliases are republished in place, which silently
+        # invalidates the checksum pinned next to them
+        for name, spec in (_config(box_dir).get("isos") or {}).items():
+            uri = spec["uri"]
+            assert "latest" not in uri.lower(), (
+                f"{name} points at a moving alias: {uri}")
+
+    def test_vms_boot_from_a_declared_iso(self, box_dir):
+        config = _config(box_dir)
+        declared = set((config.get("isos") or {}).keys())
+        vms = 0
+        for cluster in config["clusters"].values():
+            for vm_name, vm in (cluster.get("vms") or {}).items():
+                vms += 1
+                cdroms = [c["name"] for c in (vm.get("cdroms") or [])]
+                assert cdroms, f"{vm_name} has no cdroms:"
+                assert set(cdroms) <= declared, (
+                    f"{vm_name} references an undeclared iso: {cdroms}")
+                assert "cdrom" in (vm.get("boot_order") or []), vm_name
+                assert vm.get("disk_size"), (
+                    f"{vm_name} needs a disk_size to fall through to the ISO")
+        assert vms, "no vms defined"
+
+    def test_no_ssh_expectations_are_declared(self, box_dir):
+        # these boxes cannot provision a login; declaring admin_user/ssh_config
+        # would promise something the box does not deliver
+        for cluster in _config(box_dir)["clusters"].values():
+            assert "admin_user" not in cluster
+            assert "base_image" not in cluster
+
+    def test_readme_documents_the_limitation(self, box_dir):
+        # scoped to the boxes added alongside this check: talos-iso-boot has
+        # no README at all and ubuntu-24.04-live-iso-boot predates the
+        # convention, and retrofitting those belongs in its own change
+        if os.path.basename(box_dir) not in EXPECTED_AT_LEAST:
+            pytest.skip("pre-existing box, README convention not retrofitted")
+        readme = os.path.join(box_dir, "README.md")
+        assert os.path.exists(readme), "an iso-boot box needs a README"
+        text = open(readme, encoding="utf-8").read().lower()
+        assert "boxman ssh" in text and "not" in text
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("box_dir", ISO_BOXES,
+                         ids=[os.path.basename(d) for d in ISO_BOXES])
+def test_pinned_iso_urls_are_still_reachable(box_dir):
+    """The pinned URLs still resolve (a HEAD request, no download)."""
+    import urllib.request
+    for name, spec in (_config(box_dir).get("isos") or {}).items():
+        request = urllib.request.Request(spec["uri"], method="HEAD")
+        with urllib.request.urlopen(request, timeout=30) as response:
+            assert response.status == 200, f"{name}: {spec['uri']}"
+            assert int(response.headers.get("Content-Length", 0)) > 0

--- a/tests/test_provision_boxes.py
+++ b/tests/test_provision_boxes.py
@@ -38,6 +38,8 @@ OS_VARIANT_TO_ID = {
     "ubuntu24.04": "ubuntu",
     "rocky9": "rocky",
     "centos7.0": "centos",
+    # libvirt/osinfo calls it archlinux; /etc/os-release says ID=arch
+    "archlinux": "arch",
 }
 
 # ---------------------------------------------------------------------------
@@ -60,11 +62,22 @@ def discover_boxes():
     ``create-templates`` fails and every parametrized test skips
     (issue #81). They are covered under the docker runtime by
     ``tests/test_lifecycle_e2e.py`` instead.
+
+    ISO-boot boxes (``*-iso-boot``) are excluded too, and for a more basic
+    reason: they have no ``templates:`` block and deliberately never
+    provision a login. They boot a distro from an installer/live ISO and
+    stop there, so there is no admin user, no injected key and no
+    ``ssh_config`` for the assertions below to use -- every test in this
+    class would fail on them by design rather than find a defect. What
+    they *do* need verifying (ISO downloaded and checksummed, CDROM
+    attached, boot order hd,cdrom) is documented per box in their README.
     """
     pattern = os.path.join(BOXES_DIR, "*/conf.yml")
+    excluded_suffixes = ("-docker-runtime", "-iso-boot")
     return sorted(
         os.path.dirname(p) for p in glob.glob(pattern)
-        if not os.path.basename(os.path.dirname(p)).endswith("-docker-runtime")
+        if not os.path.basename(
+            os.path.dirname(p)).endswith(excluded_suffixes)
     )
 
 

--- a/tests/test_provision_boxes.py
+++ b/tests/test_provision_boxes.py
@@ -69,8 +69,12 @@ def discover_boxes():
     stop there, so there is no admin user, no injected key and no
     ``ssh_config`` for the assertions below to use -- every test in this
     class would fail on them by design rather than find a defect. What
-    they *do* need verifying (ISO downloaded and checksummed, CDROM
-    attached, boot order hd,cdrom) is documented per box in their README.
+    they *do* need verifying -- ISO downloaded and checksummed, CDROM
+    attached, boot devices configured -- is covered deterministically by
+    tests/test_iso_boot_boxes.py and documented per box in their README.
+    (The effective boot order is deliberately not asserted here: virt-install
+    does not honour the requested ordering for --cdrom installs, which the
+    per-box READMEs explain.)
     """
     pattern = os.path.join(BOXES_DIR, "*/conf.yml")
     excluded_suffixes = ("-docker-runtime", "-iso-boot")
@@ -194,14 +198,16 @@ def provisioned_box(request):
     # --- setup ---
     result = _run(f"boxman --conf {conf_path} create-templates --force", warn=True)
     if not result.ok:
-        pytest.skip(
+        # deliberately a failure, not a skip: this job exists to catch exactly
+        # this, and skipping leaves CI green after a box has stopped working
+        pytest.fail(
             f"create-templates failed for {os.path.basename(box_dir)}: "
             f"{result.stderr.strip()}"
         )
 
     result = _run(f"boxman --conf {conf_path} provision --force", warn=True)
     if not result.ok:
-        pytest.skip(
+        pytest.fail(
             f"provision failed for {os.path.basename(box_dir)}: "
             f"{result.stderr.strip()}"
         )


### PR DESCRIPTION
`boxes/` covered only Ubuntu, Rocky and CentOS — all the same cloud-init template shape. These three add a rolling-release guest and two declaratively-configured distros.

## The three boxes are not the same shape, deliberately

**`tiny-libvirt-arch-cloudinit`** — a normal template box. Provisioned and SSH-verified end to end on a real host (`ID=arch`, both NICs up, extra disk attached).

Two Arch-specific details worth reviewing:
- pins the **dated** image path rather than `images/latest/`, so the checksum stays valid — with a comment that it will 404 eventually, since Arch prunes old directories
- does a full `pacman -Syu`, because Arch does not support partial upgrades and a pinned image goes stale
- overrides `cloudinit_network_config`. Arch has no netplan, so cloud-init uses its systemd-networkd renderer, which writes the ethernet **key** into `[Match] Name=` and discards `match: {name: "en*"}` globs. boxman's default preset is keyed `all-en`/`all-eth`, so on Arch it matches nothing: no address, `cloud-final` never starts, template creation fails after the full timeout. That is #150; the box works around it explicitly.

**`nixos-25.05-iso-boot`** and **`guix-1.5.0-iso-boot`** — ISO-boot boxes, following the existing `talos-iso-boot` precedent. They boot the distro; they do **not** provision it.

That is not laziness. Neither distro has a usable path through `templates:`: NixOS publishes no generic cloud image and no official image enables cloud-init, and Guix has no cloud-init at all — its only qcow2 is a GNOME desktop demo image. boxman's template flow always builds a NoCloud seed then waits on cloud-init plus the guest agent, so either would time out and never receive an SSH key, producing a box that *looks* supported and isn't. Both READMEs state this plainly, and #149 tracks the declarative-provisioning hook they would need.

Both verified on a real host: ISO downloads and checksums, VM defined with the ISO attached, and the guest boots far enough to take a DHCP lease — NixOS reaches its `[nixos@nixos:~]$` auto-login shell, Guix reaches its guided installer.

## The Guix checksum is not upstream's

GNU publishes only a detached OpenPGP signature for that ISO, no `.sha256`. The pinned hash was computed locally **after** verifying the signature (good signature, key `A28BF40C3E551372662D14F741AAE7DCCA3D8351`, Efraim Flashner, 2026-01-22), and the README documents the full reproduce-it chain. I could not independently confirm that key against Guix's published committer keyring — savannah returned a 502 rather than a not-found — so the README presents the signature as the authority and the sha256 only as a download pin. Worth a second opinion.

## Test discovery change

`test_provision_boxes` discovers every box and asserts SSH connectivity, so it now excludes `*-iso-boot` for the same reason `*-docker-runtime` is excluded — those boxes deliberately never provision a login, so every assertion would fail by design rather than find a defect. This also fixes the two **pre-existing** iso-boot boxes, which were already being discovered and would already have failed. Also maps `archlinux` → `arch`, since osinfo uses the former and `/etc/os-release` the latter.

## Notes

2040 passing, ruff clean, all three configs pass `validate_box.py`. The one failure is pre-existing and also present on `main` (`test_stale_file_logs_warning` asserts on `caplog` for a logger with `propagate=False`).

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)